### PR TITLE
feat(tng): add StatusProvider trait and unified /status/ REST API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ When creating or amending commits:
 - **Never** include any Claude session URLs, session IDs, or links to claude.ai in commit messages or PR descriptions. Commit messages should only describe the code changes.
 - **Never** include "🤖 Generated with [Claude Code](https://claude.com/claude-code)" or similar AI attribution footers in PR descriptions or commit messages.
 - **Always** use `--no-gpg-sign` to avoid GPG signing.
-- **Never commit plan or spec files** (e.g. `docs/*-plan.md`, `docs/*-design.md`, `docs/*-spec.md`). These should be gitignored and kept local only.
+- **Never commit plan or spec files** (e.g. `docs/*-plan.md`, `docs/*-design.md`, `docs/*-spec.md`, or anything under `docs/superpowers/`). These should be gitignored (already covered by `.gitignore`) and kept local only.
+- **Never commit any file that is already gitignored** — if a file matches `.gitignore`, it is intentionally local-only.
 
 ## PR Requirements
 
@@ -105,3 +106,27 @@ git filter-branch -f --msg-filter 'sed "/Co-Authored-By:/d"' --env-filter '
   fi
 ' <base-commit>..HEAD
 ```
+
+
+## API Compatibility
+
+When designing public APIs (REST endpoints, config fields, trait methods, public structs/traits), always design the full namespace structure upfront — do not defer naming decisions. Retrofitting a namespace layer later (e.g. inserting `/ohttp/` into an existing path like `/status/egress/<id>/keys` → `/status/egress/<id>/ohttp/keys`) breaks backward compatibility and is extremely costly. If a category of resources might grow multiple sub-resources in the future, include that category's namespace from day one.
+
+When a change breaks backward compatibility:
+1. **Update `docs/version_compatibility.md` and `docs/version_compatibility_zh.md`** — add a new row to the compatibility table describing the breaking change and the version it was introduced.
+2. **Do not silently remove or rename existing endpoints, config fields, or public struct fields** — either keep the old path working (with deprecation warnings) or ensure the version compatibility doc reflects the break.
+3. **Consider additive-only changes first** — new endpoints alongside old ones, optional fields alongside required ones, new trait methods with default implementations.
+
+
+## Error Handling
+
+- **Never** discard error context by formatting errors into strings (e.g., `anyhow::anyhow!("[{}] {}", source, e)` or `format!("{}", e)`).
+- Use `anyhow::Context::context()` or `anyhow::Context::with_context()` to attach labels while preserving the original error in the chain:
+  ```rust
+  // Good — original error is preserved via source()
+  .map_err(|e| anyhow::Error::from(e).context("source label"))
+
+  // Bad — original error type is lost, only Display string remains
+  .map_err(|e| anyhow::anyhow!("[source] {}", e))
+  ```
+- When wrapping `io::Error` into `io::Error::other(anyhow::Error)`, convert with `anyhow::Error::from(e)` and use `.context()` for the label.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7686,6 +7686,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "httparse",
+ "humantime-serde",
  "hyper 1.8.1",
  "hyper-util 0.1.7",
  "indexmap 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ getrandom = "0.3"
 gloo = {version = "0.11.0"}
 h2 = {version = "0.4.10", features = ["stream"]}
 hex = "0.4.3"
+humantime-serde = "1.1.1"
 hpke = "0.13.0"
 http = "1.3.1"
 http-body = "1.0.1"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1497,6 +1497,12 @@ Generate using `openssl genpkey -algorithm X25519 -outform PEM`. TNG uses inotif
 |---|---|
 | `/livez` | Liveness check; returns `200 OK` indicating the instance is running |
 | `/readyz` | Readiness check; returns `200 OK` indicating the instance can handle traffic |
+| `/status/` | Returns a list of available component types (e.g., `["egress", "ingress"]`) |
+| `/status/egress/` | Returns a list of egress instance IDs |
+| `/status/egress/{id}/` | Returns a list of resources for the specified egress |
+| `/status/egress/{id}/ohttp/keys` | Returns the OHTTP key status snapshot for the specified egress |
+| `/status/ingress/` | Returns a list of ingress instance IDs |
+| `/status/ingress/{id}/ohttp/keys` | Returns the ingress OHTTP client cache state |
 
 ---
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -1509,6 +1509,12 @@ MC4CAQAwBQYDK2VuBCIEILi5PepL11X3ptJneUQu40m2kiuNeLD9MRK4CYh94t1d
 |---|---|
 | `/livez` | 存活检查，返回 `200 OK` 表示实例正在运行 |
 | `/readyz` | 就绪检查，返回 `200 OK` 表示实例可以处理流量 |
+| `/status/` | 返回可用组件类型列表（如 `["egress", "ingress"]`） |
+| `/status/egress/` | 返回 egress 实例 ID 列表 |
+| `/status/egress/{id}/` | 返回指定 egress 的资源列表 |
+| `/status/egress/{id}/ohttp/keys` | 返回 egress 的 OHTTP 密钥状态快照 |
+| `/status/ingress/` | 返回 ingress 实例 ID 列表 |
+| `/status/ingress/{id}/ohttp/keys` | 返回 ingress OHTTP 客户端缓存状态 |
 
 ---
 

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -30,6 +30,7 @@ futures = {workspace = true}
 getrandom = {workspace = true}
 h2 = {workspace = true}
 hex = {workspace = true}
+humantime-serde = {workspace = true}
 hpke = {workspace = true}
 http = {workspace = true}
 http-body = {workspace = true}

--- a/tng/src/control_interface/restful.rs
+++ b/tng/src/control_interface/restful.rs
@@ -1,10 +1,13 @@
 use std::{convert::Infallible, sync::Arc};
 
 use anyhow::Result;
-use axum::{routing::get, Router};
+use axum::{extract::Path, routing::get, Json, Router};
 use http::{HeaderValue, StatusCode};
 use tower::ServiceBuilder;
 
+use crate::error::TngError;
+use crate::state::TngState;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::{config::control_interface::RestfulArgs, HTTP_RESPONSE_SERVER_HEADER};
 
 use super::ControlInterfaceCore;
@@ -21,34 +24,53 @@ impl RestfulControlInterface {
 
     pub async fn serve(&self) -> Result<()> {
         // build our application with a route
-        let app = Router::new()
-            .route(
-                "/livez",
-                get({
-                    let core = self.core.clone();
-                    move || async move {
-                        if core.livez().await {
-                            (StatusCode::OK, "ok")
-                        } else {
-                            (StatusCode::SERVICE_UNAVAILABLE, "not ok")
+        let app =
+            Router::new()
+                .route(
+                    "/livez",
+                    get({
+                        let core = self.core.clone();
+                        move || async move {
+                            if core.livez().await {
+                                (StatusCode::OK, "ok")
+                            } else {
+                                (StatusCode::SERVICE_UNAVAILABLE, "not ok")
+                            }
                         }
-                    }
-                }),
-            )
-            .route(
-                "/readyz",
-                get({
-                    let core = self.core.clone();
-                    move || async move {
-                        if core.readyz().await {
-                            (StatusCode::OK, "ok")
-                        } else {
-                            (StatusCode::SERVICE_UNAVAILABLE, "not ok")
+                    }),
+                )
+                .route(
+                    "/readyz",
+                    get({
+                        let core = self.core.clone();
+                        move || async move {
+                            if core.readyz().await {
+                                (StatusCode::OK, "ok")
+                            } else {
+                                (StatusCode::SERVICE_UNAVAILABLE, "not ok")
+                            }
                         }
-                    }
-                }),
-            )
-            .layer(ServiceBuilder::new().layer(axum::middleware::from_fn(add_server_header)));
+                    }),
+                )
+                .route(
+                    "/status/",
+                    get({
+                        let core = self.core.clone();
+                        move || async move {
+                            status_response(Arc::clone(&core.state), String::new()).await
+                        }
+                    }),
+                )
+                .route(
+                    "/status/{*path}",
+                    get({
+                        let core = self.core.clone();
+                        move |Path(path): Path<String>| async move {
+                            status_response(Arc::clone(&core.state), path).await
+                        }
+                    }),
+                )
+                .layer(ServiceBuilder::new().layer(axum::middleware::from_fn(add_server_header)));
 
         let addr = (
             self.args.address.host.as_deref().unwrap_or("0.0.0.0"),
@@ -80,9 +102,36 @@ async fn add_server_header(
     Ok(res)
 }
 
+async fn status_response(
+    state: Arc<TngState>,
+    raw_path: String,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let path: Vec<&str> = raw_path.split('/').filter(|s| !s.is_empty()).collect();
+    let result = state.query_status(&path).await;
+    match result {
+        Ok(StatusQueryResult::Subtree(children)) => (
+            StatusCode::OK,
+            Json(serde_json::Value::Array(
+                children
+                    .into_iter()
+                    .map(|c| serde_json::Value::String(c.into_owned()))
+                    .collect(),
+            )),
+        ),
+        Ok(StatusQueryResult::Value(v)) => (StatusCode::OK, Json(v)),
+        Err(TngError::StatusPathNotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not found"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-
     use crate::{config::TngConfig, runtime::TngRuntime};
     use scopeguard::defer;
     use serde_json::json;
@@ -173,6 +222,118 @@ mod tests {
             }
             _ = join_handle => {}
         }
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_status_endpoints() -> Result<()> {
+        let port = portpicker::pick_unused_port().unwrap();
+        let egress_port = portpicker::pick_unused_port().unwrap();
+
+        let config: TngConfig = serde_json::from_value(json!(
+            {
+                "control_interface": {
+                    "restful": {
+                        "host": "127.0.0.1",
+                        "port": port
+                    }
+                },
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": { "port": portpicker::pick_unused_port().unwrap() },
+                            "out": {
+                                "host": "127.0.0.1",
+                                "port": portpicker::pick_unused_port().unwrap()
+                            }
+                        },
+                        "no_ra": true
+                    }
+                ],
+                "add_egress": [
+                    {
+                        "mapping": {
+                            "in": { "host": "127.0.0.1", "port": egress_port },
+                            "out": { "host": "127.0.0.1", "port": portpicker::pick_unused_port().unwrap() }
+                        },
+                        "decap_from_http": {},
+                        "no_ra": true
+                    }
+                ]
+            }
+        ))?;
+
+        let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
+
+        let tng_runtime = TngRuntime::from_config(config).await?;
+        let canceller = tng_runtime.canceller();
+
+        #[allow(clippy::disallowed_methods)]
+        let join_handle =
+            tokio::task::spawn(async move { tng_runtime.serve_with_ready(ready_sender).await });
+
+        ready_receiver.await?;
+
+        // /status/ should return ["egress", "ingress"]
+        {
+            let resp = reqwest::ClientBuilder::new()
+                .no_proxy()
+                .build()?
+                .get(format!("http://127.0.0.1:{port}/status/"))
+                .send()
+                .await?;
+            assert!(resp.status() == StatusCode::OK, "got {}", resp.status());
+            let body: Vec<String> = resp.json().await?;
+            assert_eq!(body, vec!["egress", "ingress"]);
+        }
+
+        // /status/egress/ should return [0]
+        {
+            let resp = reqwest::ClientBuilder::new()
+                .no_proxy()
+                .build()?
+                .get(format!("http://127.0.0.1:{port}/status/egress/"))
+                .send()
+                .await?;
+            assert!(resp.status() == StatusCode::OK, "got {}", resp.status());
+            let body: Vec<String> = resp.json().await?;
+            assert_eq!(body, vec!["0"]);
+        }
+
+        // /status/egress/0/ohttp/keys should return KeyStatusSnapshot
+        {
+            let resp = reqwest::ClientBuilder::new()
+                .no_proxy()
+                .build()?
+                .get(format!(
+                    "http://127.0.0.1:{port}/status/egress/0/ohttp/keys"
+                ))
+                .send()
+                .await?;
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            assert!(status == StatusCode::OK, "got {status}: {body_text}");
+            let body: serde_json::Value = serde_json::from_str(&body_text).unwrap_or_default();
+            assert_eq!(body["key_manager_type"], "self_generated");
+            assert!(body["local_keys"].is_array());
+        }
+
+        // /status/egress/999/ohttp/keys should return 404
+        {
+            let resp = reqwest::ClientBuilder::new()
+                .no_proxy()
+                .build()?
+                .get(format!(
+                    "http://127.0.0.1:{port}/status/egress/999/ohttp/keys"
+                ))
+                .send()
+                .await?;
+            assert!(resp.status() == StatusCode::NOT_FOUND);
+        }
+
+        canceller.cancel();
+        let _ = join_handle.await;
 
         Ok(())
     }

--- a/tng/src/error.rs
+++ b/tng/src/error.rs
@@ -144,7 +144,7 @@ pub enum TngError {
     #[error("Failed to watch file {0}")]
     WatchFileFailed(PathBuf, #[source] anyhow::Error),
 
-    #[error("bad expire timestamp: {0}")]
+    #[error("bad expire timestamp")]
     BadExpireTimeStamp(#[source] anyhow::Error),
 
     #[error("Failed to decode TngToken from wire format")]
@@ -158,6 +158,9 @@ pub enum TngError {
 
     #[error("Failed to verify attestation evidence")]
     EvidenceVerifyError(#[source] rats_cert::errors::Error),
+
+    #[error("Status path not found")]
+    StatusPathNotFound,
 }
 
 /// Error response structure
@@ -235,6 +238,7 @@ impl IntoResponse for TngError {
             | TngError::LoadPrivateKeyFailed(..) => StatusCode::INTERNAL_SERVER_ERROR,
             TngError::InvalidParameter(..) => StatusCode::INTERNAL_SERVER_ERROR,
             TngError::WatchFileFailed(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            TngError::StatusPathNotFound => StatusCode::NOT_FOUND,
             #[cfg(feature = "__egress-common")]
             TngError::SerfCrateError(..) => StatusCode::INTERNAL_SERVER_ERROR,
             TngError::KeyUpdateMessageEncodeError(..)

--- a/tng/src/lib.rs
+++ b/tng/src/lib.rs
@@ -15,6 +15,8 @@ pub mod runtime;
 mod service;
 #[cfg(not(wasm))]
 mod state;
+#[cfg(not(wasm))]
+pub(crate) mod status;
 pub mod tunnel;
 
 shadow!(build);

--- a/tng/src/runtime.rs
+++ b/tng/src/runtime.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::observability::metric::simple_exporter::noop::NoopMeterProvider;
 use crate::service::RegistedService;
-use crate::state::TngState;
+use crate::state::{EgressStatusHandle, IngressStatusHandle, TngState};
 use crate::tunnel::egress::flow::EgressFlow;
 use crate::tunnel::egress::mapping::MappingEgress;
 use crate::tunnel::ingress::flow::IngressFlow;
@@ -99,88 +99,89 @@ impl TngRuntime {
 
         // Create all ingress and egress.
         let mut services: Vec<(Box<dyn RegistedService + Send + Sync>, Span)> = vec![];
+        let mut state = TngState::new();
 
         for (id, add_ingress) in tng_config.add_ingress.iter().enumerate() {
             let add_ingress = add_ingress.clone();
             let span = tracing::info_span!("ingress", id);
 
-            let sevice = async {
-                Ok::<Box<_>, anyhow::Error>(match &add_ingress.ingress_mode {
+            let service = async {
+                let flow = match &add_ingress.ingress_mode {
                     IngressMode::Mapping(mapping_args) => {
-                        Box::new(
-                            IngressFlow::new(
-                                MappingIngress::new(id, mapping_args).await?,
-                                &add_ingress.common,
-                                &service_metrics_creator,
-                                runtime.clone(),
-                            )
-                            .await?,
+                        IngressFlow::new(
+                            MappingIngress::new(id, mapping_args).await?,
+                            &add_ingress.common,
+                            &service_metrics_creator,
+                            runtime.clone(),
                         )
+                        .await?
                     }
                     IngressMode::HttpProxy(http_proxy_args) => {
-                        Box::new(
-                            IngressFlow::new(
-                                HttpProxyIngress::new(id, http_proxy_args).await?,
-                                &add_ingress.common,
-                                &service_metrics_creator,
-                                runtime.clone(),
-                            )
-                            .await?,
+                        IngressFlow::new(
+                            HttpProxyIngress::new(id, http_proxy_args).await?,
+                            &add_ingress.common,
+                            &service_metrics_creator,
+                            runtime.clone(),
                         )
+                        .await?
                     }
                     IngressMode::Netfilter(netfilter_args) => {
                         #[cfg(not(target_os = "linux"))]
                         {
                             let _ = netfilter_args;
-                            anyhow::bail!("Using egress with 'netfilter' type is not supported on OS other than Linux");
+                            anyhow::bail!("Using ingress with 'netfilter' type is not supported on OS other than Linux");
                         }
 
                         #[cfg(target_os = "linux")]
                         {
                             use crate::tunnel::ingress::netfilter::NetfilterIngress;
-                            Box::new(
-                                IngressFlow::new(
-                                    NetfilterIngress::new(id, netfilter_args).await?,
-                                    &add_ingress.common,
-                                    &service_metrics_creator,
-                                    runtime.clone(),
-                                )
-                                .await?,
-                            )
-                        }
-                    }
-                    IngressMode::Socks5(socks5_args) => {
-                        Box::new(
                             IngressFlow::new(
-                                Socks5Ingress::new(id, socks5_args).await?,
+                                NetfilterIngress::new(id, netfilter_args).await?,
                                 &add_ingress.common,
                                 &service_metrics_creator,
                                 runtime.clone(),
                             )
-                            .await?,
-                        )
+                            .await?
+                        }
                     }
-                })
+                    IngressMode::Socks5(socks5_args) => {
+                        IngressFlow::new(
+                            Socks5Ingress::new(id, socks5_args).await?,
+                            &add_ingress.common,
+                            &service_metrics_creator,
+                            runtime.clone(),
+                        )
+                        .await?
+                    }
+                };
+                Ok::<IngressFlow, anyhow::Error>(flow)
             }.instrument(span.clone()).await?;
 
-            services.push((sevice, span));
+            let flow = Arc::new(service);
+            state.add_ingress(IngressStatusHandle {
+                flow: Arc::downgrade(&flow),
+            });
+            services.push((
+                Box::new(flow) as Box<dyn RegistedService + Send + Sync>,
+                span,
+            ));
         }
 
         for (id, add_egress) in tng_config.add_egress.iter().enumerate() {
             let add_egress = add_egress.clone();
             let span = tracing::info_span!("egress", id);
 
-            let sevice = async {
-                Ok::<Box<_>, anyhow::Error>(match &add_egress.egress_mode {
-                    EgressMode::Mapping(mapping_args) => Box::new(
+            let service = async {
+                let flow = match &add_egress.egress_mode {
+                    EgressMode::Mapping(mapping_args) => {
                         EgressFlow::new(
                             MappingEgress::new(id, mapping_args).await?,
                             &add_egress.common,
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?,
-                    ),
+                        .await?
+                    }
                     EgressMode::Netfilter(netfilter_args) => {
                         #[cfg(not(target_os = "linux"))]
                         {
@@ -191,24 +192,30 @@ impl TngRuntime {
                         #[cfg(target_os = "linux")]
                         {
                             use crate::tunnel::egress::netfilter::NetfilterEgress;
-                            Box::new(
-                                EgressFlow::new(
-                                    NetfilterEgress::new(id, netfilter_args).await?,
-                                    &add_egress.common,
-                                    &service_metrics_creator,
-                                    runtime.clone(),
-                                )
-                                .await?,
+                            EgressFlow::new(
+                                NetfilterEgress::new(id, netfilter_args).await?,
+                                &add_egress.common,
+                                &service_metrics_creator,
+                                runtime.clone(),
                             )
+                            .await?
                         }
                     }
-                })
+                };
+                Ok::<EgressFlow, anyhow::Error>(flow)
             }.instrument(span.clone()).await?;
 
-            services.push((sevice, span));
+            let flow = Arc::new(service);
+            state.add_egress(EgressStatusHandle {
+                flow: Arc::downgrade(&flow),
+            });
+            services.push((
+                Box::new(flow) as Box<dyn RegistedService + Send + Sync>,
+                span,
+            ));
         }
 
-        let state = Arc::new(TngState::new());
+        let state = Arc::new(state);
 
         // Launch Control Interface
         if let Some(args) = tng_config.control_interface {

--- a/tng/src/state.rs
+++ b/tng/src/state.rs
@@ -1,8 +1,51 @@
+use std::borrow::Cow;
+use std::sync::Weak;
+
+use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
+use crate::tunnel::egress::flow::EgressFlow;
+use crate::tunnel::ingress::flow::IngressFlow;
+use async_trait::async_trait;
+
+/// Lightweight handle for querying an egress's status tree.
+pub struct EgressStatusHandle {
+    pub flow: Weak<EgressFlow>,
+}
+
+#[async_trait]
+impl StatusProvider for EgressStatusHandle {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        if let Some(flow) = self.flow.upgrade() {
+            flow.query_status(path).await
+        } else {
+            Err(TngError::StatusPathNotFound)
+        }
+    }
+}
+
+/// Lightweight handle for querying an ingress's status tree.
+pub struct IngressStatusHandle {
+    pub flow: Weak<IngressFlow>,
+}
+
+#[async_trait]
+impl StatusProvider for IngressStatusHandle {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        if let Some(flow) = self.flow.upgrade() {
+            flow.query_status(path).await
+        } else {
+            Err(TngError::StatusPathNotFound)
+        }
+    }
+}
+
 pub struct TngState {
     pub ready: (
         tokio::sync::watch::Sender<bool>,
         tokio::sync::watch::Receiver<bool>,
     ),
+    pub egresses: Vec<EgressStatusHandle>,
+    pub ingresses: Vec<IngressStatusHandle>,
 }
 
 impl Default for TngState {
@@ -15,6 +58,79 @@ impl TngState {
     pub fn new() -> Self {
         TngState {
             ready: tokio::sync::watch::channel(false),
+            egresses: Vec::new(),
+            ingresses: Vec::new(),
         }
+    }
+
+    pub fn add_egress(&mut self, handle: EgressStatusHandle) {
+        self.egresses.push(handle);
+    }
+
+    pub fn add_ingress(&mut self, handle: IngressStatusHandle) {
+        self.ingresses.push(handle);
+    }
+}
+
+#[async_trait]
+impl StatusProvider for TngState {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => {
+                let mut children = Vec::new();
+                if !self.egresses.is_empty() {
+                    children.push(Cow::Borrowed("egress"));
+                }
+                if !self.ingresses.is_empty() {
+                    children.push(Cow::Borrowed("ingress"));
+                }
+                Ok(StatusQueryResult::Subtree(children))
+            }
+            ["egress"] => Ok(StatusQueryResult::Subtree(
+                (0..self.egresses.len())
+                    .map(|i| Cow::Owned(i.to_string()))
+                    .collect(),
+            )),
+            ["egress", id, rest @ ..] => {
+                if let Ok(id) = id.parse::<usize>() {
+                    if let Some(handle) = self.egresses.get(id) {
+                        handle.query_status(rest).await
+                    } else {
+                        Err(TngError::StatusPathNotFound)
+                    }
+                } else {
+                    Err(TngError::StatusPathNotFound)
+                }
+            }
+            ["ingress"] => Ok(StatusQueryResult::Subtree(
+                (0..self.ingresses.len())
+                    .map(|i| Cow::Owned(i.to_string()))
+                    .collect(),
+            )),
+            ["ingress", id, rest @ ..] => {
+                if let Ok(id) = id.parse::<usize>() {
+                    if let Some(handle) = self.ingresses.get(id) {
+                        handle.query_status(rest).await
+                    } else {
+                        Err(TngError::StatusPathNotFound)
+                    }
+                } else {
+                    Err(TngError::StatusPathNotFound)
+                }
+            }
+            _ => Err(TngError::StatusPathNotFound),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_query_status_empty() {
+        let state = TngState::new();
+        let result = state.query_status(&[]).await;
+        assert!(matches!(result, Ok(StatusQueryResult::Subtree(ref v)) if v.is_empty()));
     }
 }

--- a/tng/src/status.rs
+++ b/tng/src/status.rs
@@ -1,0 +1,24 @@
+use std::borrow::Cow;
+
+use crate::error::TngError;
+use async_trait::async_trait;
+
+/// Result of a status query at a tree node.
+pub enum StatusQueryResult {
+    /// Reached an intermediate node — return child segment names.
+    Subtree(Vec<Cow<'static, str>>),
+    /// Reached a leaf node — return serialised value.
+    Value(serde_json::Value),
+}
+
+/// Trait for nodes in the status tree. Each node can either delegate
+/// to a child (matching a path segment) or return a leaf value.
+#[async_trait]
+pub trait StatusProvider: Send + Sync {
+    /// Walk the remaining path segments.
+    ///
+    /// - Empty iterator → list child segments (`Subtree`)
+    /// - Matching segment → delegate to child or return leaf (`Value`)
+    /// - No match → `StatusPathNotFound`
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError>;
+}

--- a/tng/src/tunnel/attestation_result.rs
+++ b/tng/src/tunnel/attestation_result.rs
@@ -37,4 +37,9 @@ impl AttestationResult {
             token: Arc::new(token),
         }
     }
+
+    /// Return the raw JWT token string.
+    pub fn token_str(&self) -> &str {
+        self.token.as_str()
+    }
 }

--- a/tng/src/tunnel/egress/flow.rs
+++ b/tng/src/tunnel/egress/flow.rs
@@ -11,6 +11,8 @@ use indexmap::IndexMap;
 use tokio::sync::mpsc::Sender;
 
 use crate::config::egress::CommonArgs;
+use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::access_log::{AccessLog, EgressMode};
 use crate::tunnel::service_metrics::ServiceMetrics;
 use crate::tunnel::service_metrics::ServiceMetricsCreator;
@@ -108,6 +110,13 @@ impl RegistedService for EgressFlow {
         }
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl RegistedService for Arc<EgressFlow> {
+    async fn serve(&self, ready: Sender<()>) -> Result<()> {
+        (**self).serve(ready).await
     }
 }
 
@@ -212,5 +221,12 @@ impl EgressFlow {
                 });
             }
         });
+    }
+}
+
+#[async_trait]
+impl StatusProvider for EgressFlow {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        self.trusted_stream_manager.query_status(path).await
     }
 }

--- a/tng/src/tunnel/egress/mod.rs
+++ b/tng/src/tunnel/egress/mod.rs
@@ -1,7 +1,7 @@
-mod protocol;
-pub(super) mod stream_manager;
+pub(crate) mod protocol;
+pub mod stream_manager;
 
-pub mod flow;
+pub(crate) mod flow;
 #[cfg(feature = "egress-mapping")]
 pub mod mapping;
 #[cfg(all(feature = "egress-netfilter", target_os = "linux"))]

--- a/tng/src/tunnel/egress/protocol/ohttp/mod.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::{
     config::egress::OHttpArgs,
     tunnel::{
@@ -61,5 +62,15 @@ impl ProtocolStreamDecoder for OHttpStreamDecoder {
             }
         }
         .boxed())
+    }
+}
+
+#[async_trait]
+impl StatusProvider for OHttpStreamDecoder {
+    async fn query_status(
+        &self,
+        path: &[&str],
+    ) -> Result<StatusQueryResult, crate::error::TngError> {
+        self.security_layer.query_status(path).await
     }
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/api/mod.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/api/mod.rs
@@ -5,11 +5,13 @@ pub mod tunnel;
 use std::sync::Arc;
 
 use anyhow::Result;
+use async_trait::async_trait;
 #[cfg(unix)]
 use tokio::sync::RwLock;
 
 use crate::config::egress::KeyArgs;
 use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::egress::protocol::ohttp::security::key_manager::file::FileBasedKeyManager;
 use crate::tunnel::egress::protocol::ohttp::security::key_manager::peer_shared::PeerSharedKeyManager;
 use crate::tunnel::egress::protocol::ohttp::security::key_manager::{
@@ -80,5 +82,12 @@ impl OhttpServerApi {
             #[cfg(unix)]
             passport_cache: Arc::new(RwLock::new(None)),
         })
+    }
+}
+
+#[async_trait]
+impl StatusProvider for OhttpServerApi {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        self.key_manager.query_status(path).await
     }
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/file.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/file.rs
@@ -1,20 +1,44 @@
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
+    time::SystemTime,
 };
 
 use async_trait::async_trait;
+use serde::Serialize;
 use tokio::sync::RwLock;
 
+use crate::status::{StatusProvider, StatusQueryResult};
+use crate::tunnel::egress::protocol::ohttp::security::key_manager::{
+    KeyInfo, KeyManager, KeyStatus,
+};
+use crate::tunnel::ohttp::key_config::{KeyConfigExtend, PublicKeyData};
 use crate::{
     error::TngError,
-    tunnel::{
-        egress::protocol::ohttp::security::key_manager::{KeyInfo, KeyManager},
-        ohttp::key_config::{KeyConfigExtend, PublicKeyData},
-        utils::{file_watcher::FileWatcher, runtime::supervised_task::SupervisedTaskResult},
-    },
+    tunnel::utils::{file_watcher::FileWatcher, runtime::supervised_task::SupervisedTaskResult},
     TokioRuntime,
 };
+
+/// Snapshot of the file-based key manager status for the status API.
+#[derive(Serialize)]
+struct FileKeyStatus<'a> {
+    key_manager_type: &'static str,
+    key: FileKeyValue<'a>,
+}
+
+/// Single key entry in the file-based status snapshot.
+#[derive(Serialize)]
+struct FileKeyValue<'a> {
+    key_id: u8,
+    public_key: &'a PublicKeyData,
+    status: KeyStatus,
+    #[serde(with = "humantime_serde")]
+    actived_at: SystemTime,
+    #[serde(with = "humantime_serde")]
+    stale_at: SystemTime,
+    #[serde(with = "humantime_serde")]
+    expire_at: SystemTime,
+}
 
 /// A key manager that loads an HPKE private key from a PEM file and monitors the file for changes.
 ///
@@ -161,6 +185,41 @@ impl KeyManager for FileBasedKeyManager {
     async fn get_client_visible_key(&self) -> Result<KeyInfo, TngError> {
         let key = self.inner.key.read().await;
         Ok(key.1.clone())
+    }
+
+    fn key_manager_type(&self) -> &'static str {
+        "file"
+    }
+}
+
+#[async_trait]
+impl StatusProvider for FileBasedKeyManager {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => Ok(StatusQueryResult::Subtree(vec!["keys".into()])),
+            ["keys"] => {
+                let key = self.inner.key.read().await;
+                let (public_key, info) = &*key;
+                let status = FileKeyStatus {
+                    key_manager_type: "file",
+                    key: FileKeyValue {
+                        key_id: info.key_config.key_id(),
+                        public_key,
+                        status: info.status,
+                        actived_at: info.actived_at,
+                        stale_at: info.stale_at,
+                        expire_at: info.expire_at,
+                    },
+                };
+                serde_json::to_value(&status)
+                    .map(StatusQueryResult::Value)
+                    .map_err(|e| {
+                        tracing::error!(?e, "Failed to serialise key status");
+                        TngError::StatusPathNotFound
+                    })
+            }
+            _ => Err(TngError::StatusPathNotFound),
+        }
     }
 }
 

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/mod.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/mod.rs
@@ -1,8 +1,11 @@
 //! Key management for OHTTP servers
 //!
 //! This module provides abstractions for managing OHTTP key configurations.
-//! It defines traits and implementations for different key management strategies:
+//! It defines traits and implementations for different key management strategies,
+//! and requires [`StatusProvider`] as a supertrait so every key manager can respond
+//! to `/status/egress/<id>` queries with its current key state.
 
+use crate::status::StatusProvider;
 use crate::tunnel::ohttp::key_config::PublicKeyData;
 use crate::{error::TngError, tunnel::ohttp::key_config::KeyConfigExtend};
 use std::time::SystemTime;
@@ -15,7 +18,8 @@ pub mod peer_shared;
 pub mod self_generated;
 
 /// Key status indicating whether a key is pending, active or stale
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum KeyStatus {
     /// Pending key that is waiting to be activated, can be used for new connections but not given to new clients
     Pending,
@@ -175,7 +179,7 @@ fn format_system_time(t: SystemTime) -> String {
 /// This trait abstracts different ways of obtaining OHTTP key configurations,
 /// allowing for flexibility in how keys are generated or acquired.
 #[async_trait]
-pub trait KeyManager: Send + Sync {
+pub trait KeyManager: StatusProvider + Send + Sync {
     /// Get an key info with their status by key ID
     ///
     /// Returns an key configuration for the given ID.
@@ -185,4 +189,41 @@ pub trait KeyManager: Send + Sync {
     ///
     /// Returns the key that is active, valid, and safe to expose.
     async fn get_client_visible_key(&self) -> Result<KeyInfo, TngError>;
+
+    /// Return a human-readable type name for this key manager.
+    fn key_manager_type(&self) -> &'static str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn make_test_key_info(key_id: u8) -> KeyInfo {
+        KeyInfo {
+            key_config: ohttp::KeyConfig::new(
+                key_id,
+                ohttp::hpke::Kem::X25519Sha256,
+                vec![ohttp::SymmetricSuite::new(
+                    ohttp::hpke::Kdf::HkdfSha256,
+                    ohttp::hpke::Aead::ChaCha20Poly1305,
+                )],
+            )
+            .expect("create key config"),
+            status: KeyStatus::Active,
+            actived_at: SystemTime::now(),
+            stale_at: SystemTime::now() + Duration::from_secs(300),
+            expire_at: SystemTime::now() + Duration::from_secs(600),
+        }
+    }
+
+    #[test]
+    fn test_key_info_debug_output() {
+        let info = make_test_key_info(1);
+        let debug = format!("{:?}", info);
+        assert!(debug.contains("public_key"));
+        assert!(debug.contains("status"));
+        assert!(debug.contains("actived_at"));
+        assert!(debug.contains("expire_at"));
+    }
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/cluster_key_set.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/cluster_key_set.rs
@@ -366,6 +366,11 @@ impl ClusterKeySet {
         self.trigger_notify();
         true
     }
+
+    /// Iterate over all keys in the cluster key set.
+    pub fn iter_keys(&self) -> impl Iterator<Item = (&PublicKeyData, &KeyInfo)> {
+        self.keys.iter()
+    }
 }
 
 impl TryFrom<super::cluster_key_set::ClusterKeySet> for super::serf_message::pb::ClusterKeySet {

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/key_manager.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/key_manager.rs
@@ -1,9 +1,47 @@
 use crate::error::TngError;
-use crate::tunnel::egress::protocol::ohttp::security::key_manager::{KeyInfo, KeyManager};
+use crate::status::{StatusProvider, StatusQueryResult};
+use crate::tunnel::egress::protocol::ohttp::security::key_manager::{
+    KeyInfo, KeyManager, KeyStatus,
+};
 use crate::tunnel::ohttp::key_config::PublicKeyData;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::Serialize;
+use std::time::SystemTime;
+
+/// Cluster topology snapshot.
+#[derive(Serialize)]
+struct ClusterStatus {
+    node_id: String,
+    members: Vec<ClusterMember>,
+}
+
+/// Cluster member entry.
+#[derive(Serialize)]
+struct ClusterMember {
+    node_id: String,
+    status: &'static str,
+}
+
+/// Single key entry in the peer-shared status snapshot.
+#[derive(Serialize)]
+struct PeerSharedKeyValue {
+    source_node_id: String,
+    key_id: u8,
+    public_key: PublicKeyData,
+    status: KeyStatus,
+    #[serde(with = "humantime_serde")]
+    expire_at: SystemTime,
+}
+
+/// Snapshot of the peer-shared key manager status for the status API.
+#[derive(Serialize)]
+struct PeerSharedStatus {
+    key_manager_type: &'static str,
+    keys: Vec<PeerSharedKeyValue>,
+    cluster: ClusterStatus,
+}
 
 #[async_trait]
 impl KeyManager for super::PeerSharedKeyManager {
@@ -36,5 +74,56 @@ impl KeyManager for super::PeerSharedKeyManager {
         let cks = self.inner.cluster_key_set.read().await;
         // Return the client-visible key (active key with latest stale_at)
         Ok(cks.get_client_visible_key()?.clone())
+    }
+
+    fn key_manager_type(&self) -> &'static str {
+        "peer_shared"
+    }
+}
+
+#[async_trait]
+impl StatusProvider for super::PeerSharedKeyManager {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => Ok(StatusQueryResult::Subtree(vec!["keys".into()])),
+            ["keys"] => {
+                let node_id = self.serf.memberlist().local_id().to_string();
+
+                let cks = self.inner.cluster_key_set.read().await;
+                let keys: Vec<PeerSharedKeyValue> = cks
+                    .iter_keys()
+                    .map(|(public_key, info)| PeerSharedKeyValue {
+                        source_node_id: node_id.clone(),
+                        key_id: info.key_config.key_id(),
+                        public_key: public_key.clone(),
+                        status: info.status,
+                        expire_at: info.expire_at,
+                    })
+                    .collect();
+                drop(cks);
+
+                let serf_members = self.serf.members().await;
+                let members: Vec<ClusterMember> = serf_members
+                    .iter()
+                    .map(|m| ClusterMember {
+                        node_id: m.node().to_string(),
+                        status: "alive",
+                    })
+                    .collect();
+
+                let status = PeerSharedStatus {
+                    key_manager_type: "peer_shared",
+                    keys,
+                    cluster: ClusterStatus { node_id, members },
+                };
+                serde_json::to_value(&status)
+                    .map(StatusQueryResult::Value)
+                    .map_err(|e| {
+                        tracing::error!(?e, "Failed to serialise key status");
+                        TngError::StatusPathNotFound
+                    })
+            }
+            _ => Err(TngError::StatusPathNotFound),
+        }
     }
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
@@ -42,7 +42,7 @@ const SERF_USER_EVENT_BROADCAST_CLUSTER_KEY_SET: &str = "broadcast_cluster_key_s
 
 pub struct PeerSharedKeyManager {
     pub(super) inner: Arc<PeerSharedKeyManagerInner>,
-    serf: Arc<SerfGracefulShutdown>,
+    pub(super) serf: Arc<SerfGracefulShutdown>,
 }
 
 type InstrumentedTokioRuntime = InstrumentedRuntime<serf::agnostic::tokio::TokioRuntime>;
@@ -802,7 +802,7 @@ async fn load_peers_from_file(path: &str) -> Result<Vec<String>, anyhow::Error> 
         .with_context(|| format!("Failed to parse peers file as JSON: {path}"))
 }
 
-struct SerfGracefulShutdown {
+pub(super) struct SerfGracefulShutdown {
     serf: Option<Serf>,
     runtime: TokioRuntime,
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/self_generated.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/self_generated.rs
@@ -1,4 +1,5 @@
 use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::egress::protocol::ohttp::security::key_manager::{
     KeyInfo, KeyManager, KeyStatus,
 };
@@ -13,6 +14,28 @@ use std::time::{Duration, SystemTime};
 use anyhow::Result;
 use async_trait::async_trait;
 use itertools::Itertools;
+use serde::Serialize;
+
+/// Snapshot of the self-generated key manager status for the status API.
+#[derive(Serialize)]
+struct SelfGeneratedStatus<'a> {
+    key_manager_type: &'static str,
+    local_keys: Vec<KeyValue<'a>>,
+}
+
+/// Single key entry in the self-generated status snapshot.
+#[derive(Serialize)]
+struct KeyValue<'a> {
+    key_id: u8,
+    public_key: &'a PublicKeyData,
+    status: KeyStatus,
+    #[serde(with = "humantime_serde")]
+    actived_at: SystemTime,
+    #[serde(with = "humantime_serde")]
+    stale_at: SystemTime,
+    #[serde(with = "humantime_serde")]
+    expire_at: SystemTime,
+}
 
 /// Implementation of KeyManager that generates random keys with automatic rotation
 pub struct SelfGeneratedKeyManager {
@@ -163,10 +186,48 @@ impl KeyManager for SelfGeneratedKeyManager {
             .map(|(_, key_info)| key_info.clone())
             .ok_or(TngError::NoActiveKey)
     }
+
+    fn key_manager_type(&self) -> &'static str {
+        "self_generated"
+    }
 }
 
 impl Drop for SelfGeneratedKeyManager {
     fn drop(&mut self) {
         self.refresh_task.abort();
+    }
+}
+
+#[async_trait]
+impl StatusProvider for SelfGeneratedKeyManager {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => Ok(StatusQueryResult::Subtree(vec!["keys".into()])),
+            ["keys"] => {
+                let keys = self.inner.keys.read().await;
+                let local_keys: Vec<KeyValue<'_>> = keys
+                    .iter()
+                    .map(|(public_key, info)| KeyValue {
+                        key_id: info.key_config.key_id(),
+                        public_key,
+                        status: info.status,
+                        actived_at: info.actived_at,
+                        stale_at: info.stale_at,
+                        expire_at: info.expire_at,
+                    })
+                    .collect::<Vec<_>>();
+                let status = SelfGeneratedStatus {
+                    key_manager_type: "self_generated",
+                    local_keys,
+                };
+                serde_json::to_value(&status)
+                    .map(StatusQueryResult::Value)
+                    .map_err(|e| {
+                        tracing::error!(?e, "Failed to serialise key status");
+                        TngError::StatusPathNotFound
+                    })
+            }
+            _ => Err(TngError::StatusPathNotFound),
+        }
     }
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/mod.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/mod.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use hyper_util::rt::TokioIo;
 use tower::Service;
 use tracing::Instrument;
 
+use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::{
     config::egress::OHttpArgs,
     tunnel::{
@@ -68,5 +71,12 @@ impl OHttpSecurityLayer {
         }
         .instrument(tracing::info_span!("security"))
         .await
+    }
+}
+
+#[async_trait]
+impl StatusProvider for OHttpSecurityLayer {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        self.ohttp_server.query_status(path).await
     }
 }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/server.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/server.rs
@@ -14,6 +14,7 @@ use tower_http::{
     cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer, ExposeHeaders},
 };
 
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::ra_context::RaContext;
 use crate::{
     config::egress::{CorsConfig, OHttpArgs},
@@ -28,6 +29,7 @@ use crate::{
     tunnel::egress::protocol::ohttp::security::{api::OhttpServerApi, context::TngStreamContext},
     HTTP_RESPONSE_SERVER_HEADER,
 };
+use async_trait::async_trait;
 
 /// TNG OHTTP Server implementation
 ///
@@ -173,6 +175,13 @@ impl OhttpServer {
             )
             .layer(axum::middleware::from_fn(add_server_header))
             .layer(axum::middleware::from_fn(log_request))
+    }
+}
+
+#[async_trait]
+impl StatusProvider for OhttpServer {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        self.api.query_status(path).await
     }
 }
 

--- a/tng/src/tunnel/egress/protocol/rats_tls/mod.rs
+++ b/tng/src/tunnel/egress/protocol/rats_tls/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
+    error::TngError,
+    status::{StatusProvider, StatusQueryResult},
     tunnel::{
         egress::{
             protocol::rats_tls::{security::RatsTlsSecurityLayer, wrapping::RatsTlsWrappingLayer},
@@ -79,5 +81,12 @@ impl ProtocolStreamDecoder for RatsTlsStreamDecoder {
             }
             .boxed())
         }
+    }
+}
+
+#[async_trait]
+impl StatusProvider for RatsTlsStreamDecoder {
+    async fn query_status(&self, _path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        Err(TngError::StatusPathNotFound)
     }
 }

--- a/tng/src/tunnel/egress/stream_manager/trusted.rs
+++ b/tng/src/tunnel/egress/stream_manager/trusted.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::{
     config::egress::CommonArgs,
     tunnel::{
@@ -31,7 +33,7 @@ pub type ProtocolStreamDecoderOutput =
     BoxStream<'static, Result<(Box<dyn CommonStreamTrait + Sync>, Option<AttestationResult>)>>;
 
 #[async_trait]
-pub trait ProtocolStreamDecoder {
+pub trait ProtocolStreamDecoder: StatusProvider {
     async fn decode_stream(
         &self,
         input: Box<dyn CommonStreamTrait + Sync + 'static>,
@@ -139,6 +141,17 @@ impl StreamManager for TrustedStreamManager {
                 yield Ok(NextStream::DirectlyForward(Box::new(stream)));
             }
             .boxed()),
+        }
+    }
+}
+
+#[async_trait]
+impl StatusProvider for TrustedStreamManager {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => Ok(StatusQueryResult::Subtree(vec!["ohttp".into()])),
+            ["ohttp", rest @ ..] => self.decoder.query_status(rest).await,
+            _ => Err(TngError::StatusPathNotFound),
         }
     }
 }

--- a/tng/src/tunnel/ingress/flow/mod.rs
+++ b/tng/src/tunnel/ingress/flow/mod.rs
@@ -10,6 +10,8 @@ use indexmap::IndexMap;
 use tokio::sync::mpsc::Sender;
 
 use crate::config::ingress::CommonArgs;
+use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::access_log::{AccessLog, IngressMode};
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::service_metrics::ServiceMetrics;
@@ -121,6 +123,13 @@ impl RegistedService for IngressFlow {
     }
 }
 
+#[async_trait]
+impl RegistedService for Arc<IngressFlow> {
+    async fn serve(&self, ready: Sender<()>) -> Result<()> {
+        (**self).serve(ready).await
+    }
+}
+
 impl IngressFlow {
     async fn serve_in_async_task_no_throw_error(
         &self,
@@ -214,5 +223,12 @@ impl IngressFlow {
                 }
             },
         );
+    }
+}
+
+#[async_trait]
+impl StatusProvider for IngressFlow {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        self.trusted_stream_manager.query_status(path).await
     }
 }

--- a/tng/src/tunnel/ingress/protocol/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/mod.rs
@@ -6,9 +6,14 @@ pub mod rats_tls;
 use std::{future::Future, net::SocketAddr, pin::Pin};
 
 use anyhow::Result;
-use async_trait::async_trait;
 
-use crate::{tunnel::endpoint::TngEndpoint, AttestationResult, CommonStreamTrait};
+#[cfg(not(wasm))]
+use crate::status::StatusProvider;
+use crate::AttestationResult;
+#[cfg(not(wasm))]
+use crate::{tunnel::endpoint::TngEndpoint, CommonStreamTrait};
+#[cfg(not(wasm))]
+use async_trait::async_trait;
 
 pub type ForwardTask = Pin<Box<dyn Future<Output = Result<()>> + std::marker::Send + 'static>>;
 
@@ -18,8 +23,9 @@ pub type ProtocolStreamForwarderOutput = (
     /* upstream_local */ Option<SocketAddr>,
 );
 
+#[cfg(not(wasm))]
 #[async_trait]
-pub trait ProtocolStreamForwarder {
+pub trait ProtocolStreamForwarder: StatusProvider {
     async fn forward_stream<'a>(
         &self,
         endpoint: &'a TngEndpoint,

--- a/tng/src/tunnel/ingress/protocol/ohttp/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/mod.rs
@@ -9,6 +9,8 @@ mod ohttp_stream_forwarder {
 
     use crate::{
         config::ingress::OHttpArgs,
+        error::TngError,
+        status::{StatusProvider, StatusQueryResult},
         tunnel::{
             endpoint::TngEndpoint,
             ingress::protocol::{
@@ -108,6 +110,13 @@ mod ohttp_stream_forwarder {
             }
             .instrument(tracing::info_span!("security"))
             .await
+        }
+    }
+
+    #[async_trait]
+    impl StatusProvider for OHttpStreamForwarder {
+        async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+            self.security_layer.query_status(path).await
         }
     }
 }

--- a/tng/src/tunnel/ingress/protocol/ohttp/security/client.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/security/client.rs
@@ -22,6 +22,7 @@ use rats_cert::tee::AttesterPipeline;
 use rats_cert::tee::GenericAttester as _;
 use rats_cert::tee::ReportData;
 use rats_cert::tee::{GenericConverter, GenericVerifier as _};
+use serde::Serialize;
 // tokio_with_wasm::task::spawn does not propagate the current tracing span,
 // so we must explicitly .instrument() the spawned future.
 #[cfg(wasm)]
@@ -110,7 +111,36 @@ struct KeyStoreValue {
     server_attestation_result: Option<AttestationResult>,
 }
 
+/// A single entry in the status API response for an upstream OHTTP server.
+///
+/// Contains the server URL, optional HPKE public key in hex format,
+/// and optional server attestation result as a raw JWT string.
+#[derive(Serialize)]
+pub struct ServerStatusEntry {
+    pub(crate) url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) server_public_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) server_attestation: Option<String>,
+}
+
 impl OHttpClient {
+    /// Return server status info for the status API.
+    pub async fn server_status(&self) -> Option<ServerStatusEntry> {
+        let ksv = self.key_store_value.get_latest().await.ok()?;
+        Some(ServerStatusEntry {
+            url: self.inner.base_url.to_string(),
+            server_public_key: ksv
+                .server_key_config_list
+                .first()
+                .and_then(|kc| kc.public_key().ok().map(|pk| hex::encode(pk.as_ref()))),
+            server_attestation: ksv
+                .server_attestation_result
+                .as_ref()
+                .map(|ar| ar.token_str().to_string()),
+        })
+    }
+
     pub async fn new(
         ra_context: Arc<RaContext>,
         http_client: Arc<reqwest::Client>,
@@ -783,5 +813,45 @@ impl OHttpClientInner {
             .map_err(|e| TngError::ClientGetBackgroundCheckResultFaild(e.into()))?;
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_server_status_entry_full() {
+        let entry = ServerStatusEntry {
+            url: "http://10.0.0.1:8080/path".to_string(),
+            server_public_key: Some("a1b2c3d4".to_string()),
+            server_attestation: Some("eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig".to_string()),
+        };
+        let value = serde_json::to_value(&entry).unwrap();
+        assert_eq!(value["url"], "http://10.0.0.1:8080/path");
+        assert_eq!(value["server_public_key"], "a1b2c3d4");
+        assert_eq!(
+            value["server_attestation"],
+            "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig"
+        );
+    }
+
+    #[test]
+    fn test_server_status_entry_partial() {
+        let entry = ServerStatusEntry {
+            url: "http://10.0.0.2:9090/".to_string(),
+            server_public_key: None,
+            server_attestation: None,
+        };
+        let value = serde_json::to_value(&entry).unwrap();
+        assert_eq!(value["url"], "http://10.0.0.2:9090/");
+        assert!(
+            value.get("server_public_key").is_none(),
+            "server_public_key should be omitted when None"
+        );
+        assert!(
+            value.get("server_attestation").is_none(),
+            "server_attestation should be omitted when None"
+        );
     }
 }

--- a/tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs
@@ -3,6 +3,8 @@ mod path_rewrite;
 
 use std::{collections::HashMap, sync::Arc};
 
+#[cfg(not(wasm))]
+use crate::status::{StatusProvider, StatusQueryResult};
 #[cfg(unix)]
 use crate::tunnel::utils::socket::{
     TCP_KEEPALIVE_IDLE_SECS, TCP_KEEPALIVE_INTERVAL_SECS, TCP_KEEPALIVE_PROBE_COUNT,
@@ -12,20 +14,35 @@ use crate::{
     error::TngError,
     tunnel::{
         endpoint::TngEndpoint,
-        ingress::protocol::ohttp::security::{client::OHttpClient, path_rewrite::PathRewriteGroup},
+        ingress::protocol::ohttp::security::{
+            client::{OHttpClient, ServerStatusEntry},
+            path_rewrite::PathRewriteGroup,
+        },
         ra_context::RaContext,
     },
     AttestationResult, TokioRuntime, HTTP_REQUEST_USER_AGENT_HEADER,
 };
 use anyhow::{Context, Result};
+#[cfg(not(wasm))]
+use async_trait::async_trait;
 use http::HeaderValue;
+use serde::Serialize;
 use tokio::sync::{OnceCell, RwLock};
 use url::Url;
+
+/// Cached OHTTP client per base URL, lazily initialized on first use.
+type OhttpClientCache = RwLock<HashMap<Url, Arc<OnceCell<Arc<OHttpClient>>>>>;
+
+/// Root status response for /status/.../ohttp/keys.
+#[derive(Serialize)]
+struct ServersStatus {
+    servers: Vec<ServerStatusEntry>,
+}
 
 pub struct OHttpSecurityLayer {
     ra_context: Arc<RaContext>,
     http_client: Arc<reqwest::Client>,
-    ohttp_clients: RwLock<HashMap<Url, Arc<OnceCell<Arc<OHttpClient>>>>>,
+    ohttp_clients: OhttpClientCache,
     path_rewrite_group: PathRewriteGroup,
     runtime: TokioRuntime,
 }
@@ -67,10 +84,12 @@ impl OHttpSecurityLayer {
             builder.build()?
         };
 
+        let ohttp_clients: OhttpClientCache = Default::default();
+
         Ok(Self {
             ra_context,
             http_client: Arc::new(http_client),
-            ohttp_clients: Default::default(),
+            ohttp_clients,
             path_rewrite_group: PathRewriteGroup::new(&ohttp_args.path_rewrites)?,
             runtime,
         })
@@ -164,5 +183,74 @@ impl OHttpSecurityLayer {
         })
         .await
         .cloned()
+    }
+}
+
+#[cfg(not(wasm))]
+#[async_trait]
+impl StatusProvider for OHttpSecurityLayer {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => Ok(StatusQueryResult::Subtree(vec!["keys".into()])),
+            ["keys"] => {
+                let map = self.ohttp_clients.read().await;
+                let mut servers = Vec::with_capacity(map.len());
+                for cell in map.values() {
+                    if let Some(client) = cell.get() {
+                        if let Some(entry) = client.server_status().await {
+                            servers.push(entry);
+                        }
+                    }
+                }
+                let status = ServersStatus { servers };
+                serde_json::to_value(&status)
+                    .map(StatusQueryResult::Value)
+                    .map_err(|e| {
+                        tracing::error!(?e, "Failed to serialise server status");
+                        TngError::StatusPathNotFound
+                    })
+            }
+            _ => Err(TngError::StatusPathNotFound),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::client::ServerStatusEntry;
+    use super::ServersStatus;
+
+    #[test]
+    fn test_servers_status_collection() {
+        let status = ServersStatus {
+            servers: vec![
+                ServerStatusEntry {
+                    url: "http://a.com".to_string(),
+                    server_public_key: Some("key1".to_string()),
+                    server_attestation: None,
+                },
+                ServerStatusEntry {
+                    url: "http://b.com".to_string(),
+                    server_public_key: Some("key2".to_string()),
+                    server_attestation: Some("jwt2".to_string()),
+                },
+            ],
+        };
+        let value = serde_json::to_value(&status).unwrap();
+        let servers = value["servers"].as_array().unwrap();
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0]["url"], "http://a.com");
+        assert_eq!(servers[0]["server_public_key"], "key1");
+        assert!(servers[0].get("server_attestation").is_none());
+        assert_eq!(servers[1]["url"], "http://b.com");
+        assert_eq!(servers[1]["server_attestation"], "jwt2");
+    }
+
+    #[test]
+    fn test_servers_status_empty() {
+        let status = ServersStatus { servers: vec![] };
+        let value = serde_json::to_value(&status).unwrap();
+        let servers = value["servers"].as_array().unwrap();
+        assert!(servers.is_empty());
     }
 }

--- a/tng/src/tunnel/ingress/protocol/rats_tls/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/rats_tls/mod.rs
@@ -2,6 +2,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::{
+    error::TngError,
+    status::{StatusProvider, StatusQueryResult},
     tunnel::{
         endpoint::TngEndpoint,
         ingress::protocol::{
@@ -81,5 +83,12 @@ impl ProtocolStreamForwarder for RatsTlsStreamForwarder {
             attestation_result,
             local_addr,
         ))
+    }
+}
+
+#[async_trait]
+impl StatusProvider for RatsTlsStreamForwarder {
+    async fn query_status(&self, _path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        Err(TngError::StatusPathNotFound)
     }
 }

--- a/tng/src/tunnel/ingress/stream_manager/trusted.rs
+++ b/tng/src/tunnel/ingress/stream_manager/trusted.rs
@@ -4,7 +4,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
+use async_trait::async_trait;
 
+use crate::error::TngError;
+use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::ingress::protocol::ohttp::OHttpStreamForwarder;
 use crate::tunnel::ingress::protocol::rats_tls::RatsTlsStreamForwarder;
 use crate::tunnel::ingress::protocol::ProtocolStreamForwarder;
@@ -131,5 +134,16 @@ impl StreamManager for TrustedStreamManager {
         self.stream_forwarder
             .forward_stream(endpoint, downstream)
             .await
+    }
+}
+
+#[async_trait]
+impl StatusProvider for TrustedStreamManager {
+    async fn query_status(&self, path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        match path {
+            [] => Ok(StatusQueryResult::Subtree(vec!["ohttp".into()])),
+            ["ohttp", rest @ ..] => self.stream_forwarder.query_status(rest).await,
+            _ => Err(TngError::StatusPathNotFound),
+        }
     }
 }

--- a/tng/src/tunnel/ohttp/key_config.rs
+++ b/tng/src/tunnel/ohttp/key_config.rs
@@ -1,7 +1,14 @@
 use crate::error::TngError;
+use serde::ser::Serializer;
 
 #[derive(Eq, Hash, PartialEq, Clone, Ord, PartialOrd)]
 pub struct PublicKeyData(Vec<u8>);
+
+impl serde::Serialize for PublicKeyData {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(&self.0))
+    }
+}
 
 impl PublicKeyData {
     pub fn new(data: Vec<u8>) -> Self {


### PR DESCRIPTION
Introduce StatusProvider as a common interface for status reporting across the TNG hierarchy. All egress, ingress, protocol, and key manager components implement query_status() to expose their status through a tree-walking REST endpoint.

**New:**
- tng/src/status.rs: StatusProvider trait + StatusQueryResult enum
- tng/src/state.rs: TngState with egress/ingress status handles
- /status/ and /status/{*path} GET endpoints in control interface
- ServerStatusEntry in ingress OHTTP client (public key + attestation)
- key_manager_type() getter on KeyManager trait
- token_str() getter on AttestationResult
- Typo fix: sevice -> service in runtime.rs