### PR TITLE
maybe_cached.rs: account for AS token JWT exp and cert validity in TTL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "rats-cert"
 version = "0.1.0"
-source = "git+https://github.com/inclavare-containers/rats-rs.git?rev=7e4eb4b114be6ae742856ea185e6bc59d23285e8#7e4eb4b114be6ae742856ea185e6bc59d23285e8"
+source = "git+https://github.com/inclavare-containers/rats-rs.git?rev=15690513da0ad14795fbd3b8ee1c4dcbfdee3037#15690513da0ad14795fbd3b8ee1c4dcbfdee3037"
 dependencies = [
  "anyhow",
  "as-any",
@@ -4289,6 +4289,7 @@ dependencies = [
  "which 7.0.3",
  "ws_stream_tungstenite",
  "ws_stream_wasm",
+ "x509-cert",
 ]
 
 [[package]]

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -94,18 +94,19 @@ tracing-opentelemetry = {version = "0.30.0", optional = true}
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 url = "2.5"
 which = {version = "7.0.3", optional = true}
+x509-cert = {version = "0.2.5"}
 
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
 async-tungstenite = {version = "0.25.1", optional = true, features = ["tokio-runtime"]}
 axum = {version = "0.8.4", features = ["tokio", "http1", "http2", "ws"]}
-rats-cert = {git = "https://github.com/inclavare-containers/rats-rs.git", rev = "7e4eb4b114be6ae742856ea185e6bc59d23285e8", default-features = false, features = ["crypto-rustcrypto", "attester-coco", "verifier-coco"]}
+rats-cert = {git = "https://github.com/inclavare-containers/rats-rs.git", rev = "15690513da0ad14795fbd3b8ee1c4dcbfdee3037", default-features = false, features = ["crypto-rustcrypto", "attester-coco", "verifier-coco"]}
 socket2 = {version = "0.5.10"}
 tokio = {workspace = true, features = ["rt-multi-thread", "time"]}
 ws_stream_tungstenite = {version = "0.13.0"}
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
 axum = {version = "0.8.4", default-features = false, features = ["json"]}# to disable mio
-rats-cert = {git = "https://github.com/inclavare-containers/rats-rs.git", rev = "7e4eb4b114be6ae742856ea185e6bc59d23285e8", default-features = false, features = ["crypto-rustcrypto", "verifier-coco"]}
+rats-cert = {git = "https://github.com/inclavare-containers/rats-rs.git", rev = "15690513da0ad14795fbd3b8ee1c4dcbfdee3037", default-features = false, features = ["crypto-rustcrypto", "verifier-coco"]}
 ring = {version = "0.17.11", features = ["wasm32_unknown_unknown_js"]}
 rustls-pki-types = {version = "*", features = ["web"]}
 serde-wasm-bindgen = "0.6.5"

--- a/tng/src/tunnel/egress/protocol/ohttp/security/keystore.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/keystore.rs
@@ -165,9 +165,7 @@ impl ServerKeyStore {
                             KeyConfigResponse {
                                 hpke_key_config: userdata.hpke_key_config,
                                 attestation_info: Some(ServerAttestationInfo::Passport {
-                                    attestation_result: AttestationResultJwt(
-                                        token.as_str().to_owned(),
-                                    ),
+                                    attestation_result: AttestationResultJwt(token.into_str()),
                                 }),
                             }
                         }
@@ -466,7 +464,7 @@ impl ServerKeyStore {
                         let token  = coco_converter.convert(&coco_evidence).await?;
 
                         let response = AttestationVerifyResponse {
-                            attestation_result: token.as_str().to_string(),
+                            attestation_result: token.into_str(),
                         };
                         Ok(Json(response))
 

--- a/tng/src/tunnel/ohttp/protocol/header.rs
+++ b/tng/src/tunnel/ohttp/protocol/header.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone)]
+#[allow(unused)]
 pub enum OhttpApi {
     KeyConfig,
     Tunnel,


### PR DESCRIPTION
Previously, the expiration strategy only considered partial lifetimes (e.g., key config), but ignored the attestation token's `exp` claim.

This change:
- Updates `Expire` with `Ord` support to enable comparison
- Extracts `exp` from AS token JWT via `CocoAsToken::exp()`
- Computes effective TTL as `min(token_exp, cert_expiry, key_config_expire)`
- Applies unified expiration in both `CertManager` and `OHttpClient` caches

Now cached credentials respect *all* trust-boundary expiration sources, closing a potential window of stale or over-trusted material.