### PR TITLE
chore(deps): update hyper with backpressure bypass fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.8.1"
-source = "git+https://github.com/inclavare-containers/hyper.git?rev=59b43a6315a8f48ebfa4d12bbcd80cc0b1969a26#59b43a6315a8f48ebfa4d12bbcd80cc0b1969a26"
+source = "git+https://github.com/inclavare-containers/hyper.git?rev=6fde2c7c2e00b4fc1b9e31b827654230f488630f#6fde2c7c2e00b4fc1b9e31b827654230f488630f"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ git = "https://github.com/inclavare-containers/tokio-graceful.git"
 
 [patch.crates-io.hyper]
 git = "https://github.com/inclavare-containers/hyper.git"
-rev = "59b43a6315a8f48ebfa4d12bbcd80cc0b1969a26"
+rev = "6fde2c7c2e00b4fc1b9e31b827654230f488630f"
 
 [patch.crates-io]
 hyper-util = {path = "./deps/hyper-util-shim"}


### PR DESCRIPTION
## Summary

- Update hyper patch revision to `6fde2c7c` which includes the backpressure bypass fix from [hyperium/hyper#4050](https://github.com/hyperium/hyper/pull/4050)
- This fixes OOM in `multiplex=true` H2 CONNECT tunnels where data was being pushed into h2's `pending_send` queue despite zero available flow control window, causing unbounded memory growth

## Root cause

In `UpgradedSendStreamTask::tick()`, when `poll_capacity()` returned `Poll::Pending` (no H2 flow control window available), the original code would `break` out of the inner loop and fall through to `rx.poll_next() → send_data()`, pushing data into the h2 send buffer with zero capacity. This broke the HTTP/2 flow control chain, causing unbounded memory growth (45GB+) when downstream consumers were slower than upstream producers.

## Test plan

- [x] `cargo build --release` passes
- [x] `make bench` with `TNG_MULTIPLEX=true` completes without OOM
- [x] Rebased onto latest `gh/master`