### PR TITLE
feat: Add ASR evidence fetching support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -470,8 +470,10 @@ In the TNG architecture, we have integrated a standardized remote attestation pr
 
 > [!NOTE]
 > **Provider selection**: The Attestation Agent stack and the Attestation Service stack are selected with **`aa_provider`** and **`as_provider`** respectively. If `aa_provider` or `as_provider` is omitted, it defaults to **`"coco"`** (Confidential Containers). Currently supported providers are:
-> - **`"coco"`** — [Confidential Containers](https://github.com/confidential-containers) (default). Interfaces with the CoCo Attestation Agent and CoCo Attestation Service.
-> - **`"ita"`** — [Intel Trust Authority](https://www.intel.com/content/www/us/en/security/trust-authority.html). Interfaces with the CoCo Attestation Agent for evidence collection and the Intel Trust Authority cloud service for attestation and token verification.
+> - **`"coco"`** — [Confidential Containers](https://github.com/confidential-containers) (default). Interfaces with the CoCo Attestation Agent (AA) and CoCo Attestation Service.
+> - **`"ita"`** — [Intel Trust Authority](https://www.intel.com/content/www/us/en/security/trust-authority.html). Interfaces with the CoCo Attestation Agent (AA) for evidence collection and the Intel Trust Authority cloud service for attestation and token verification.
+> - **`"coco_asr"`** (`aa_provider` only) — Same as `"coco"` but collects evidence via the CoCo [API Server Rest](https://github.com/confidential-containers/guest-components/tree/main/api-server-rest) (ASR) HTTP proxy instead of connecting directly to the AA. Useful when TNG runs in a container without direct access to the AA Unix socket.
+> - **`"ita_asr"`** (`aa_provider` only) — Same as `"ita"` but collects evidence via the CoCo API Server Rest (ASR) HTTP proxy instead of connecting directly to the AA.
 
 <a name="attest"></a>
 ### Attester: The Initiator Proving Its Trustworthiness
@@ -482,8 +484,8 @@ In TNG, you can configure any endpoint as an Attester role, enabling it to respo
 
 > [!NOTE]
 > **Current Implementation Notes**:  
-> Currently, TNG only supports obtaining Evidence through the [Attestation Agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent).  
-> The Attestation Agent runs in a protected guest environment, responsible for interacting with the underlying TEE and encapsulating standardized attestation data, ensuring the security and portability of the attestation process.
+> Currently, TNG supports obtaining Evidence through the [Attestation Agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent) (AA) either directly (`"coco"` / `"ita"` providers) or indirectly via the [API Server Rest](https://github.com/confidential-containers/guest-components/tree/main/api-server-rest) (ASR) HTTP proxy (`"coco_asr"` / `"ita_asr"` providers).  
+> The ASR providers are useful when TNG runs in a container that does not have direct access to the AA Unix socket.
 > Both the **CoCo** and **ITA** providers use the same Attestation Agent for evidence collection, but differ in how the runtime data is processed and injected into the evidence (according to the requirements of the respective attestation services).
 
 <a name="verify"></a>
@@ -527,6 +529,8 @@ In the Background Check model, the [Attest](#attest) configuration should includ
 - **`aa_addr`** (string, required for "uds"): Attestation Agent unix socket address (e.g., "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock")
 - **`refresh_interval`** (int, optional, default value is 600): Specifies the cache time for obtaining evidence from the Attestation Agent (in seconds). If set to 0, it requests the latest evidence each time a secure session is established. In Background Check mode, this option only takes effect when communicating using the rats-tls protocol, affecting the frequency of updating its own X.509 certificate. This option has no effect when communicating using the OHTTP protocol.
 
+Alternatively, to collect evidence via the CoCo [API Server Rest](https://github.com/confidential-containers/guest-components/tree/main/api-server-rest) (ASR) HTTP proxy instead of connecting directly to the AA (useful when TNG runs in a container), set `aa_provider` to `"coco_asr"` and provide **`asr_addr`** (the ASR HTTP address, e.g. `"http://127.0.0.1:8006"`) instead of `aa_addr`.
+
 Example:
 
 ```json
@@ -554,6 +558,15 @@ Example:
 }
 ```
 
+Example using the ASR proxy:
+
+```json
+"attest": {
+    "aa_provider": "coco_asr",
+    "asr_addr": "http://127.0.0.1:8006"
+}
+```
+
 ##### Using the ITA Provider
 
 When `aa_provider` is set to `"ita"`, the Attest configuration uses the following fields:
@@ -562,12 +575,23 @@ When `aa_provider` is set to `"ita"`, the Attest configuration uses the followin
 - **`aa_addr`** (string, required): Attestation Agent Unix socket address (e.g., `"unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"`)
 - **`refresh_interval`** (int, optional, default value is 600): Same behavior as described above for the CoCo provider.
 
+Alternatively, set `aa_provider` to `"ita_asr"` and provide **`asr_addr`** instead of `aa_addr` to collect ITA evidence via the ASR HTTP proxy.
+
 Example:
 
 ```json
 "attest": {
     "aa_provider": "ita",
     "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+}
+```
+
+Example using the ASR proxy:
+
+```json
+"attest": {
+    "aa_provider": "ita_asr",
+    "asr_addr": "http://127.0.0.1:8006"
 }
 ```
 
@@ -895,6 +919,8 @@ In the Passport model, the [Attest](#attest) configuration should include the fo
 - **`as_headers`** (object, optional, default is {}): Custom headers to be sent with attestation service requests. This is useful when the attestation service is deployed behind an authentication mechanism that requires additional Authorization headers or other custom headers.
 - **`policy_ids`** (array [string]): List of policy IDs
 
+As with Background Check mode, you can use `aa_provider` = `"coco_asr"` with `asr_addr` instead of `aa_addr` to collect evidence via the ASR HTTP proxy.
+
 Example:
 
 ```json
@@ -926,6 +952,8 @@ When `aa_provider` and `as_provider` are set to `"ita"`, the Attest configuratio
 - **`as_addr`** (string, optional, default is `"https://api.trustauthority.intel.com"`): Intel Trust Authority API base URL
 - **`api_key`** (string, optional): Intel Trust Authority API key. Can also be set via the **`ITA_API_KEY`** environment variable.
 - **`policy_ids`** (array [string], optional, default is empty): List of ITA policy IDs that must match for attestation to succeed
+
+As with Background Check mode, you can use `aa_provider` = `"ita_asr"` with `asr_addr` instead of `aa_addr` to collect evidence via the ASR HTTP proxy.
 
 Example:
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -178,6 +178,26 @@ RUST_LOG=debug attestation-agent --attestation_sock unix:///run/confidential-con
 
 This will run an attestation-agent instance and create a ttrpc listener at `/run/confidential-containers/attestation-agent/attestation-agent.sock`.
 
+### Running API Server Rest (ASR)
+
+Some tests (e.g. the `coco_asr` and `ita_asr` e2e tests in `rats-cert`) require a running [API Server Rest](https://github.com/confidential-containers/guest-components/tree/main/api-server-rest) (ASR) instance that proxies HTTP requests to the attestation-agent. The ASR must be reachable at `http://127.0.0.1:8006`.
+
+> [!NOTE]
+> At the time of writing, the upstream ASR is missing two interface features needed by TNG: an `encoding` parameter on `/aa/evidence` for hex-encoded runtime data, and an `/aa/additional_evidence` endpoint for fetching additional evidence (for devices such as GPU). These are implemented in the [Cohere fork](https://github.com/cohere-ai/guest-components/tree/cohere) ([PR](https://github.com/cohere-ai/guest-components/pull/2)).
+
+1. Clone and run the ASR from the Cohere fork with the `attestation` feature enabled:
+
+```sh
+git clone https://github.com/cohere-ai/guest-components.git --branch cohere
+cd guest-components
+cargo run --release -p api-server-rest -- --features attestation
+```
+
+This will listen on `127.0.0.1:8006` by default and connect to the attestation-agent at its default Unix socket path (`/run/confidential-containers/attestation-agent/attestation-agent.sock`). Ensure the attestation-agent is already running before starting the ASR.
+
+> [!IMPORTANT]
+> The ASR rejects any request whose source IP is not loopback (`127.0.0.1`), returning `403 Forbidden`. The tests and the ASR must therefore run on the same host.
+
 ### Running attestation-service
 
 1. Obtain the latest trustee RPM package from [here](https://github.com/openanolis/trustee/releases) and install it using yum.

--- a/rats-cert/src/errors.rs
+++ b/rats-cert/src/errors.rs
@@ -403,4 +403,23 @@ pub enum Error {
 
     #[error("Incompatible types: {detail}")]
     IncompatibleTypes { detail: String },
+
+    // ASR (API Server Rest) errors
+    #[cfg(feature = "attester-coco")]
+    #[error("ASR HTTP request to `{endpoint}` failed: {source}")]
+    AsrHttpRequestFailed {
+        endpoint: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[cfg(feature = "attester-coco")]
+    #[error(
+        "ASR HTTP response error from `{endpoint}`: status={status_code}, body={response_body}"
+    )]
+    AsrHttpResponseError {
+        endpoint: String,
+        status_code: u16,
+        response_body: String,
+    },
 }

--- a/rats-cert/src/tee/coco/asr_attester/asr_client.rs
+++ b/rats-cert/src/tee/coco/asr_attester/asr_client.rs
@@ -153,3 +153,103 @@ impl AsrClient {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn get_evidence_returns_response_bytes() {
+        let server = MockServer::start().await;
+        let expected_evidence = b"fake-tdx-quote-bytes";
+
+        Mock::given(method("GET"))
+            .and(path("/aa/evidence"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(expected_evidence.to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AsrClient::new(&server.uri()).unwrap();
+        let evidence = client.get_evidence(b"test-hash".to_vec()).await.unwrap();
+        assert_eq!(evidence, expected_evidence);
+    }
+
+    #[tokio::test]
+    async fn get_evidence_returns_error_on_non_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/aa/evidence"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AsrClient::new(&server.uri()).unwrap();
+        let err = client
+            .get_evidence(b"test-hash".to_vec())
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::AsrHttpResponseError {
+                status_code: 500,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_tee_type_parses_info_response() {
+        let server = MockServer::start().await;
+        let tee_type = "tdx";
+
+        Mock::given(method("GET"))
+            .and(path("/info"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"tee": tee_type})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AsrClient::new(&server.uri()).unwrap();
+        assert_eq!(client.get_tee_type().await.unwrap(), tee_type);
+    }
+
+    #[tokio::test]
+    async fn get_additional_evidence_returns_none_on_failure() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/aa/additional_evidence"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AsrClient::new(&server.uri()).unwrap();
+        assert!(client.get_additional_evidence(vec![]).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_additional_evidence_returns_bytes_on_success() {
+        let server = MockServer::start().await;
+        let expected = b"gpu-evidence-blob";
+
+        Mock::given(method("GET"))
+            .and(path("/aa/additional_evidence"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(expected.to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = AsrClient::new(&server.uri()).unwrap();
+        let result = client.get_additional_evidence(vec![]).await;
+        assert_eq!(result.unwrap(), expected);
+    }
+}

--- a/rats-cert/src/tee/coco/asr_attester/asr_client.rs
+++ b/rats-cert/src/tee/coco/asr_attester/asr_client.rs
@@ -210,8 +210,7 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/info"))
             .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"tee": tee_type})),
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"tee": tee_type})),
             )
             .expect(1)
             .mount(&server)

--- a/rats-cert/src/tee/coco/asr_attester/asr_client.rs
+++ b/rats-cert/src/tee/coco/asr_attester/asr_client.rs
@@ -1,0 +1,155 @@
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use reqwest::Client;
+
+use crate::errors::*;
+
+/// HTTP response from `GET /info` on the CoCo API Server Rest (ASR).
+#[derive(serde::Deserialize)]
+struct AsrInfoResponse {
+    tee: String,
+}
+
+/// HTTP client for the CoCo API Server Rest (ASR).
+///
+/// Mirrors the [`AaClient`] interface but communicates over HTTP instead of
+/// ttrpc, enabling TNG instances running in containers (without direct access
+/// to the AA Unix socket) to collect attestation evidence through the ASR proxy.
+///
+/// Conforms to the ASR interface defined in
+/// <https://github.com/cohere-ai/guest-components/pull/2>.
+pub(crate) struct AsrClient {
+    http: Client,
+    base_url: String,
+}
+
+impl AsrClient {
+    pub fn new(asr_addr: &str) -> Result<Self> {
+        Ok(Self {
+            http: Client::new(),
+            base_url: asr_addr.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// Request a TEE evidence quote from the ASR with the given runtime_data_hash bytes.
+    pub async fn get_evidence(&self, runtime_data_hash_value: Vec<u8>) -> Result<Vec<u8>> {
+        let runtime_data_b64 = BASE64.encode(&runtime_data_hash_value);
+        let url = format!("{}/aa/evidence", self.base_url);
+
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[
+                ("runtime_data", &runtime_data_b64),
+                ("encoding", &"base64".to_string()),
+            ])
+            .send()
+            .await
+            .map_err(|e| Error::AsrHttpRequestFailed {
+                endpoint: url.clone(),
+                source: e,
+            })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::AsrHttpResponseError {
+                endpoint: url,
+                status_code: status,
+                response_body: body,
+            });
+        }
+
+        Ok(resp
+            .bytes()
+            .await
+            .map_err(|e| Error::AsrHttpRequestFailed {
+                endpoint: url,
+                source: e,
+            })?
+            .to_vec())
+    }
+
+    /// Query the TEE type string from the ASR via `GET /info` (e.g. "tdx", "snp").
+    pub async fn get_tee_type(&self) -> Result<String> {
+        let url = format!("{}/info", self.base_url);
+
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| Error::AsrHttpRequestFailed {
+                endpoint: url.clone(),
+                source: e,
+            })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::AsrHttpResponseError {
+                endpoint: url,
+                status_code: status,
+                response_body: body,
+            });
+        }
+
+        let info: AsrInfoResponse = resp.json().await.map_err(|e| Error::AsrHttpRequestFailed {
+            endpoint: url,
+            source: e,
+        })?;
+        Ok(info.tee)
+    }
+
+    /// Request additional device evidence (e.g. GPU attestation) from the ASR.
+    ///
+    /// Returns `Ok(None)` when the ASR does not support additional evidence,
+    /// the endpoint returns non-success, or the response is empty.
+    pub async fn get_additional_evidence(
+        &self,
+        runtime_data_hash_value: Vec<u8>,
+    ) -> Option<Vec<u8>> {
+        let runtime_data_b64 = BASE64.encode(&runtime_data_hash_value);
+        let url = format!("{}/aa/additional_evidence", self.base_url);
+
+        let resp = match self
+            .http
+            .get(&url)
+            .query(&[
+                ("runtime_data", &runtime_data_b64),
+                ("encoding", &"base64".to_string()),
+            ])
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "GetAdditionalEvidence request to ASR failed, proceeding without additional evidence"
+                );
+                return None;
+            }
+        };
+
+        if !resp.status().is_success() {
+            tracing::warn!(
+                status = %resp.status(),
+                "ASR additional_evidence returned non-success, proceeding without additional evidence"
+            );
+            return None;
+        }
+
+        match resp.bytes().await {
+            Ok(bytes) if !bytes.is_empty() => Some(bytes.to_vec()),
+            Ok(_) => None,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "Failed to read additional evidence response body from ASR"
+                );
+                None
+            }
+        }
+    }
+}

--- a/rats-cert/src/tee/coco/asr_attester/mod.rs
+++ b/rats-cert/src/tee/coco/asr_attester/mod.rs
@@ -1,0 +1,56 @@
+use crate::crypto::{DefaultCrypto, HashAlgo};
+use crate::errors::*;
+use crate::tee::coco::evidence::{tee_from_str, CocoEvidence};
+use crate::tee::{
+    serialize_canon_json, wrap_runtime_data_as_structed, GenericAttester, ReportData,
+};
+
+pub(crate) mod asr_client;
+
+pub(crate) use asr_client::AsrClient;
+
+/// CoCo attester that fetches evidence via the API Server Rest (ASR) HTTP
+/// interface instead of talking to the Attestation Agent over ttrpc.
+///
+/// Produces the same [`CocoEvidence`] as [`CocoAttester`], so downstream
+/// converters and verifiers are unaffected.
+pub struct CocoAsrAttester {
+    asr: AsrClient,
+}
+
+impl CocoAsrAttester {
+    pub fn new(asr_addr: &str) -> Result<Self> {
+        Ok(Self {
+            asr: AsrClient::new(asr_addr)?,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl GenericAttester for CocoAsrAttester {
+    type Evidence = CocoEvidence;
+
+    async fn get_evidence(&self, report_data: &ReportData) -> Result<CocoEvidence> {
+        let aa_runtime_data = wrap_runtime_data_as_structed(report_data)?;
+        let aa_runtime_data_bytes = serialize_canon_json(&aa_runtime_data)?;
+        let aa_runtime_data_hash_algo = HashAlgo::Sha384;
+
+        let aa_runtime_data_hash_value =
+            DefaultCrypto::hash(aa_runtime_data_hash_algo, &aa_runtime_data_bytes);
+
+        let evidence = self.asr.get_evidence(aa_runtime_data_hash_value).await?;
+
+        let tee_type_str = self.asr.get_tee_type().await?;
+        let tee_type = tee_from_str(&tee_type_str)?;
+
+        let additional_evidence = self.asr.get_additional_evidence(Vec::new()).await;
+
+        Ok(CocoEvidence::new(
+            tee_type,
+            evidence,
+            additional_evidence,
+            String::from_utf8(aa_runtime_data_bytes).map_err(Error::InvalidUtf8)?,
+            aa_runtime_data_hash_algo,
+        )?)
+    }
+}

--- a/rats-cert/src/tee/coco/attester/mod.rs
+++ b/rats-cert/src/tee/coco/attester/mod.rs
@@ -1,7 +1,6 @@
-use super::evidence::CocoEvidence;
 use crate::crypto::{DefaultCrypto, HashAlgo};
 use crate::errors::*;
-use crate::tee::coco::evidence::tee_from_str;
+use crate::tee::coco::evidence::{tee_from_str, CocoEvidence};
 use crate::tee::{
     serialize_canon_json, wrap_runtime_data_as_structed, GenericAttester, ReportData,
 };

--- a/rats-cert/src/tee/coco/mod.rs
+++ b/rats-cert/src/tee/coco/mod.rs
@@ -29,6 +29,7 @@ mod tests {
     const TEST_AA_ADDR: &str =
         "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
     const TEST_AS_ADDR: &str = "http://127.0.0.1:8080";
+    const TEST_ASR_ADDR: &str = "http://127.0.0.1:8006";
     const TEST_AS_CERT_PATH: &str = "/tmp/as-full.pem";
 
     fn make_as_addr_config() -> AttestationServiceAddrArgs {
@@ -121,6 +122,48 @@ mod tests {
             "Passport verification failed: {:?}",
             result.err()
         );
+    }
+
+    /// E2E test: ASR variant
+    /// Flow: CocoAsrAttester::get_evidence -> CocoConverter::convert -> CocoVerifier::verify_evidence
+    /// Same as the AA-based e2e but collects evidence via the ASR HTTP proxy.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_e2e_asr_flow() {
+        use crate::tee::coco::asr_attester::CocoAsrAttester;
+
+        // Create attester (connects to running ASR)
+        let attester = CocoAsrAttester::new(TEST_ASR_ADDR).expect("Failed to create ASR attester");
+
+        // Create converter (sends evidence to remote AS for verification)
+        let converter =
+            CocoRestfulConverter::new(TEST_AS_ADDR, &vec!["default".to_string()], &HashMap::new())
+                .expect("Failed to create converter");
+
+        // Create verifier (validates AS-issued token)
+        let verifier = CocoRemoteVerifier::new(
+            &Some(make_as_addr_config()),
+            &Some(vec![TEST_AS_CERT_PATH.to_string()]),
+            &vec!["default".to_string()],
+        )
+        .await
+        .expect("Failed to create verifier");
+
+        // Get evidence from TEE via ASR
+        let report_data = ReportData::Claims(serde_json::Map::new());
+        let evidence = attester
+            .get_evidence(&report_data)
+            .await
+            .expect("Failed to get evidence via ASR");
+
+        // Convert evidence to AS token
+        let token = converter
+            .convert(&evidence)
+            .await
+            .expect("Failed to convert evidence");
+
+        // Verify the token
+        let result = verifier.verify_evidence(&token, &report_data).await;
+        assert!(result.is_ok(), "Verification failed: {:?}", result.err());
     }
 
     #[cfg(feature = "__builtin-as")]

--- a/rats-cert/src/tee/coco/mod.rs
+++ b/rats-cert/src/tee/coco/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "attester-coco")]
+pub mod asr_attester;
+#[cfg(feature = "attester-coco")]
 pub mod attester;
 #[cfg(feature = "verifier-coco")]
 pub mod converter;

--- a/rats-cert/src/tee/ita/asr_attester.rs
+++ b/rats-cert/src/tee/ita/asr_attester.rs
@@ -4,7 +4,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 
 use crate::errors::*;
-use crate::tee::coco::attester::AaClient;
+use crate::tee::coco::asr_attester::asr_client::AsrClient;
 use crate::tee::{
     serialize_canon_json, wrap_runtime_data_as_structed, GenericAttester, ReportData,
 };
@@ -14,44 +14,26 @@ use super::attester_common::{
 };
 use super::evidence::{ItaEvidence, ItaNonce};
 
-/// ITA-specific attester wrapping the shared [`AaClient`].
+/// ITA-specific attester that fetches evidence via the API Server Rest (ASR)
+/// HTTP interface instead of talking to the Attestation Agent over ttrpc.
 ///
-/// Although evidence for ITA can be collected using the same CoCo Attestation Agent
-/// as [`CocoAttester`], the Intel Trust Authority service requires runtime data and nonce
-/// to be hashed and embedded into the evidence differently:
-///   - **Hash algorithm**: SHA-512 (vs SHA-384 for CoCo).
-///   - **Nonce binding**: `SHA-512(nonce.val || nonce.iat || runtime_data)` — components of
-///     the ITA nonce and runtime_data mixed into evidence so the verifier can prove freshness.
-///   - **GPU evidence binding**: The nonce must also be featured in the GPU evidence with
-///     hash `SHA-256(nonce.val || nonce.iat)`. We also fold the resulting GPU evidence blob
-///     into the runtime_data for primary evidence, creating a cross-device binding
-///     (though this isn't required by ITA).
-///
-/// This attester also parses AA-specific response formats (e.g. the
-/// `device_evidence_list` blob from `get_additional_evidence`) into the
-/// AA-agnostic [`ItaEvidence`] / [`ItaNvgpuEvidence`] types that
-/// [`ItaConverter`] consumes, keeping the converter independent of any
-/// particular evidence source.
-pub struct ItaAttester {
-    aa: AaClient,
+/// Produces the same [`ItaEvidence`] as [`ItaAttester`], so downstream
+/// converters and verifiers are unaffected. The runtime-data hashing,
+/// nonce binding, and GPU evidence parsing logic is identical.
+pub struct ItaAsrAttester {
+    asr: AsrClient,
 }
 
-impl ItaAttester {
-    pub fn new(aa_addr: &str) -> Result<Self> {
+impl ItaAsrAttester {
+    pub fn new(asr_addr: &str) -> Result<Self> {
         Ok(Self {
-            aa: AaClient::new(aa_addr)?,
-        })
-    }
-
-    pub fn new_with_timeout_nano(aa_addr: &str, timeout_nano: i64) -> Result<Self> {
-        Ok(Self {
-            aa: AaClient::new_with_timeout(aa_addr, timeout_nano)?,
+            asr: AsrClient::new(asr_addr)?,
         })
     }
 }
 
 #[async_trait::async_trait]
-impl GenericAttester for ItaAttester {
+impl GenericAttester for ItaAsrAttester {
     type Evidence = ItaEvidence;
 
     async fn get_evidence(&self, report_data: &ReportData) -> Result<ItaEvidence> {
@@ -83,19 +65,20 @@ impl GenericAttester for ItaAttester {
             }
         };
 
-        let aa_additional_evidence = self
-            .aa
-            .get_additional_evidence(ae_runtime_data_hash.to_vec());
+        let asr_additional_evidence = self
+            .asr
+            .get_additional_evidence(ae_runtime_data_hash.to_vec())
+            .await;
 
-        // Parse AA's blob into structured NVGPU evidence (if present).
-        let nvgpu_evidence = match &aa_additional_evidence {
+        // Parse ASR's blob into structured NVGPU evidence (if present).
+        let nvgpu_evidence = match &asr_additional_evidence {
             Some(blob) => parse_gpu_evidence(blob, ae_runtime_data_hash)?,
             None => None,
         };
 
         // If additional evidence is present, embed it into the runtime_data
         // for primary evidence for cryptographic binding of devices.
-        if let Some(ref ev) = aa_additional_evidence {
+        if let Some(ref ev) = asr_additional_evidence {
             if let Some(obj) = runtime_data_value.as_object_mut() {
                 obj.insert(
                     "additional_evidence".to_string(),
@@ -109,17 +92,22 @@ impl GenericAttester for ItaAttester {
         let runtime_data_hash = derive_runtime_data_hash(nonce.as_ref(), &runtime_data_bytes)?;
 
         let evidence_raw = self
-            .aa
+            .asr
             .get_evidence(runtime_data_hash)
-            .map_err(|e| Error::ItaError(format!("Failed to get primary evidence from AA: {e}")))?;
+            .await
+            .map_err(|e| {
+                Error::ItaError(format!("Failed to get primary evidence from ASR: {e}"))
+            })?;
 
-        // AA returns evidence as a JSON object (e.g. {"cc_eventlog":"...", "quote":"..."}).
-        let aa_evidence: serde_json::Value =
+        // ASR returns evidence as a JSON object (e.g. {"cc_eventlog":"...", "quote":"..."}).
+        let asr_evidence: serde_json::Value =
             serde_json::from_slice(&evidence_raw).map_err(Error::ParseEvidenceFromBytesFailed)?;
-        let tdx_quote_b64 = aa_evidence
+        let tdx_quote_b64 = asr_evidence
             .get("quote")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| Error::ItaError("AA evidence JSON missing 'quote' field".to_string()))?;
+            .ok_or_else(|| {
+                Error::ItaError("ASR evidence JSON missing 'quote' field".to_string())
+            })?;
         let tdx_quote = BASE64
             .decode(tdx_quote_b64)
             .map_err(Error::Base64DecodeFailed)?;

--- a/rats-cert/src/tee/ita/attester_common.rs
+++ b/rats-cert/src/tee/ita/attester_common.rs
@@ -148,8 +148,7 @@ mod tests {
         });
         let hash = [0xABu8; 32];
         let result =
-            parse_gpu_evidence(serde_json::to_vec(&blob).unwrap().as_slice(), hash)
-                .unwrap();
+            parse_gpu_evidence(serde_json::to_vec(&blob).unwrap().as_slice(), hash).unwrap();
 
         let gpu = result.expect("should return Some for valid nvidia blob");
         assert_eq!(gpu.certificate, cert);

--- a/rats-cert/src/tee/ita/attester_common.rs
+++ b/rats-cert/src/tee/ita/attester_common.rs
@@ -1,0 +1,239 @@
+use std::collections::HashMap;
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use kbs_types::Tee;
+use sha2::{Digest, Sha256, Sha512};
+
+use crate::errors::*;
+
+use super::evidence::{ItaNonce, ItaNvgpuEvidence};
+
+/// GPU device evidence as returned by the CoCo AA / ASR `get_additional_evidence()`.
+///
+/// The response is a JSON map keyed by [`kbs_types::Tee`] variant, e.g.:
+/// ```json
+/// { "nvidia": { "device_evidence_list": [{ "evidence": "<b64>", "certificate": "<pem>", "arch": "hopper" }] } }
+/// ```
+#[derive(serde::Deserialize)]
+struct GpuDeviceList {
+    device_evidence_list: Vec<GpuDevice>,
+}
+
+#[derive(serde::Deserialize)]
+struct GpuDevice {
+    evidence: String,
+    certificate: String,
+    arch: String,
+}
+
+/// Parse an additional_evidence blob into an [`ItaNvgpuEvidence`].
+///
+/// Returns `Ok(None)` when the blob contains no NVIDIA GPU device evidence.
+pub(crate) fn parse_gpu_evidence(
+    blob: &[u8],
+    runtime_data_hash: [u8; 32],
+) -> Result<Option<ItaNvgpuEvidence>> {
+    let tee_map: HashMap<Tee, serde_json::Value> =
+        serde_json::from_slice(blob).map_err(Error::ParseAdditionalEvidenceJsonFailed)?;
+
+    let nvidia_value = match tee_map.get(&Tee::Nvidia) {
+        Some(v) => v.clone(),
+        None => {
+            tracing::debug!("No Nvidia key in additional evidence; skipping GPU attestation");
+            return Ok(None);
+        }
+    };
+
+    let gpu_list: GpuDeviceList =
+        serde_json::from_value(nvidia_value).map_err(Error::ParseAdditionalEvidenceJsonFailed)?;
+
+    let device = match gpu_list.device_evidence_list.into_iter().next() {
+        Some(d) => d,
+        None => {
+            tracing::warn!("nvidia device_evidence_list is empty; skipping GPU attestation");
+            return Ok(None);
+        }
+    };
+
+    // ITA expects evidence as base64(hex(raw_bytes)), while AA/ASR provides base64(raw_bytes).
+    let raw = BASE64
+        .decode(&device.evidence)
+        .map_err(Error::Base64DecodeFailed)?;
+    let reencoded_evidence = BASE64.encode(hex::encode(&raw).as_bytes());
+
+    Ok(Some(ItaNvgpuEvidence {
+        evidence: reencoded_evidence,
+        certificate: device.certificate,
+        arch: device.arch,
+        runtime_data_hash,
+    }))
+}
+
+/// Derive `SHA-256(decode(nonce.val) || decode(nonce.iat))` for additional evidence collection
+/// (used in GPU evidence collection).
+pub(crate) fn derive_additional_evidence_runtime_data_hash(nonce: &ItaNonce) -> Result<[u8; 32]> {
+    let val_bytes = BASE64
+        .decode(&nonce.val)
+        .map_err(Error::Base64DecodeFailed)?;
+    let iat_bytes = BASE64
+        .decode(&nonce.iat)
+        .map_err(Error::Base64DecodeFailed)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&val_bytes);
+    hasher.update(&iat_bytes);
+    Ok(hasher.finalize().into())
+}
+
+/// Derive runtime data hash according to ITA expectations.
+/// With nonce: `SHA-512(decode(nonce.val) || decode(nonce.iat) || runtime_data_bytes)`
+/// Without nonce (RA-TLS): `SHA-512(runtime_data_bytes)`
+pub(crate) fn derive_runtime_data_hash(
+    nonce: Option<&ItaNonce>,
+    runtime_data_bytes: &[u8],
+) -> Result<Vec<u8>> {
+    let mut hasher = Sha512::new();
+    if let Some(nonce) = nonce {
+        let val_bytes = BASE64
+            .decode(&nonce.val)
+            .map_err(Error::Base64DecodeFailed)?;
+        let iat_bytes = BASE64
+            .decode(&nonce.iat)
+            .map_err(Error::Base64DecodeFailed)?;
+        hasher.update(&val_bytes);
+        hasher.update(&iat_bytes);
+    }
+    hasher.update(runtime_data_bytes);
+    Ok(hasher.finalize().to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_RUNTIME_DATA: &[u8] = br#"{"a":"12","b":"34","c":"56"}"#;
+
+    fn sample_nonce() -> ItaNonce {
+        ItaNonce {
+            val: "aGVsbG8=".into(), // base64("hello")
+            iat: "d29ybGQ=".into(), // base64("world")
+            signature: "dGVzdC1zaWc=".into(),
+        }
+    }
+
+    fn bad_nonce() -> ItaNonce {
+        ItaNonce {
+            val: "!!!not-base64!!!".into(),
+            iat: "d29ybGQ=".into(),
+            signature: "sig".into(),
+        }
+    }
+
+    // -- parse_gpu_evidence --
+
+    #[test]
+    fn parse_gpu_evidence_valid_nvidia_blob() {
+        let raw_bytes = vec![1u8, 2, 3];
+        let input_b64 = BASE64.encode(&raw_bytes);
+        let cert = "test-cert-pem";
+        let arch = "hopper";
+        let blob = serde_json::json!({
+            "nvidia": {
+                "device_evidence_list": [{
+                    "evidence": input_b64,
+                    "certificate": cert,
+                    "arch": arch
+                }]
+            }
+        });
+        let hash = [0xABu8; 32];
+        let result =
+            parse_gpu_evidence(serde_json::to_vec(&blob).unwrap().as_slice(), hash)
+                .unwrap();
+
+        let gpu = result.expect("should return Some for valid nvidia blob");
+        assert_eq!(gpu.certificate, cert);
+        assert_eq!(gpu.arch, arch);
+        assert_eq!(gpu.runtime_data_hash, hash);
+        let expected_evidence = BASE64.encode(hex::encode(&raw_bytes).as_bytes());
+        assert_eq!(gpu.evidence, expected_evidence);
+    }
+
+    #[test]
+    fn parse_gpu_evidence_no_nvidia_key() {
+        let blob = serde_json::json!({"sample": {}});
+        let result =
+            parse_gpu_evidence(serde_json::to_vec(&blob).unwrap().as_slice(), [0u8; 32]).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_gpu_evidence_empty_device_list() {
+        let blob = serde_json::json!({
+            "nvidia": {"device_evidence_list": []}
+        });
+        let result =
+            parse_gpu_evidence(serde_json::to_vec(&blob).unwrap().as_slice(), [0u8; 32]).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_gpu_evidence_invalid_json() {
+        assert!(parse_gpu_evidence(b"not json", [0u8; 32]).is_err());
+    }
+
+    // -- derive_additional_evidence_runtime_data_hash --
+
+    #[test]
+    fn additional_evidence_hash_known_answer() {
+        let hash = derive_additional_evidence_runtime_data_hash(&sample_nonce()).unwrap();
+        // SHA-256("hello" || "world")
+        assert_eq!(
+            hex::encode(hash),
+            "936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af"
+        );
+    }
+
+    #[test]
+    fn additional_evidence_hash_invalid_base64() {
+        assert!(derive_additional_evidence_runtime_data_hash(&bad_nonce()).is_err());
+    }
+
+    // -- derive_runtime_data_hash --
+
+    #[test]
+    fn runtime_data_hash_with_nonce_known_answer() {
+        let nonce = sample_nonce();
+        let hash = derive_runtime_data_hash(Some(&nonce), SAMPLE_RUNTIME_DATA).unwrap();
+        // SHA-512("hello" || "world" || SAMPLE_RUNTIME_DATA)
+        assert_eq!(
+            hex::encode(&hash),
+            "c2bd195b9104a139a2aa82584870446c7efb0fa6d4f4fb0c5db668382bde9710\
+             e874010639b54b49adfd56f2f98e687f04dbcff7bf32f7f8fa7c1001c846e05c"
+        );
+    }
+
+    #[test]
+    fn runtime_data_hash_without_nonce_known_answer() {
+        let hash = derive_runtime_data_hash(None, SAMPLE_RUNTIME_DATA).unwrap();
+        // SHA-512(SAMPLE_RUNTIME_DATA)
+        assert_eq!(
+            hex::encode(&hash),
+            "e01416f798823156a9241bfd0d9da76b3f8dd3c2313cd91bcf4021e4b7519ecc\
+             f68e454bf1198d71ddfcedfc6ad153dd697f1fa740e2ef78629cff3e3fd4d43c"
+        );
+    }
+
+    #[test]
+    fn runtime_data_hash_nonce_participates() {
+        let nonce = sample_nonce();
+        let with = derive_runtime_data_hash(Some(&nonce), SAMPLE_RUNTIME_DATA).unwrap();
+        let without = derive_runtime_data_hash(None, SAMPLE_RUNTIME_DATA).unwrap();
+        assert_ne!(with, without);
+    }
+
+    #[test]
+    fn runtime_data_hash_invalid_base64_nonce() {
+        assert!(derive_runtime_data_hash(Some(&bad_nonce()), SAMPLE_RUNTIME_DATA).is_err());
+    }
+}

--- a/rats-cert/src/tee/ita/mod.rs
+++ b/rats-cert/src/tee/ita/mod.rs
@@ -4,7 +4,11 @@ pub mod evidence;
 pub mod token;
 
 #[cfg(feature = "attester-ita")]
-pub mod attester;
+mod asr_attester;
+#[cfg(feature = "attester-ita")]
+mod attester;
+#[cfg(feature = "attester-ita")]
+mod attester_common;
 #[cfg(any(feature = "attester-ita", feature = "verifier-ita"))]
 pub mod converter;
 #[cfg(any(feature = "attester-ita", feature = "verifier-ita"))]
@@ -17,6 +21,8 @@ pub use evidence::{ItaEvidence, ItaNonce};
 #[cfg(any(feature = "attester-ita", feature = "verifier-ita"))]
 pub use token::ItaToken;
 
+#[cfg(feature = "attester-ita")]
+pub use asr_attester::ItaAsrAttester;
 #[cfg(feature = "attester-ita")]
 pub use attester::ItaAttester;
 #[cfg(any(feature = "attester-ita", feature = "verifier-ita"))]

--- a/rats-cert/src/tee/ita/mod.rs
+++ b/rats-cert/src/tee/ita/mod.rs
@@ -39,6 +39,7 @@ mod tests {
 
     const TEST_AA_ADDR: &str =
         "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock";
+    const TEST_ASR_ADDR: &str = "http://127.0.0.1:8006";
     const TEST_ITA_API_URL: &str = "https://api.trustauthority.intel.com";
     const TEST_ITA_JWKS_URL: &str = "https://portal.trustauthority.intel.com";
 
@@ -118,6 +119,59 @@ mod tests {
             .get_evidence(&report_data)
             .await
             .expect("Failed to get evidence");
+
+        // Convert evidence to ITA token
+        let token = converter
+            .convert(&evidence)
+            .await
+            .expect("Failed to convert evidence to token");
+
+        // Verify the token
+        let result = verifier.verify_evidence(&token, &report_data).await;
+        assert!(result.is_ok(), "Verification failed: {:?}", result.err());
+    }
+
+    /// E2E test with nonce: ItaConverter::get_nonce -> ItaAsrAttester -> ItaConverter -> ItaVerifier
+    /// Same as the AA-based nonce e2e but collects evidence via the ASR HTTP proxy.
+    ///
+    /// Requires a running ASR proxy at `TEST_ASR_ADDR`.
+    /// Ignored if the `ITA_API_KEY` env var is not set.
+    #[test_with::env(ITA_API_KEY)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_e2e_ita_asr_flow() {
+        use crate::tee::ita::ItaAsrAttester;
+
+        let api_key = std::env::var("ITA_API_KEY").unwrap();
+
+        // Create attester (connects to running ASR)
+        let attester = ItaAsrAttester::new(TEST_ASR_ADDR).expect("Failed to create ASR attester");
+
+        // Create converter (sends evidence to ITA for appraisal)
+        let converter =
+            ItaConverter::new(&api_key, TEST_ITA_API_URL, &[]).expect("Failed to create converter");
+
+        // Create verifier (validates ITA-issued JWT via JWKS)
+        let verifier = ItaVerifier::new(TEST_ITA_JWKS_URL, &[]).expect("Failed to create verifier");
+
+        // Fetch nonce from ITA
+        let nonce = converter
+            .get_nonce()
+            .await
+            .expect("Failed to get nonce from ITA");
+
+        // Include nonce as challenge_token in the report data claims
+        let mut claims = serde_json::Map::new();
+        claims.insert(
+            "challenge_token".to_string(),
+            serde_json::Value::String(nonce),
+        );
+        let report_data = ReportData::Claims(claims);
+
+        // Get evidence from TEE via ASR (nonce bound into evidence)
+        let evidence = attester
+            .get_evidence(&report_data)
+            .await
+            .expect("Failed to get evidence via ASR");
 
         // Convert evidence to ITA token
         let token = converter

--- a/tng/src/config/ra.rs
+++ b/tng/src/config/ra.rs
@@ -173,6 +173,16 @@ impl RaArgsUnchecked {
                             )));
                         }
                     }
+                    AttesterArgs::CocoAsr(args) => {
+                        Url::parse(&args.asr_addr)
+                            .with_context(|| format!("Invalid ASR address: {}", args.asr_addr))
+                            .map_err(TngError::InvalidParameter)?;
+                    }
+                    AttesterArgs::ItaAsr(args) => {
+                        Url::parse(&args.asr_addr)
+                            .with_context(|| format!("Invalid ASR address: {}", args.asr_addr))
+                            .map_err(TngError::InvalidParameter)?;
+                    }
                 },
             };
 
@@ -330,6 +340,8 @@ impl RaArgsUnchecked {
 pub enum AttesterArgs {
     Coco(CocoAttesterArgs),
     Ita(ItaAttesterArgs),
+    CocoAsr(CocoAsrAttesterArgs),
+    ItaAsr(ItaAsrAttesterArgs),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -342,6 +354,34 @@ pub struct ItaAttesterArgs {
 impl ItaAttesterArgs {
     pub fn to_attester(&self) -> anyhow::Result<rats_cert::tee::ita::ItaAttester> {
         rats_cert::tee::ita::ItaAttester::new(&self.aa_addr).map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CocoAsrAttesterArgs {
+    /// API Server Rest HTTP address (e.g. `"http://127.0.0.1:8006"`)
+    pub asr_addr: String,
+}
+
+#[cfg(unix)]
+impl CocoAsrAttesterArgs {
+    pub fn to_attester(
+        &self,
+    ) -> anyhow::Result<rats_cert::tee::coco::asr_attester::CocoAsrAttester> {
+        rats_cert::tee::coco::asr_attester::CocoAsrAttester::new(&self.asr_addr).map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItaAsrAttesterArgs {
+    /// API Server Rest HTTP address (e.g. `"http://127.0.0.1:8006"`)
+    pub asr_addr: String,
+}
+
+#[cfg(unix)]
+impl ItaAsrAttesterArgs {
+    pub fn to_attester(&self) -> anyhow::Result<rats_cert::tee::ita::ItaAsrAttester> {
+        rats_cert::tee::ita::ItaAsrAttester::new(&self.asr_addr).map_err(Into::into)
     }
 }
 

--- a/tng/src/tunnel/provider/attester.rs
+++ b/tng/src/tunnel/provider/attester.rs
@@ -1,6 +1,7 @@
 use rats_cert::errors::*;
+use rats_cert::tee::coco::asr_attester::CocoAsrAttester;
 use rats_cert::tee::coco::attester::CocoAttester;
-use rats_cert::tee::ita::ItaAttester;
+use rats_cert::tee::ita::{ItaAsrAttester, ItaAttester};
 use rats_cert::tee::{GenericAttester, ReportData};
 
 use super::evidence::TngEvidence;
@@ -9,13 +10,15 @@ use super::evidence::TngEvidence;
 pub enum TngAttester {
     Coco(CocoAttester),
     Ita(ItaAttester),
+    CocoAsr(CocoAsrAttester),
+    ItaAsr(ItaAsrAttester),
 }
 
 impl TngAttester {
     pub fn provider_type(&self) -> super::provider_type::ProviderType {
         match self {
-            Self::Coco(_) => super::provider_type::ProviderType::Coco,
-            Self::Ita(_) => super::provider_type::ProviderType::Ita,
+            Self::Coco(_) | Self::CocoAsr(_) => super::provider_type::ProviderType::Coco,
+            Self::Ita(_) | Self::ItaAsr(_) => super::provider_type::ProviderType::Ita,
         }
     }
 }
@@ -28,6 +31,8 @@ impl GenericAttester for TngAttester {
         match self {
             Self::Coco(a) => Ok(a.get_evidence(report_data).await?.into()),
             Self::Ita(a) => Ok(a.get_evidence(report_data).await?.into()),
+            Self::CocoAsr(a) => Ok(a.get_evidence(report_data).await?.into()),
+            Self::ItaAsr(a) => Ok(a.get_evidence(report_data).await?.into()),
         }
     }
 }

--- a/tng/src/tunnel/provider/factory.rs
+++ b/tng/src/tunnel/provider/factory.rs
@@ -27,6 +27,8 @@ pub fn create_attester(config: &AttesterArgs) -> Result<TngAttester> {
             }
         },
         AttesterArgs::Ita(args) => Ok(TngAttester::Ita(args.to_attester()?)),
+        AttesterArgs::CocoAsr(args) => Ok(TngAttester::CocoAsr(args.to_attester()?)),
+        AttesterArgs::ItaAsr(args) => Ok(TngAttester::ItaAsr(args.to_attester()?)),
     }
 }
 


### PR DESCRIPTION
TNG usually fetches TEE evidence via Attestation Agent (AA). However, when running TNG in a container, communication with AA becomes complicated as AA interfaces over unix sockets. CoCo project provides the API Server Rest (ASR) component to proxy HTTP requests from containers to the AA. This PR adds support for TNG to interface with ASR to fetch evidence compatible with both CoCo AS and Intel Trust Authority (ITA).

Note that ASR's interface lacked certain features that prevented TNG from utilizing it. These have been remedied with [this PR](https://github.com/cohere-ai/guest-components/pull/2)n our ASR (guest-components) fork. Expect us to open a PR with upstream soon. If those changes are merged upstream, documentation here can be updated accordingly.

@imlk0 Would be great if you can take a look and give us feedback on the approach, thanks!