### PR TITLE
feat(tests): pre-compile test binaries before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,15 @@ run-test-coverage: install-test-deps
 
 	./tng-testsuite/run-test.sh --coverage
 
-.PHONE: run-test-on-bin
+.PHONY: run-test-on-bin
 run-test-on-bin: install-test-deps
+	cargo build --no-default-features --features on-bin --package tng-testsuite --tests
 	cargo test --no-default-features --features on-bin --package tng-testsuite --tests -- --nocapture
 
 
-.PHONE: run-test-on-podman
+.PHONY: run-test-on-podman
 run-test-on-podman: install-test-deps
+	cargo build --no-default-features --features on-podman --package tng-testsuite --tests
 	cargo test --no-default-features --features on-podman --package tng-testsuite --tests -- --nocapture
 
 

--- a/tng-testsuite/run-test.sh
+++ b/tng-testsuite/run-test.sh
@@ -125,6 +125,14 @@ if $ENABLE_COVERAGE; then
     cargo llvm-cov clean --workspace
 fi
 
+# Pre-compile all test binaries before running tests (non-coverage only)
+if ! $ENABLE_COVERAGE; then
+    echo "============= Pre-compiling test binaries ============="
+    cargo build --workspace --exclude tng-wasm
+    cargo build --no-default-features --features on-source-code --package tng-testsuite
+    echo "============= Pre-compilation finished ============="
+fi
+
 # Run unit tests
 echo "============= Starting unit test ============="
 summary_lines+=("$(format_result "Unit tests" "")")


### PR DESCRIPTION
## Summary
- Add a pre-compilation step before running unit and integration tests in `run-test.sh`
- Add pre-build steps to `make run-test-on-bin` and `make run-test-on-podman` targets

This avoids repeated compilation during each `cargo test` invocation, making test runs faster and smoother.

## Changes
- `tng-testsuite/run-test.sh`: build all test binaries upfront before running individual tests
- `Makefile`: `run-test-on-bin` and `run-test-on-podman` now run `cargo build --tests` first