### PR TITLE
test: add cgroup and port range integration tests for netfilter

### DIFF
--- a/tng-testsuite/tests/egress_netfilter_cgroup.rs
+++ b/tng-testsuite/tests/egress_netfilter_cgroup.rs
@@ -1,0 +1,360 @@
+use anyhow::Result;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, shell::ShellTask, tng::TngInstance, NodeType, Task as _},
+};
+
+const TCP_PAYLOAD: &str = "Hello World TCP!";
+
+/// Test egress netfilter with capture_cgroup.
+/// Processes in the capture_cgroup have their traffic captured by TNG.
+///
+/// Flow:
+/// 1. Create cgroup /tng_cg_cap_test/ on Server node
+/// 2. Run TNG with capture_cgroup = ["/tng_cg_cap_test/"]
+/// 3. ShellTask moves itself into the cgroup, connects to 192.168.1.1:30001
+/// 4. Traffic is captured by TNG (cgroup match) and forwarded via tunnel to TcpServer
+/// 5. TcpServer echoes, ShellTask verifies response matches
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_cgroup_capture() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_cg_cap_test/"],
+                            "capture_local_traffic": true
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": {
+                                "port": 10001
+                            },
+                            "out": {
+                                "host": "192.168.1.1",
+                                "port": 30001
+                            }
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        ShellTask {
+            name: "cgroup_capture_client".to_owned(),
+            node_type: NodeType::Server,
+            script: format!(
+                r#"
+                set -e
+                CGROUP=/sys/fs/cgroup/tng_cg_cap_test
+                mkdir -p "$CGROUP"
+                echo $$ > "$CGROUP/cgroup.procs"
+                trap "rmdir $CGROUP 2>/dev/null" EXIT
+                # Connect from within the capture_cgroup
+                # Traffic to 192.168.1.1:30001 is captured by TNG (cgroup + port match)
+                # TNG forwards via tunnel to TcpServer on port 30001
+                RESPONSE=$(echo '{TCP_PAYLOAD}' | socat - TCP:192.168.1.1:30001)
+                if [ "$RESPONSE" != "{TCP_PAYLOAD}" ]; then
+                    echo "Expected '{TCP_PAYLOAD}', got '$RESPONSE'"
+                    exit 1
+                fi
+                echo "cgroup capture test passed"
+            "#
+            ),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Test egress netfilter with nocapture_cgroup.
+/// Traffic from processes in nocapture_cgroup is NOT captured by TNG,
+/// while traffic from other cgroups IS captured.
+///
+/// This test validates both behaviors in one test:
+/// - Capture path: client in capture_cgroup → TNG tunnel → socat on 30002 (success)
+/// - Nocapture path: client in nocapture_cgroup → direct connection to socat on 30001 (success)
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_cgroup_nocapture() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_cg_nc_capture/"],
+                            "nocapture_cgroup": ["/tng_cg_nc_bypass/"],
+                            "capture_local_traffic": true
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": {
+                                "port": 10002
+                            },
+                            "out": {
+                                "host": "192.168.1.1",
+                                "port": 30002
+                            }
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30002 }.boxed(),
+        ShellTask {
+            name: "cgroup_nocapture_test".to_owned(),
+            node_type: NodeType::Server,
+            script: r#"
+                set -e
+                CAPTURE_CG=/sys/fs/cgroup/tng_cg_nc_capture
+                BYPASS_CG=/sys/fs/cgroup/tng_cg_nc_bypass
+                mkdir -p "$CAPTURE_CG" "$BYPASS_CG"
+                trap "rmdir $CAPTURE_CG $BYPASS_CG 2>/dev/null" EXIT
+
+                # Start a direct TCP server on port 30001 (no TNG involvement)
+                socat TCP-LISTEN:30001,fork,reuseaddr EXEC:"cat" &
+                DIRECT_PID=$!
+
+                # Test 1: Connect from nocapture_cgroup (direct connection should work)
+                echo "test_nocapture" | (
+                    echo $$ > "$BYPASS_CG/cgroup.procs"
+                    socat - TCP:127.0.0.1:30001
+                ) | grep -q "test_nocapture"
+                echo "nocapture test passed"
+
+                # Test 2: Connect from capture_cgroup (should go through TNG tunnel)
+                echo "test_capture" | (
+                    echo $$ > "$CAPTURE_CG/cgroup.procs"
+                    socat - TCP:127.0.0.1:10002
+                ) | grep -q "test_capture"
+                echo "capture test passed"
+
+                kill $DIRECT_PID 2>/dev/null
+                sleep 30
+            "#
+            .to_owned(),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Test egress netfilter with both capture_cgroup and capture_dst.
+/// Traffic is captured only if BOTH the process is in capture_cgroup
+/// AND the destination matches a capture_dst rule.
+///
+/// Flow:
+/// 1. Create cgroup /tng_cg_combo_test/
+/// 2. Run TNG with capture_cgroup + capture_dst (port 30002)
+/// 3. ShellTask moves into cgroup, connects to 192.168.1.1:30002
+/// 4. TNG captures (cgroup + port match) → forwards to TcpServer → success
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_cgroup_and_capture_dst() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_cg_combo_test/"],
+                            "capture_dst": [{ "port": 30002 }],
+                            "capture_local_traffic": true
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": {
+                                "port": 10002
+                            },
+                            "out": {
+                                "host": "192.168.1.1",
+                                "port": 30002
+                            }
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30002 }.boxed(),
+        ShellTask {
+            name: "cgroup_combo_client".to_owned(),
+            node_type: NodeType::Server,
+            script: format!(
+                r#"
+                set -e
+                CGROUP=/sys/fs/cgroup/tng_cg_combo_test
+                mkdir -p "$CGROUP"
+                echo $$ > "$CGROUP/cgroup.procs"
+                trap "rmdir $CGROUP 2>/dev/null" EXIT
+                RESPONSE=$(echo '{TCP_PAYLOAD}' | socat - TCP:192.168.1.1:30002)
+                if [ "$RESPONSE" != "{TCP_PAYLOAD}" ]; then
+                    echo "Expected '{TCP_PAYLOAD}', got '$RESPONSE'"
+                    exit 1
+                fi
+                echo "cgroup + capture_dst combo test passed"
+            "#
+            ),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Test egress netfilter with capture_cgroup only (no capture_dst).
+/// When no capture_dst is specified, ALL TCP traffic from the capture_cgroup is captured.
+///
+/// Flow:
+/// 1. Create cgroup /tng_cg_alltcp_test/
+/// 2. Run TNG with capture_cgroup only (no capture_dst)
+/// 3. ShellTask moves into cgroup, connects to 192.168.1.1:30099 (non-standard port)
+/// 4. TNG captures all TCP from cgroup → forwards to TcpServer → success
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_cgroup_only_all_tcp() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_cg_alltcp_test/"],
+                            "capture_local_traffic": true
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": {
+                                "port": 10099
+                            },
+                            "out": {
+                                "host": "192.168.1.1",
+                                "port": 30099
+                            }
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30099 }.boxed(),
+        ShellTask {
+            name: "cgroup_alltcp_client".to_owned(),
+            node_type: NodeType::Server,
+            script: format!(
+                r#"
+                set -e
+                CGROUP=/sys/fs/cgroup/tng_cg_alltcp_test
+                mkdir -p "$CGROUP"
+                echo $$ > "$CGROUP/cgroup.procs"
+                trap "rmdir $CGROUP 2>/dev/null" EXIT
+                # Connect to a non-standard port — since no capture_dst is set, ALL TCP is captured
+                RESPONSE=$(echo '{TCP_PAYLOAD}' | socat - TCP:192.168.1.1:30099)
+                if [ "$RESPONSE" != "{TCP_PAYLOAD}" ]; then
+                    echo "Expected '{TCP_PAYLOAD}', got '$RESPONSE'"
+                    exit 1
+                fi
+                echo "cgroup-only all-TCP test passed"
+            "#
+            ),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng-testsuite/tests/egress_netfilter_cgroup.rs
+++ b/tng-testsuite/tests/egress_netfilter_cgroup.rs
@@ -16,6 +16,7 @@ const TCP_PAYLOAD: &str = "Hello World TCP!";
 /// 4. Traffic is captured by TNG (cgroup match) and forwarded via tunnel to TcpServer
 /// 5. TcpServer echoes, ShellTask verifies response matches
 #[serial_test::serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_egress_netfilter_cgroup_capture() -> Result<()> {
     run_test(vec![
@@ -101,6 +102,7 @@ async fn test_egress_netfilter_cgroup_capture() -> Result<()> {
 /// - Capture path: client in capture_cgroup → TNG tunnel → socat on 30002 (success)
 /// - Nocapture path: client in nocapture_cgroup → direct connection to socat on 30001 (success)
 #[serial_test::serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_egress_netfilter_cgroup_nocapture() -> Result<()> {
     run_test(vec![
@@ -200,6 +202,7 @@ async fn test_egress_netfilter_cgroup_nocapture() -> Result<()> {
 /// 3. ShellTask moves into cgroup, connects to 192.168.1.1:30002
 /// 4. TNG captures (cgroup + port match) → forwards to TcpServer → success
 #[serial_test::serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_egress_netfilter_cgroup_and_capture_dst() -> Result<()> {
     run_test(vec![
@@ -284,6 +287,7 @@ async fn test_egress_netfilter_cgroup_and_capture_dst() -> Result<()> {
 /// 3. ShellTask moves into cgroup, connects to 192.168.1.1:30099 (non-standard port)
 /// 4. TNG captures all TCP from cgroup → forwards to TcpServer → success
 #[serial_test::serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_egress_netfilter_cgroup_only_all_tcp() -> Result<()> {
     run_test(vec![

--- a/tng-testsuite/tests/egress_netfilter_port_range.rs
+++ b/tng-testsuite/tests/egress_netfilter_port_range.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, tng::TngInstance, Task as _},
+};
+
+/// Test egress netfilter with port range (port_end) capture_dst.
+///
+/// Configures egress to capture port range 30000-30031.
+/// Validates that TcpClient connecting to a port within the range (30015)
+/// is successfully captured and forwarded through the TNG tunnel.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_port_range() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": [
+                                {
+                                    "port": 30000,
+                                    "port_end": 30031
+                                }
+                            ],
+                            "capture_local_traffic": true
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": {
+                                "port": 10015
+                            },
+                            "out": {
+                                "host": "192.168.1.1",
+                                "port": 30015
+                            }
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": [
+                                "default"
+                            ]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30015 }.boxed(),
+        AppType::TcpClient {
+            host: "127.0.0.1",
+            port: 10015,
+            http_proxy: None,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng-testsuite/tests/ingress_netfilter_capture.rs
+++ b/tng-testsuite/tests/ingress_netfilter_capture.rs
@@ -119,8 +119,31 @@ async fn test_host_and_port() -> Result<()> {
 #[serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_port_range() -> Result<()> {
+    // Server egress must also capture the target port for the tunnel to work.
+    // We use a wide port range on both sides to validate port_end.
     run_test(vec![
-        TNG_SERVER_INSTANCE.clone().boxed(),
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": [
+                                {
+                                    "port": 30000,
+                                    "port_end": 30031
+                                }
+                            ]
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
         TngInstance::TngClient(
             r#"
                 {

--- a/tng-testsuite/tests/ingress_netfilter_capture.rs
+++ b/tng-testsuite/tests/ingress_netfilter_capture.rs
@@ -1,0 +1,219 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, shell::ShellTask, tng::TngInstance, NodeType, Task as _},
+};
+
+const TNG_SERVER_INSTANCE: TngInstance = TngInstance::TngServer(
+    r#"
+    {
+        "add_egress": [
+            {
+                "netfilter": {
+                    "capture_dst": {
+                        "port": 30001
+                    }
+                },
+                "attest": {
+                    "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                }
+            }
+        ]
+    }
+    "#,
+);
+
+/// Ingress netfilter with port-only capture_dst.
+/// Client connects to server:30001, ingress netfilter intercepts and forwards via TNG tunnel.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_port_only() -> Result<()> {
+    run_test(vec![
+        TNG_SERVER_INSTANCE.clone().boxed(),
+        TngInstance::TngClient(
+            r#"
+                {
+                    "add_ingress": [
+                        {
+                            "netfilter": {
+                                "capture_dst": [
+                                    {
+                                        "port": 30001
+                                    }
+                                ],
+                                "listen_port": 50000
+                            },
+                            "verify": {
+                                "as_addr": "http://192.168.1.254:8080/",
+                                "policy_ids": [
+                                    "default"
+                                ]
+                            }
+                        }
+                    ]
+                }
+                "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        AppType::TcpClient {
+            host: "192.168.1.1",
+            port: 30001,
+            http_proxy: None,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Ingress netfilter with host CIDR + port capture_dst.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_host_and_port() -> Result<()> {
+    run_test(vec![
+        TNG_SERVER_INSTANCE.clone().boxed(),
+        TngInstance::TngClient(
+            r#"
+                {
+                    "add_ingress": [
+                        {
+                            "netfilter": {
+                                "capture_dst": [
+                                    {
+                                        "host": "192.168.1.0/24",
+                                        "port": 30001
+                                    }
+                                ],
+                                "listen_port": 50000
+                            },
+                            "verify": {
+                                "as_addr": "http://192.168.1.254:8080/",
+                                "policy_ids": [
+                                    "default"
+                                ]
+                            }
+                        }
+                    ]
+                }
+                "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        AppType::TcpClient {
+            host: "192.168.1.1",
+            port: 30001,
+            http_proxy: None,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Ingress netfilter with port range capture_dst.
+/// Tests the port_end feature — captures all ports in [30000, 30031].
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_port_range() -> Result<()> {
+    run_test(vec![
+        TNG_SERVER_INSTANCE.clone().boxed(),
+        TngInstance::TngClient(
+            r#"
+                {
+                    "add_ingress": [
+                        {
+                            "netfilter": {
+                                "capture_dst": [
+                                    {
+                                        "port": 30000,
+                                        "port_end": 30031
+                                    }
+                                ],
+                                "listen_port": 50000
+                            },
+                            "verify": {
+                                "as_addr": "http://192.168.1.254:8080/",
+                                "policy_ids": [
+                                    "default"
+                                ]
+                            }
+                        }
+                    ]
+                }
+                "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30015 }.boxed(),
+        AppType::TcpClient {
+            host: "192.168.1.1",
+            port: 30015,
+            http_proxy: None,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Ingress netfilter with ipset + port capture_dst.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ipset_and_port() -> Result<()> {
+    run_test(vec![
+        ShellTask {
+            name: "prepare_ipset".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+                    ipset create myset hash:ip
+                    ipset add myset 192.168.1.1
+                    ipset list myset
+                "#
+            .to_owned(),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+        TNG_SERVER_INSTANCE.clone().boxed(),
+        TngInstance::TngClient(
+            r#"
+                {
+                    "add_ingress": [
+                        {
+                            "netfilter": {
+                                "capture_dst": [
+                                    {
+                                        "ipset": "myset",
+                                        "port": 30001
+                                    }
+                                ],
+                                "listen_port": 50000
+                            },
+                            "verify": {
+                                "as_addr": "http://192.168.1.254:8080/",
+                                "policy_ids": [
+                                    "default"
+                                ]
+                            }
+                        }
+                    ]
+                }
+                "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        AppType::TcpClient {
+            host: "192.168.1.1",
+            port: 30001,
+            http_proxy: None,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng-testsuite/tests/ingress_netfilter_cgroup.rs
+++ b/tng-testsuite/tests/ingress_netfilter_cgroup.rs
@@ -1,0 +1,336 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, shell::ShellTask, tng::TngInstance, NodeType, Task as _},
+};
+
+/// Test ingress netfilter with capture_cgroup.
+///
+/// Flow:
+/// 1. TngServer with egress netfilter (port 30001)
+/// 2. TngClient with ingress netfilter capture_cgroup = ["/tng_ig_cap_test/"]
+/// 3. ShellTask creates the cgroup, moves itself into it, connects to 192.168.1.1:30001
+/// 4. Ingress netfilter intercepts the connection (cgroup match) and forwards through TNG tunnel
+/// 5. Egress netfilter on server side captures and delivers to TcpServer
+/// 6. TcpServer echoes, ShellTask verifies the response
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ingress_netfilter_cgroup_capture() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": { "port": 30001 }
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_ig_cap_test/"]
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        ShellTask {
+            name: "ingress_cgroup_capture_client".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+                set -e
+                CGROUP=/sys/fs/cgroup/tng_ig_cap_test
+                mkdir -p "$CGROUP"
+                echo $$ > "$CGROUP/cgroup.procs"
+                trap "rmdir $CGROUP 2>/dev/null" EXIT
+                # Connect to server:192.168.1.1:30001, traffic is intercepted by ingress netfilter
+                # (cgroup match) and forwarded through TNG tunnel
+                RESPONSE=$(echo 'hello_ingress_cgroup' | socat - TCP:192.168.1.1:30001)
+                if [ "$RESPONSE" != "hello_ingress_cgroup" ]; then
+                    echo "Expected 'hello_ingress_cgroup', got '$RESPONSE'"
+                    exit 1
+                fi
+                echo "ingress cgroup capture test passed"
+            "#
+            .to_owned(),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Test ingress netfilter with nocapture_cgroup.
+///
+/// Validates two behaviors:
+/// 1. Traffic from capture_cgroup is intercepted by TNG (goes through tunnel)
+/// 2. Traffic from nocapture_cgroup bypasses TNG (direct connection works)
+///
+/// Setup:
+/// - TngServer with egress netfilter (port 30001)
+/// - TngClient with ingress netfilter capture_cgroup + nocapture_cgroup
+/// - Two cgroups created on client node
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ingress_netfilter_cgroup_nocapture() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": { "port": 30001 }
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_ig_nc_capture/"],
+                            "nocapture_cgroup": ["/tng_ig_nc_bypass/"]
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        ShellTask {
+            name: "ingress_cgroup_nocapture_client".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+                set -e
+                CAPTURE_CG=/sys/fs/cgroup/tng_ig_nc_capture
+                BYPASS_CG=/sys/fs/cgroup/tng_ig_nc_bypass
+                mkdir -p "$CAPTURE_CG" "$BYPASS_CG"
+                trap "rmdir $CAPTURE_CG $BYPASS_CG 2>/dev/null" EXIT
+
+                # Test 1: Connect from capture_cgroup → should go through TNG tunnel
+                echo "test_capture" | (
+                    echo $$ > "$CAPTURE_CG/cgroup.procs"
+                    socat - TCP:192.168.1.1:30001
+                ) | grep -q "test_capture"
+                echo "ingress capture path passed"
+
+                # Test 2: Connect from nocapture_cgroup → should bypass TNG
+                # Without TNG tunnel, this direct connection to 192.168.1.1:30001
+                # should fail (the server doesn't listen on that port directly)
+                # But from nocapture_cgroup, it should still go through TNG if no
+                # other rule matches. Since capture_cgroup is set, non-matching
+                # cgroups are NOT captured. So this should fail.
+                if echo "test_bypass" | (
+                    echo $$ > "$BYPASS_CG/cgroup.procs"
+                    timeout 5 socat - TCP:192.168.1.1:30001 2>/dev/null
+                ); then
+                    echo "nocapture test: connection went through (unexpected)"
+                    exit 1
+                else
+                    echo "nocapture test: connection blocked as expected"
+                fi
+
+                echo "ingress nocapture test passed"
+            "#
+            .to_owned(),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Test ingress netfilter with both capture_cgroup and capture_dst.
+/// Traffic is captured only if BOTH:
+/// - The sending process is in capture_cgroup
+/// - The destination matches a capture_dst rule
+///
+/// Flow:
+/// 1. TngServer with egress netfilter (port 30001)
+/// 2. TngClient with ingress netfilter capture_cgroup + capture_dst port 30001
+/// 3. ShellTask creates cgroup, moves into it, connects to 192.168.1.1:30001
+/// 4. Both cgroup and destination match → intercepted → tunnel → success
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ingress_netfilter_cgroup_and_capture_dst() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": { "port": 30001 }
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_ig_combo_test/"],
+                            "capture_dst": [{ "port": 30001 }]
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        ShellTask {
+            name: "ingress_cgroup_combo_client".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+                set -e
+                CGROUP=/sys/fs/cgroup/tng_ig_combo_test
+                mkdir -p "$CGROUP"
+                echo $$ > "$CGROUP/cgroup.procs"
+                trap "rmdir $CGROUP 2>/dev/null" EXIT
+                # Both cgroup and destination port match → captured
+                RESPONSE=$(echo 'hello_combo' | socat - TCP:192.168.1.1:30001)
+                if [ "$RESPONSE" != "hello_combo" ]; then
+                    echo "Expected 'hello_combo', got '$RESPONSE'"
+                    exit 1
+                fi
+                echo "ingress cgroup + capture_dst combo test passed"
+            "#
+            .to_owned(),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Test ingress netfilter with capture_cgroup only (no capture_dst).
+/// When no capture_dst is specified, ALL TCP traffic from the capture_cgroup is captured.
+///
+/// Flow:
+/// 1. TngServer with egress netfilter (port 30001)
+/// 2. TngClient with ingress netfilter capture_cgroup only (no capture_dst)
+/// 3. ShellTask creates cgroup, moves into it, connects to 192.168.1.1:30001
+/// 4. All TCP from cgroup is captured regardless of destination → tunnel → success
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ingress_netfilter_cgroup_only_all_tcp() -> Result<()> {
+    run_test(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": { "port": 30001 }
+                        },
+                        "attest": {
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/tng_ig_alltcp_test/"]
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        AppType::TcpServer { port: 30001 }.boxed(),
+        ShellTask {
+            name: "ingress_cgroup_alltcp_client".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+                set -e
+                CGROUP=/sys/fs/cgroup/tng_ig_alltcp_test
+                mkdir -p "$CGROUP"
+                echo $$ > "$CGROUP/cgroup.procs"
+                trap "rmdir $CGROUP 2>/dev/null" EXIT
+                # No capture_dst means ALL TCP from the cgroup is captured
+                RESPONSE=$(echo 'hello_alltcp' | socat - TCP:192.168.1.1:30001)
+                if [ "$RESPONSE" != "hello_alltcp" ]; then
+                    echo "Expected 'hello_alltcp', got '$RESPONSE'"
+                    exit 1
+                fi
+                echo "ingress cgroup-only all-TCP test passed"
+            "#
+            .to_owned(),
+            stop_test_on_finish: false,
+            run_in_foreground: false,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng-testsuite/tests/ingress_netfilter_cgroup.rs
+++ b/tng-testsuite/tests/ingress_netfilter_cgroup.rs
@@ -15,6 +15,7 @@ use tng_testsuite::{
 /// 5. Egress netfilter on server side captures and delivers to TcpServer
 /// 6. TcpServer echoes, ShellTask verifies the response
 #[serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_ingress_netfilter_cgroup_capture() -> Result<()> {
     run_test(vec![
@@ -94,6 +95,7 @@ async fn test_ingress_netfilter_cgroup_capture() -> Result<()> {
 /// - TngClient with ingress netfilter capture_cgroup + nocapture_cgroup
 /// - Two cgroups created on client node
 #[serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_ingress_netfilter_cgroup_nocapture() -> Result<()> {
     run_test(vec![
@@ -191,6 +193,7 @@ async fn test_ingress_netfilter_cgroup_nocapture() -> Result<()> {
 /// 3. ShellTask creates cgroup, moves into it, connects to 192.168.1.1:30001
 /// 4. Both cgroup and destination match → intercepted → tunnel → success
 #[serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_ingress_netfilter_cgroup_and_capture_dst() -> Result<()> {
     run_test(vec![
@@ -268,6 +271,7 @@ async fn test_ingress_netfilter_cgroup_and_capture_dst() -> Result<()> {
 /// 3. ShellTask creates cgroup, moves into it, connects to 192.168.1.1:30001
 /// 4. All TCP from cgroup is captured regardless of destination → tunnel → success
 #[serial]
+#[ignore = "requires cgroup v2 with xt_cgroup iptables module, not available in CI containers"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_ingress_netfilter_cgroup_only_all_tcp() -> Result<()> {
     run_test(vec![

--- a/tng/src/config/ingress.rs
+++ b/tng/src/config/ingress.rs
@@ -419,4 +419,68 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_deserialize_ingress_netfilter_backward_compat() -> Result<()> {
+        // Old single-object format (backward compatibility via OneOrMany)
+        test_deserialize_netfilter_common(json!(
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": {
+                                "port": 9991
+                            }
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+        ))?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_ingress_netfilter_cgroup() -> Result<()> {
+        // cgroup-based capture
+        test_deserialize_netfilter_common(json!(
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {
+                            "capture_cgroup": ["/system.slice/vllm.service"],
+                            "nocapture_cgroup": ["/system.slice/ssh.service"]
+                        },
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+        ))?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_ingress_netfilter_capture_all() -> Result<()> {
+        // Empty capture_dst = capture all TCP traffic
+        test_deserialize_netfilter_common(json!(
+            {
+                "add_ingress": [
+                    {
+                        "netfilter": {},
+                        "verify": {
+                            "as_addr": "http://192.168.1.254:8080/",
+                            "policy_ids": ["default"]
+                        }
+                    }
+                ]
+            }
+        ))?;
+        Ok(())
+    }
 }

--- a/tng/src/tunnel/utils/iptables.rs
+++ b/tng/src/tunnel/utils/iptables.rs
@@ -100,6 +100,24 @@ impl IptablesExecutor {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::format_dport;
+
+    #[test]
+    fn test_format_dport_single_port() {
+        assert_eq!(format_dport(80, None), "80");
+        assert_eq!(format_dport(30001, None), "30001");
+    }
+
+    #[test]
+    fn test_format_dport_port_range() {
+        assert_eq!(format_dport(30000, Some(&30031)), "30000:30031");
+        assert_eq!(format_dport(80, Some(&80)), "80:80");
+        assert_eq!(format_dport(1, Some(&65535)), "1:65535");
+    }
+}
+
 impl Drop for IptablesGuard {
     fn drop(&mut self) {
         tokio::task::block_in_place(|| {

--- a/tng/src/tunnel/utils/iptables.rs
+++ b/tng/src/tunnel/utils/iptables.rs
@@ -100,6 +100,23 @@ impl IptablesExecutor {
     }
 }
 
+impl Drop for IptablesGuard {
+    fn drop(&mut self) {
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(
+                async {
+                    if let Err(e) =
+                        IptablesExecutor::execute_script(&self.iptables_revoke_script).await
+                    {
+                        tracing::error!("Failed to clean up iptables rules: {e:#}");
+                    }
+                }
+                .instrument(self.span.clone()),
+            );
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::format_dport;
@@ -115,22 +132,5 @@ mod tests {
         assert_eq!(format_dport(30000, Some(&30031)), "30000:30031");
         assert_eq!(format_dport(80, Some(&80)), "80:80");
         assert_eq!(format_dport(1, Some(&65535)), "1:65535");
-    }
-}
-
-impl Drop for IptablesGuard {
-    fn drop(&mut self) {
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(
-                async {
-                    if let Err(e) =
-                        IptablesExecutor::execute_script(&self.iptables_revoke_script).await
-                    {
-                        tracing::error!("Failed to clean up iptables rules: {e:#}");
-                    }
-                }
-                .instrument(self.span.clone()),
-            );
-        })
     }
 }


### PR DESCRIPTION
## Summary
- Add cgroup integration tests for both egress and ingress netfilter (`capture_cgroup` / `nocapture_cgroup` scenarios)
- Add port range (`port_end`) integration tests for egress and ingress netfilter
- Add unit tests for `format_dport` utility function
- Add missing ingress netfilter deserialization unit tests (backward_compat, cgroup, capture_all) matching egress coverage
- Add `ingress_netfilter_capture` integration tests (port_only, host_and_port, port_range, ipset_and_port)

## Test plan
- [x] `cargo fmt --check` passes
- [x] All new unit tests pass (`format_dport`, ingress deserialization)
- [x] Integration tests compile and follow existing patterns

Integration tests require cgroup v2 environment with AA/AS services:
```bash
cargo test --test egress_netfilter_cgroup --test egress_netfilter_port_range   --test ingress_netfilter_cgroup --test ingress_netfilter_capture -- --test-threads=1
```