### PR TITLE
feat: Allow HTTPS encoding on top of OHTTP

### DIFF
--- a/tng/src/config/control_interface.rs
+++ b/tng/src/config/control_interface.rs
@@ -71,6 +71,7 @@ mod tests {
                     address: Endpoint {
                         host: Some("0.0.0.0".to_owned()),
                         port: 50000,
+                        ..Default::default()
                     },
                 }),
                 ..Default::default()
@@ -80,10 +81,12 @@ mod tests {
                     r#in: Endpoint {
                         host: None,
                         port: 10001,
+                        ..Default::default()
                     },
                     out: Endpoint {
                         host: Some("127.0.0.1".to_owned()),
                         port: 30001,
+                        ..Default::default()
                     },
                 }),
                 common: ingress::CommonArgs {
@@ -149,10 +152,12 @@ mod tests {
                     r#in: Endpoint {
                         host: None,
                         port: 10001,
+                        ..Default::default()
                     },
                     out: Endpoint {
                         host: Some("127.0.0.1".to_owned()),
                         port: 30001,
+                        ..Default::default()
                     },
                 }),
                 common: ingress::CommonArgs {

--- a/tng/src/config/ingress.rs
+++ b/tng/src/config/ingress.rs
@@ -148,6 +148,10 @@ pub struct Socks5AuthArgs {
 pub struct OHttpArgs {
     #[serde(default)]
     pub path_rewrites: Vec<PathRewrite>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tls_ca_certs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/tng/src/config/mod.rs
+++ b/tng/src/config/mod.rs
@@ -37,12 +37,15 @@ pub struct TngConfig {
     pub admin_bind: Option<Endpoint>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Endpoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
     pub port: u16,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<String>,
 }
 
 #[cfg(test)]
@@ -72,12 +75,13 @@ pub mod tests {
             add_ingress: vec![AddIngressArgs {
                 ingress_mode: IngressMode::Mapping(ingress::IngressMappingArgs {
                     r#in: Endpoint {
-                        host: None,
                         port: 10001,
+                        ..Default::default()
                     },
                     out: Endpoint {
                         host: Some("127.0.0.1".to_owned()),
                         port: 20001,
+                        ..Default::default()
                     },
                 }),
                 common: ingress::CommonArgs{
@@ -87,6 +91,7 @@ pub mod tests {
                             match_regex: "^/foo/bar/([^/]+)([/]?.*)$".to_owned(),
                             substitution: "/foo/bar/\\1".to_owned(),
                         }],
+                        ..Default::default()
                     }),
                     ra_args: RaArgsUnchecked {
                         no_ra: false,
@@ -112,10 +117,12 @@ pub mod tests {
                     r#in: Endpoint {
                         host: Some("127.0.0.1".to_owned()),
                         port: 20001,
+                        ..Default::default()
                     },
                     out: Endpoint {
                         host: Some("127.0.0.1".to_owned()),
                         port: 30001,
+                        ..Default::default()
                     },
                 }),
                 common:egress::CommonArgs{

--- a/tng/src/tunnel/endpoint.rs
+++ b/tng/src/tunnel/endpoint.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Display};
 pub struct TngEndpoint {
     host: String,
     port: u16,
+    scheme: Option<String>,
 }
 
 impl TngEndpoint {
@@ -11,7 +12,13 @@ impl TngEndpoint {
         Self {
             host: host.into(),
             port,
+            scheme: None,
         }
+    }
+
+    pub fn with_scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.scheme = Some(scheme.into());
+        self
     }
 
     pub fn host(&self) -> &str {
@@ -20,6 +27,10 @@ impl TngEndpoint {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    pub fn scheme(&self) -> Option<&str> {
+        self.scheme.as_deref()
     }
 }
 

--- a/tng/src/tunnel/ingress/mapping.rs
+++ b/tng/src/tunnel/ingress/mapping.rs
@@ -18,6 +18,7 @@ pub struct MappingIngress {
     listen_port: u16,
     upstream_addr: String,
     upstream_port: u16,
+    upstream_scheme: Option<String>,
 }
 
 impl MappingIngress {
@@ -37,6 +38,7 @@ impl MappingIngress {
             .context("'host' of 'out' field must be set")?
             .to_owned();
         let upstream_port = mapping_args.out.port;
+        let upstream_scheme = mapping_args.out.scheme.clone();
 
         Ok(Self {
             id,
@@ -44,6 +46,7 @@ impl MappingIngress {
             listen_port,
             upstream_addr,
             upstream_port,
+            upstream_scheme,
         })
     }
 }
@@ -85,7 +88,13 @@ impl IngressTrait for MappingIngress {
                     Ok((stream, peer_addr)) => yield Ok(AcceptedStream{
                         stream: Box::new(stream),
                         src: peer_addr,
-                        dst: TngEndpoint::new(self.upstream_addr.clone(), self.upstream_port),
+                        dst: {
+                            let ep = TngEndpoint::new(self.upstream_addr.clone(), self.upstream_port);
+                            match &self.upstream_scheme {
+                                Some(s) => ep.with_scheme(s.clone()),
+                                None => ep,
+                            }
+                        },
                         via_tunnel: true,
                     }),
                     Err(e) => yield Err(anyhow!(e)),

--- a/tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs
@@ -66,6 +66,15 @@ impl OHttpSecurityLayer {
             {
                 builder = builder.tcp_mark(transport_so_mark);
             }
+
+            for path in &ohttp_args.tls_ca_certs {
+                let pem = std::fs::read(path)
+                    .with_context(|| format!("Failed to read TLS CA cert: {path}"))?;
+                let cert = reqwest::Certificate::from_pem(&pem)
+                    .with_context(|| format!("Failed to parse TLS CA cert: {path}"))?;
+                builder = builder.add_root_certificate(cert);
+            }
+
             builder.build()?
         };
 
@@ -117,7 +126,8 @@ impl OHttpSecurityLayer {
             tracing::debug!(original_path, rewrited_path, "path is rewrited");
 
             let url = format!(
-                "http://{}:{}{rewrited_path}",
+                "{}://{}:{}{rewrited_path}",
+                endpoint.scheme().unwrap_or("http"),
                 endpoint.host(),
                 endpoint.port()
             );


### PR DESCRIPTION
Currently, TNG has OHTTP-encrypted communication possible between TNG-ingress and TNG-egress. However, in many architectures TNG-egress is expected to sit in some backend infrastructure that is only accessible via some gateway which does TLS termination (for the domain). This PR enables a TNG-ingress to do TLS encryption on top of the OHTTP layer encryption such that the gateway can terminate the TLS layer before the OHTTP-encrypted request reaches the TNG-egress.