### PR TITLE
feat: add Windows x86_64-pc-windows-gnu cross-build support

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -20,7 +20,7 @@ jobs:
           - "x86_64-apple-darwin"
           - "x86_64-unknown-linux-gnu"
           - "aarch64-unknown-linux-gnu"
-          # - "x86_64-pc-windows-msvc"
+          - "x86_64-pc-windows-gnu"
     name: Build For ${{ matrix.target }}
     uses: ./.github/workflows/zigbuild.yml
     with:
@@ -76,8 +76,6 @@ jobs:
           draft: false
           fail_on_unmatched_files: true
           prerelease: ${{ env.PRE_RELEASE }}
-          # files: |
-          #   ./artifacts/*.zip
-          #   ./artifacts/*.tar.gz
           files: |
             ./artifacts/*.tar.gz
+            ./artifacts/*.zip

--- a/.github/workflows/zigbuild.yml
+++ b/.github/workflows/zigbuild.yml
@@ -44,7 +44,12 @@ jobs:
           ${{ contains( inputs.target, 'apple' ) && 'RUSTFLAGS="-L native=/usr/lib/ --cfg tokio_unstable"' || 'RUSTFLAGS="--cfg tokio_unstable"'  }} cargo ${{ env.build-tool }} --target ${{ inputs.target }} --release
       - name: Get binary path
         if: ${{ runner.os != 'Windows' }}
-        run: echo "executable=$(find . -maxdepth 4 -type f -exec file {} \; | grep 'executable' | grep 'target' | grep -o '^[^:]*')" >> "$GITHUB_ENV"
+        run: |
+          if [[ "${{ inputs.target }}" == *"windows"* ]]; then
+            echo "executable=./target/${{ inputs.target }}/release/${{ env.exe_name }}" >> "$GITHUB_ENV"
+          else
+            echo "executable=./target/${{ inputs.target }}/release/${{ env.exe_name }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/zigbuild.yml
+++ b/.github/workflows/zigbuild.yml
@@ -16,10 +16,11 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ contains( inputs.target, 'linux' ) && 'ubuntu-latest' || ( contains( inputs.target, 'apple' ) && 'macos-latest' || ( contains( inputs.target, 'windows' ) && 'windows-latest' || 'ubuntu-latest' ) ) }}
+    runs-on: ${{ contains( inputs.target, 'linux' ) && 'ubuntu-latest' || ( contains( inputs.target, 'apple' ) && 'macos-latest' || ( contains( inputs.target, 'windows-msvc' ) && 'windows-latest' || 'ubuntu-latest' ) ) }}
     env:
       build-tool: ${{ contains( inputs.target, 'windows-msvc' ) && 'build' || 'zigbuild' }}
       executable: ./target/${{inputs.target}}/release/*.exe
+      exe_name: ${{ contains( inputs.target, 'windows' ) && 'tng.exe' || 'tng' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,5 +47,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.target }}
-          path: target/${{ inputs.target }}/release/tng
+          path: target/${{ inputs.target }}/release/${{ env.exe_name }}
           if-no-files-found: error

--- a/.github/workflows/zigbuild.yml
+++ b/.github/workflows/zigbuild.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install cargo-zigbuild
         if: ${{ env.build-tool == 'zigbuild' }}
         run: rustup toolchain add nightly && cargo +nightly install cargo-zigbuild --version 0.19.8
+      - name: Install mingw-w64
+        if: ${{ contains( inputs.target, 'windows' ) && env.build-tool == 'zigbuild' }}
+        run: sudo apt-get update && sudo apt-get install -y mingw-w64
       - name: cargo compile
         run: |
           ${{ contains( inputs.target, 'apple' ) && 'RUSTFLAGS="-L native=/usr/lib/ --cfg tokio_unstable"' || 'RUSTFLAGS="--cfg tokio_unstable"'  }} cargo ${{ env.build-tool }} --target ${{ inputs.target }} --release

--- a/Makefile
+++ b/Makefile
@@ -296,11 +296,43 @@ wasm-integration-test: wasm-build-debug install-test-deps
 www-demo:
 	cd tng-wasm/www && npm run start
 
-.PHONE: mac-cross-build
+.PHONY: mac-cross-build
 mac-cross-build:
 	RUSTFLAGS="-L native=/usr/lib/" cargo zigbuild --target aarch64-apple-darwin
 
-.PHONE: clippy
+.PHONY: install-windows-build-deps
+install-windows-build-deps:
+	@if ! command -v zig >/dev/null 2>&1; then \
+		echo "=== Installing Zig ==="; \
+		ARCH=$$(uname -m); \
+		if [ "$$ARCH" = "aarch64" ]; then ZIG_ARCH="aarch64"; else ZIG_ARCH="x86_64"; fi; \
+		ZIG_VERSION=0.16.0; \
+		ZIG_DIR=/tmp/zig-$${ZIG_ARCH}-linux-$${ZIG_VERSION}; \
+		curl -L "https://zigmirror.com/zig-$${ZIG_ARCH}-linux-$${ZIG_VERSION}.tar.xz" -o /tmp/zig-cross.tar.xz; \
+		tar -xJf /tmp/zig-cross.tar.xz -C /tmp/; \
+		cp "$$ZIG_DIR/zig" /usr/local/bin/zig; \
+		cp -rf "$$ZIG_DIR/lib" /usr/local/lib/; \
+		cp -rf "$$ZIG_DIR/doc" /usr/local/doc/ 2>/dev/null || true; \
+		cp -f "$$ZIG_DIR/LICENSE" /usr/local/ 2>/dev/null || true; \
+		rm -f /tmp/zig-cross.tar.xz; \
+		rm -rf "$$ZIG_DIR"; \
+	fi
+	@if ! command -v x86_64-w64-mingw32-dlltool >/dev/null 2>&1; then \
+		echo "=== Installing MinGW-w64 toolchain ==="; \
+		yum install -y mingw64-gcc; \
+	fi
+	@if ! cargo --list 2>/dev/null | grep -q zigbuild; then \
+		echo "=== Installing cargo-zigbuild ==="; \
+		rustup toolchain add nightly >/dev/null 2>&1; \
+		cargo +nightly install cargo-zigbuild --version 0.19.8; \
+	fi
+	@rustup target list | grep -q "x86_64-pc-windows-gnu (installed)" || rustup target add x86_64-pc-windows-gnu
+
+.PHONY: windows-cross-build
+windows-cross-build: install-windows-build-deps
+	RUSTFLAGS="--cfg tokio_unstable" cargo zigbuild --target x86_64-pc-windows-gnu --release
+
+.PHONY: clippy
 clippy:
 	cargo clippy --all-targets -- -D warnings
 

--- a/tng/src/bin/tng/main.rs
+++ b/tng/src/bin/tng/main.rs
@@ -6,12 +6,11 @@ use std::{fs::File, io::BufReader};
 use anyhow::{bail, Context};
 use clap::Parser as _;
 use cli::{Cli, GlobalSubcommand};
+use tng::build;
+use tng::config::TngConfig;
 use tng::runtime::TngRuntime;
 use tracing_subscriber::Layer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-use tng::build;
-use tng::config::TngConfig;
 
 mod cli;
 
@@ -21,11 +20,6 @@ async fn main() {
 
     // Initialize rustls crypto provider
     #[allow(clippy::expect_used)]
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    )))]
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("Failed to install rustls crypto provider");
@@ -52,10 +46,19 @@ async fn main() {
                     }),
                 ),
         );
+
+    #[cfg(unix)]
     if cli.tokio_console {
-        // Initialize tokio console
         subscriber_init.with(console_subscriber::spawn()).init();
     } else {
+        subscriber_init.init();
+    }
+
+    #[cfg(not(unix))]
+    {
+        if cli.tokio_console {
+            eprintln!("Warning: --tokio-console is not supported on this platform. Ignoring.");
+        }
         subscriber_init.init();
     }
 
@@ -63,7 +66,7 @@ async fn main() {
         r#"
   _______   ________
  /_  __/ | / / ____/
-  / / /  |/ / / __  
+  / / /  |/ / / __
  / / / /|  / /_/ /  Welcome to the Trusted Network Gateway!
 /_/ /_/ |_/\____/   version: v{}  commit: {}  buildtime: {}"#,
         build::PKG_VERSION,

--- a/tng/src/config/ra.rs
+++ b/tng/src/config/ra.rs
@@ -90,6 +90,7 @@ impl<'de> Deserialize<'de> for RaArgsUnchecked {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum RaArgs {
     #[cfg(unix)]
     AttestOnly(AttestArgs),
@@ -128,7 +129,7 @@ impl RaArgsUnchecked {
                 (Some(attest), None) => RaArgs::AttestOnly(attest),
                 #[cfg(unix)]
                 (Some(attest), Some(verify)) => RaArgs::AttestAndVerify(attest, verify),
-                #[cfg(wasm)]
+                #[cfg(not(unix))]
                 (Some(..), _) => {
                     return Err(TngError::InvalidParameter(anyhow!("`attest` option is not supported since attestation is not supported on this platform.")));
                 }

--- a/tng/src/error.rs
+++ b/tng/src/error.rs
@@ -173,7 +173,7 @@ impl IntoResponse for TngError {
             // Timeouts / Network failures
             TngError::HttpPlainTextForwardError(..) => StatusCode::BAD_GATEWAY,
             TngError::HttpCipherTextForwardError(e) => {
-                #[cfg(unix)]
+                #[cfg(not(wasm))]
                 let is_timeout = e.is_connect() || e.is_timeout();
                 #[cfg(wasm)]
                 let is_timeout = e.is_timeout();
@@ -239,13 +239,13 @@ impl IntoResponse for TngError {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 #[async_trait]
 pub trait CheckErrorResponse: Sized {
     async fn check_error_response(self) -> Result<Self, anyhow::Error>;
 }
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 #[async_trait]
 impl CheckErrorResponse for reqwest::Response {
     async fn check_error_response(self) -> Result<Self, anyhow::Error> {

--- a/tng/src/lib.rs
+++ b/tng/src/lib.rs
@@ -4,15 +4,16 @@
 use shadow_rs::shadow;
 
 pub mod config;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 mod control_interface;
 pub mod error;
+#[cfg(not(wasm))]
 mod observability;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod runtime;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 mod service;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 mod state;
 pub mod tunnel;
 
@@ -21,7 +22,7 @@ shadow!(build);
 pub(crate) const HTTP_REQUEST_USER_AGENT_HEADER: &str =
     const_format::concatcp!("tng/", crate::build::PKG_VERSION);
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub(crate) const HTTP_RESPONSE_SERVER_HEADER: &str =
     const_format::concatcp!("tng/", crate::build::PKG_VERSION);
 

--- a/tng/src/tunnel/access_log.rs
+++ b/tng/src/tunnel/access_log.rs
@@ -10,6 +10,7 @@ use super::attestation_result::AttestationResult;
 #[derive(Debug, Clone, Copy)]
 pub enum IngressMode {
     Mapping,
+    #[cfg(all(feature = "ingress-netfilter", target_os = "linux"))]
     Netfilter,
     Socks5,
     HttpProxy,
@@ -19,6 +20,7 @@ impl Display for IngressMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IngressMode::Mapping => write!(f, "mapping"),
+            #[cfg(all(feature = "ingress-netfilter", target_os = "linux"))]
             IngressMode::Netfilter => write!(f, "netfilter"),
             IngressMode::Socks5 => write!(f, "socks5"),
             IngressMode::HttpProxy => write!(f, "http_proxy"),
@@ -30,6 +32,7 @@ impl Display for IngressMode {
 #[derive(Debug, Clone, Copy)]
 pub enum EgressMode {
     Mapping,
+    #[cfg(all(feature = "egress-netfilter", target_os = "linux"))]
     Netfilter,
 }
 
@@ -37,6 +40,7 @@ impl Display for EgressMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EgressMode::Mapping => write!(f, "mapping"),
+            #[cfg(all(feature = "egress-netfilter", target_os = "linux"))]
             EgressMode::Netfilter => write!(f, "netfilter"),
         }
     }

--- a/tng/src/tunnel/egress/flow.rs
+++ b/tng/src/tunnel/egress/flow.rs
@@ -35,6 +35,7 @@ pub(super) trait EgressTrait: Sync + Send {
     fn metric_attributes(&self) -> IndexMap<String, String>;
 
     /// Return the so_mark which should be used for creating new tcp stream to upstream.
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     fn transport_so_mark(&self) -> Option<u32>;
 
     /// Accept incomming streams. The returned stream should be a stream of incomming accepted streams.

--- a/tng/src/tunnel/egress/mapping.rs
+++ b/tng/src/tunnel/egress/mapping.rs
@@ -65,6 +65,7 @@ impl EgressTrait for MappingEgress {
         .into()
     }
 
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     fn transport_so_mark(&self) -> Option<u32> {
         None
     }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/api/key_config.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/api/key_config.rs
@@ -1,24 +1,32 @@
-use std::pin::Pin;
-use std::sync::Arc;
-
-use anyhow::{bail, Result};
+#[cfg(unix)]
+use anyhow::bail;
+use anyhow::Result;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine as _;
 use itertools::Itertools;
 use ohttp::KeyConfig;
+#[cfg(unix)]
 use rats_cert::tee::{AttesterPipeline, GenericAttester as _, GenericConverter as _, ReportData};
+#[cfg(unix)]
+use std::pin::Pin;
+#[cfg(unix)]
+use std::sync::Arc;
 
 use crate::error::TngError;
 use crate::tunnel::egress::protocol::ohttp::security::api::OhttpServerApi;
 use crate::tunnel::egress::protocol::ohttp::security::context::TngStreamContext;
 use crate::tunnel::egress::protocol::ohttp::security::key_manager::KeyManager;
+#[cfg(unix)]
 use crate::tunnel::ohttp::protocol::userdata::ServerUserData;
-use crate::tunnel::ohttp::protocol::{
-    AttestationRequest, HpkeKeyConfig, KeyConfigRequest, KeyConfigResponse, ServerAttestationInfo,
-};
-use crate::tunnel::ra_context::{AttestContext, RaContext};
+#[cfg(unix)]
+use crate::tunnel::ohttp::protocol::{AttestationRequest, ServerAttestationInfo};
+use crate::tunnel::ohttp::protocol::{HpkeKeyConfig, KeyConfigRequest, KeyConfigResponse};
+#[cfg(unix)]
+use crate::tunnel::ra_context::AttestContext;
+use crate::tunnel::ra_context::RaContext;
+#[cfg(unix)]
 use crate::tunnel::utils::maybe_cached::{Expire, MaybeCached};
 
 impl OhttpServerApi {
@@ -33,13 +41,15 @@ impl OhttpServerApi {
     ///
     /// This endpoint only needs to be accessed once. Before hpke_key_config.expire_timestamp or
     /// attestation_result expiration, the configuration needs to be refreshed in the background.
+    #[allow(unused_variables)]
     pub async fn get_hpke_configuration(
         &self,
         payload: Option<Json<KeyConfigRequest>>,
         context: TngStreamContext,
     ) -> Result<Response, TngError> {
         // Check if hit the cache
-        match (self.ra_context.attest_context(), &payload) {
+        #[cfg(unix)]
+        let response = match (self.ra_context.attest_context(), &payload) {
             // If the server is set to be a attester with passport mode, and the client is requesting a passport response, we cache it and return the cached response
             (
                 Some(attest_ctx @ AttestContext::Passport { .. }),
@@ -93,9 +103,21 @@ impl OhttpServerApi {
             )
             .await
             .map(|response: KeyConfigResponse| IntoResponse::into_response(Json(response))),
-        }
+        };
+
+        #[cfg(not(unix))]
+        let response = Self::get_hpke_configuration_internal(
+            &self.ra_context,
+            self.key_manager.as_ref(),
+            payload,
+        )
+        .await
+        .map(|response: KeyConfigResponse| IntoResponse::into_response(Json(response)));
+
+        response
     }
 
+    #[allow(unused_variables)]
     async fn get_hpke_configuration_internal(
         ra_context: &RaContext,
         key_manager: &dyn KeyManager,
@@ -132,79 +154,91 @@ impl OhttpServerApi {
         let attestation_request = payload.and_then(|Json(payload)| payload.attestation_request);
 
         let response = async {
-            Ok(match ra_context.attest_context() {
-                Some(attest_ctx) => match (attestation_request, attest_ctx) {
-                    (Some(AttestationRequest::Passport), AttestContext::Passport { attester, converter, .. }) => {
-                        // fetch a challenge token from attestation service
-                        let challenge_token = converter.get_nonce().await?;
+            #[cfg(unix)]
+            {
+                Ok(match ra_context.attest_context() {
+                    Some(attest_ctx) => match (attestation_request, attest_ctx) {
+                        (Some(AttestationRequest::Passport), AttestContext::Passport { attester, converter, .. }) => {
+                            // fetch a challenge token from attestation service
+                            let challenge_token = converter.get_nonce().await?;
 
-                        let attester_pipeline = AttesterPipeline::new(attester, converter);
+                            let attester_pipeline = AttesterPipeline::new(attester, converter);
 
-                        let userdata = ServerUserData {
-                            challenge_token: Some(challenge_token),
-                            hpke_key_config: hpke_key_config.clone(),
+                            let userdata = ServerUserData {
+                                challenge_token: Some(challenge_token),
+                                hpke_key_config: hpke_key_config.clone(),
+                            }
+                            .to_claims()?;
+
+                            let token = attester_pipeline
+                                .get_evidence(&ReportData::Claims(userdata))
+                                .await?;
+                            let as_provider = token.provider_type();
+                            KeyConfigResponse {
+                                hpke_key_config,
+                                attestation_info: Some(ServerAttestationInfo::Passport {
+                                    attestation_result: token.into_str(),
+                                    as_provider: Some(as_provider),
+                                }),
+                            }
                         }
-                        .to_claims()?;
+                        (
+                            Some(AttestationRequest::BackgroundCheck { challenge_token }),
+                            AttestContext::BackgroundCheck { attester, .. },
+                        ) => {
+                            let userdata = ServerUserData {
+                                challenge_token: Some(challenge_token),
+                                hpke_key_config: hpke_key_config.clone(),
+                            }
+                            .to_claims()?;
 
-                        let token = attester_pipeline
-                            .get_evidence(&ReportData::Claims(userdata))
-                            .await?;
-                        let as_provider = token.provider_type();
-                        KeyConfigResponse {
-                            hpke_key_config,
-                            attestation_info: Some(ServerAttestationInfo::Passport {
-                                attestation_result: token.into_str(),
-                                as_provider: Some(as_provider),
-                            }),
+                            let tng_evidence = attester
+                                .get_evidence(&ReportData::Claims(userdata))
+                                .await?;
+                            let aa_provider = tng_evidence.provider_type();
+                            let evidence = tng_evidence.serialize_to_json()?;
+
+                            KeyConfigResponse {
+                                hpke_key_config,
+                                attestation_info: Some(ServerAttestationInfo::BackgroundCheck {
+                                    evidence,
+                                    aa_provider: Some(aa_provider),
+                                }),
+                            }
                         }
-                    }
-                    (
-                        Some(AttestationRequest::BackgroundCheck { challenge_token }),
-                        AttestContext::BackgroundCheck { attester, .. },
-                    ) => {
-                        let userdata = ServerUserData {
-                            challenge_token: Some(challenge_token),
-                            hpke_key_config: hpke_key_config.clone(),
+                        (Some(AttestationRequest::Passport), AttestContext::BackgroundCheck { .. }) => {
+                            bail!("Background check model is expected but passport attestation is requested")
                         }
-                        .to_claims()?;
-
-                        let tng_evidence = attester
-                            .get_evidence(&ReportData::Claims(userdata))
-                            .await?;
-                        let aa_provider = tng_evidence.provider_type();
-                        let evidence = tng_evidence.serialize_to_json()?;
-
-                        KeyConfigResponse {
-                            hpke_key_config,
-                            attestation_info: Some(ServerAttestationInfo::BackgroundCheck {
-                                evidence,
-                                aa_provider: Some(aa_provider),
-                            }),
+                        (Some(AttestationRequest::BackgroundCheck { .. }), AttestContext::Passport { .. }) => {
+                            bail!("Passport model is expected but background check attestation is requested")
                         }
-                    }
-                    (Some(AttestationRequest::Passport), AttestContext::BackgroundCheck { .. }) => {
-                        bail!("Background check model is expected but passport attestation is requested")
-                    }
-                    (Some(AttestationRequest::BackgroundCheck { .. }), AttestContext::Passport { .. }) => {
-                        bail!("Passport model is expected but background check attestation is requested")
-                    }
-                    (None, _) => {
+                        (None, _) => {
 
-                            // Just return the key config when no attestation_request sent from client. This can happens when the server is 'attest' while client is 'no_ra'
+                                // Just return the key config when no attestation_request sent from client. This can happens when the server is 'attest' while client is 'no_ra'
+                            KeyConfigResponse {
+                                hpke_key_config,
+                                attestation_info: None,
+                            }
+                        }
+                    },
+                    None => {
+                        // No attestation required (VerifyOnly or NoRa)
                         KeyConfigResponse {
                             hpke_key_config,
                             attestation_info: None,
                         }
                     }
-                },
-                None => {
-                    // No attestation required (VerifyOnly or NoRa)
-                    KeyConfigResponse {
-                        hpke_key_config,
-                        attestation_info: None,
-                    }
-                }
-            })
+                })
+            }
+
+            #[cfg(not(unix))]
+            {
+                let _ = attestation_request;
+                Ok(KeyConfigResponse {
+                    hpke_key_config,
+                    attestation_info: None,
+                })
+            }
         }
         .await
         .map_err(TngError::GenServerHpkeConfigurationResponseFailed)?;

--- a/tng/src/tunnel/egress/protocol/ohttp/security/api/mod.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/api/mod.rs
@@ -5,6 +5,7 @@ pub mod tunnel;
 use std::sync::Arc;
 
 use anyhow::Result;
+#[cfg(unix)]
 use tokio::sync::{OnceCell, RwLock};
 
 use crate::config::egress::KeyArgs;
@@ -14,8 +15,10 @@ use crate::tunnel::egress::protocol::ohttp::security::key_manager::peer_shared::
 use crate::tunnel::egress::protocol::ohttp::security::key_manager::{
     self_generated::SelfGeneratedKeyManager, KeyManager,
 };
+#[cfg(unix)]
 use crate::tunnel::ohttp::protocol::KeyConfigResponse;
 use crate::tunnel::ra_context::RaContext;
+#[cfg(unix)]
 use crate::tunnel::utils::maybe_cached::MaybeCached;
 use crate::TokioRuntime;
 
@@ -37,6 +40,7 @@ pub struct OhttpServerApi {
     /// In passport mode, the server generates an attestation (passport) that is cached
     /// and reused for subsequent client requests to avoid expensive re-attestation.
     /// The cache automatically refreshes based on configured refresh strategy.
+    #[cfg(unix)]
     passport_cache: Arc<RwLock<OnceCell<MaybeCached<KeyConfigResponse, TngError>>>>,
 }
 
@@ -62,10 +66,13 @@ impl OhttpServerApi {
             }
         };
 
-        let passport_cache: Arc<RwLock<OnceCell<MaybeCached<KeyConfigResponse, TngError>>>> =
-            Default::default();
+        #[cfg(unix)]
+        let passport_cache: Arc<
+            RwLock<OnceCell<MaybeCached<KeyConfigResponse, TngError>>>,
+        > = Default::default();
 
         // Register a callback to reset the passport cache when key changes
+        #[cfg(unix)]
         {
             let passport_cache_cloned = passport_cache.clone();
             key_manager
@@ -82,6 +89,7 @@ impl OhttpServerApi {
         Ok(OhttpServerApi {
             ra_context,
             key_manager,
+            #[cfg(unix)]
             passport_cache,
         })
     }

--- a/tng/src/tunnel/egress/stream_manager/trusted.rs
+++ b/tng/src/tunnel/egress/stream_manager/trusted.rs
@@ -65,7 +65,7 @@ impl TrustedStreamManager {
                 .map(|a| a.multiplex)
                 .unwrap_or(true);
         let runtime = if is_h2_or_ohttp {
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             {
                 TokioRuntime::new_multi_thread(parent_runtime.shutdown_guard().clone())?
             }
@@ -74,7 +74,7 @@ impl TrustedStreamManager {
                 TokioRuntime::wasm_main_thread(parent_runtime.shutdown_guard().clone())?
             }
         } else {
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             {
                 TokioRuntime::current(parent_runtime.shutdown_guard().clone())?
             }

--- a/tng/src/tunnel/ingress/mod.rs
+++ b/tng/src/tunnel/ingress/mod.rs
@@ -1,9 +1,9 @@
 pub mod protocol;
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod stream_manager;
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod flow;
 #[cfg(feature = "ingress-http-proxy")]
 pub mod http_proxy;

--- a/tng/src/tunnel/ingress/protocol/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/mod.rs
@@ -1,33 +1,28 @@
 pub mod ohttp;
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod rats_tls;
 
-#[cfg(unix)]
-pub use unix_specific_module::*;
-#[cfg(unix)]
-mod unix_specific_module {
-    use std::{future::Future, net::SocketAddr, pin::Pin};
+use std::{future::Future, net::SocketAddr, pin::Pin};
 
-    use anyhow::Result;
-    use async_trait::async_trait;
+use anyhow::Result;
+use async_trait::async_trait;
 
-    use crate::{tunnel::endpoint::TngEndpoint, AttestationResult, CommonStreamTrait};
+use crate::{tunnel::endpoint::TngEndpoint, AttestationResult, CommonStreamTrait};
 
-    pub type ForwardTask = Pin<Box<dyn Future<Output = Result<()>> + std::marker::Send + 'static>>;
+pub type ForwardTask = Pin<Box<dyn Future<Output = Result<()>> + std::marker::Send + 'static>>;
 
-    pub type ProtocolStreamForwarderOutput = (
-        ForwardTask,
-        Option<AttestationResult>,
-        /* upstream_local */ Option<SocketAddr>,
-    );
+pub type ProtocolStreamForwarderOutput = (
+    ForwardTask,
+    Option<AttestationResult>,
+    /* upstream_local */ Option<SocketAddr>,
+);
 
-    #[async_trait]
-    pub trait ProtocolStreamForwarder {
-        async fn forward_stream<'a>(
-            &self,
-            endpoint: &'a TngEndpoint,
-            downstream: Box<dyn CommonStreamTrait + 'static>,
-        ) -> Result<ProtocolStreamForwarderOutput>;
-    }
+#[async_trait]
+pub trait ProtocolStreamForwarder {
+    async fn forward_stream<'a>(
+        &self,
+        endpoint: &'a TngEndpoint,
+        downstream: Box<dyn CommonStreamTrait + 'static>,
+    ) -> Result<ProtocolStreamForwarderOutput>;
 }

--- a/tng/src/tunnel/ingress/protocol/ohttp/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/mod.rs
@@ -1,9 +1,9 @@
 pub mod security;
 
-#[cfg(unix)]
-pub use unix_specific_module::*;
-#[cfg(unix)]
-mod unix_specific_module {
+#[cfg(not(wasm))]
+pub use ohttp_stream_forwarder::*;
+#[cfg(not(wasm))]
+mod ohttp_stream_forwarder {
 
     use std::{convert::Infallible, pin::Pin, sync::Arc};
 

--- a/tng/src/tunnel/ingress/protocol/ohttp/security/client.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/security/client.rs
@@ -24,7 +24,7 @@ use rats_cert::tee::ReportData;
 use rats_cert::tee::{GenericConverter, GenericVerifier as _};
 
 use crate::tunnel::provider::{ProviderType, TngEvidence, TngToken};
-#[cfg(unix)]
+#[cfg(not(wasm))]
 use tokio::io::AsyncReadExt;
 use tokio_util::{
     compat::{
@@ -339,7 +339,7 @@ impl OHttpClientInner {
     )> {
         #[cfg(not(unix))]
         {
-            return Ok((None, ClientAuth::NoAuth(NoAuth {}), Expire::NoExpire));
+            Ok((None, ClientAuth::NoAuth(NoAuth {}), Expire::NoExpire))
         }
 
         #[cfg(unix)]
@@ -482,9 +482,9 @@ impl OHttpClientInner {
             let client_request =
                 client.encapsulate_stream(futures::io::Cursor::new(&mut encrypted_request))?;
 
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             let (encrypted_request, request_write) = tokio::io::duplex(4096);
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             let client_request = client.encapsulate_stream(request_write.compat())?;
 
             let client_response_decapsulator = client_request.response_decapsulator()?;
@@ -514,7 +514,7 @@ impl OHttpClientInner {
             #[cfg(wasm)]
             let _: () = encryption_task.await;
 
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             self.runtime
                 .spawn_supervised_task_current_span(encryption_task);
 
@@ -552,7 +552,7 @@ impl OHttpClientInner {
                 tracing::debug!("Encrypted request body length: {:?}", body_bytes.len());
                 reqwest::Body::from(body_bytes.freeze())
             }
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             {
                 let body = std::io::Cursor::new(metadata_buf).chain(encrypted_request);
                 reqwest::Body::wrap_stream(tokio_util::io::ReaderStream::new(body))

--- a/tng/src/tunnel/ingress/stream_manager/mod.rs
+++ b/tng/src/tunnel/ingress/stream_manager/mod.rs
@@ -1,5 +1,4 @@
 pub mod trusted;
-#[cfg(unix)]
 pub mod unprotected;
 
 use std::{future::Future, net::SocketAddr, pin::Pin};

--- a/tng/src/tunnel/ingress/stream_manager/trusted.rs
+++ b/tng/src/tunnel/ingress/stream_manager/trusted.rs
@@ -50,7 +50,7 @@ impl TrustedStreamManager {
                 .map(|a| a.multiplex)
                 .unwrap_or(true);
         let runtime = if is_h2_or_ohttp {
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             {
                 TokioRuntime::new_multi_thread(parent_runtime.shutdown_guard().clone())?
             }
@@ -59,7 +59,7 @@ impl TrustedStreamManager {
                 TokioRuntime::wasm_main_thread(parent_runtime.shutdown_guard().clone())?
             }
         } else {
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             {
                 TokioRuntime::current(parent_runtime.shutdown_guard().clone())?
             }

--- a/tng/src/tunnel/ingress/stream_manager/unprotected.rs
+++ b/tng/src/tunnel/ingress/stream_manager/unprotected.rs
@@ -30,6 +30,13 @@ impl UnprotectedStreamManager {
     }
 }
 
+#[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+impl Default for UnprotectedStreamManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StreamManager for UnprotectedStreamManager {
     async fn forward_stream<'a>(
         &self,

--- a/tng/src/tunnel/mod.rs
+++ b/tng/src/tunnel/mod.rs
@@ -9,7 +9,7 @@ pub mod ingress;
 pub(crate) mod ohttp;
 pub(crate) mod provider;
 pub(crate) mod ra_context;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub(crate) mod service_metrics;
 pub(crate) mod stream;
 pub(crate) mod utils;

--- a/tng/src/tunnel/ra_context.rs
+++ b/tng/src/tunnel/ra_context.rs
@@ -24,7 +24,9 @@ use crate::config::ra::{CocoConverterArgs, ConverterArgs};
 use crate::tunnel::utils::maybe_cached::RefreshStrategy;
 
 #[cfg(unix)]
-use crate::tunnel::provider::{create_attester, TngAttester};
+use crate::tunnel::provider::create_attester;
+#[cfg(unix)]
+use crate::tunnel::provider::TngAttester;
 use crate::tunnel::provider::{create_converter, create_verifier, TngConverter, TngVerifier};
 
 /// Pre-instantiated RA context for OHTTP security
@@ -119,6 +121,7 @@ pub enum AttestContext {
 #[cfg(unix)]
 impl AttestContext {
     /// Create attestation context from AttestArgs configuration
+    #[cfg(unix)]
     pub async fn from_attest_args(attest_args: &AttestArgs) -> Result<Self> {
         match attest_args {
             AttestArgs::Passport {

--- a/tng/src/tunnel/utils/http_inspector.rs
+++ b/tng/src/tunnel/utils/http_inspector.rs
@@ -5,9 +5,17 @@ use bytes::BytesMut;
 use http::{uri::Authority, Uri};
 use scopeguard::defer;
 use tokio::io::{AsyncReadExt, AsyncWriteExt as _};
-#[cfg(unix)]
+#[cfg(not(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+)))]
 use tokio::time as tokio_time;
-#[cfg(wasm)]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+))]
 use tokio_with_wasm::alias::time as tokio_time;
 
 const HTTP_INSPECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);

--- a/tng/src/tunnel/utils/maybe_cached.rs
+++ b/tng/src/tunnel/utils/maybe_cached.rs
@@ -4,19 +4,27 @@ use std::cmp::{Ord, Ordering, PartialOrd};
 use std::{pin::Pin, sync::Arc, time::Duration};
 use tokio::select;
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 use tokio::task::JoinHandle;
 #[cfg(wasm)]
 use tokio_with_wasm::alias::task::JoinHandle;
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 use tokio::time as tokio_time;
 #[cfg(wasm)]
 use tokio_with_wasm::alias::time as tokio_time;
 
-#[cfg(unix)]
+#[cfg(not(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+)))]
 use std::time::SystemTime;
-#[cfg(wasm)]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+))]
 use web_time::SystemTime;
 
 use crate::tunnel::utils::runtime::{
@@ -141,7 +149,7 @@ impl<
                                 let expire_fut = match expire {
                                     Expire::NoExpire => {
                                         let fut = futures::future::pending();
-                                        #[cfg(unix)]
+                                        #[cfg(not(wasm))]
                                         let fut = fut.boxed();
                                         #[cfg(wasm)]
                                         let fut = fut.boxed_local();
@@ -154,7 +162,7 @@ impl<
                                             expire_time.duration_since(now).unwrap_or_default();
 
                                         let fut = tokio_time::sleep(duration);
-                                        #[cfg(unix)]
+                                        #[cfg(not(wasm))]
                                         let fut = fut.boxed();
                                         #[cfg(wasm)]
                                         let fut = fut.boxed_local();

--- a/tng/src/tunnel/utils/mod.rs
+++ b/tng/src/tunnel/utils/mod.rs
@@ -1,22 +1,21 @@
 #[cfg(unix)]
 pub mod cert_manager;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod endpoint_matcher;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod forward;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod http_inspector;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod hyper;
 #[cfg(target_os = "linux")]
 pub mod iptables;
 pub mod maybe_cached;
 pub mod runtime;
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod rustls;
-#[cfg(unix)]
 pub mod socket;
 pub mod tokio;
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub mod file_watcher;

--- a/tng/src/tunnel/utils/runtime/future.rs
+++ b/tng/src/tunnel/utils/runtime/future.rs
@@ -1,7 +1,7 @@
-#[cfg(unix)]
+#[cfg(not(wasm))]
 pub trait TokioRuntimeSupportedFuture<O>: std::future::Future<Output = O> + Send + 'static {}
 
-#[cfg(unix)]
+#[cfg(not(wasm))]
 impl<T, O> TokioRuntimeSupportedFuture<O> for T where
     T: std::future::Future<Output = O> + Send + 'static
 {

--- a/tng/src/tunnel/utils/runtime/mod.rs
+++ b/tng/src/tunnel/utils/runtime/mod.rs
@@ -37,19 +37,19 @@ pub struct TokioRuntime {
 
 #[derive(Debug)]
 enum TokioRuntimeInner {
-    #[cfg(unix)]
+    #[cfg(not(wasm))]
     Owned {
         rt: Option<tokio::runtime::Runtime>,
         rt_handle: tokio::runtime::Handle,
     },
-    #[cfg(unix)]
+    #[cfg(not(wasm))]
     Reference { rt_handle: tokio::runtime::Handle },
     #[cfg(wasm)]
     WasmMainThread,
 }
 
 impl TokioRuntime {
-    #[cfg(unix)]
+    #[cfg(not(wasm))]
     #[allow(dead_code)]
     pub fn new_multi_thread(shutdown_guard: ShutdownGuard) -> Result<Self> {
         use anyhow::Context;
@@ -68,7 +68,7 @@ impl TokioRuntime {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(not(wasm))]
     #[allow(dead_code)]
     pub fn current(shutdown_guard: ShutdownGuard) -> Result<Self> {
         let rt_handle = tokio::runtime::Handle::try_current()?;
@@ -104,12 +104,13 @@ impl TokioRuntime {
     {
         let this = self.clone();
         let handle = match self.inner.as_ref() {
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             TokioRuntimeInner::Owned { rt: _, rt_handle }
             | TokioRuntimeInner::Reference { rt_handle } => {
                 // Spawn a task with a name is a unstable feature
                 #[cfg(tokio_unstable)]
                 #[allow(clippy::disallowed_methods)]
+                #[allow(clippy::expect_used)]
                 let handle = tokio::task::Builder::new()
                     .name(name)
                     .spawn_on(
@@ -187,7 +188,7 @@ impl Drop for TokioRuntimeInner {
     /// Note: Only the `Owned` variant holds a `Runtime`; other variants require no special handling.
     fn drop(&mut self) {
         match self {
-            #[cfg(unix)]
+            #[cfg(not(wasm))]
             TokioRuntimeInner::Owned { rt, rt_handle: _ } => {
                 if let Some(rt_to_drop) = rt.take() {
                     match tokio::runtime::Handle::try_current() {

--- a/tng/src/tunnel/utils/rustls/config/client.rs
+++ b/tng/src/tunnel/utils/rustls/config/client.rs
@@ -1,17 +1,21 @@
+#[cfg(not(wasm))]
 use std::sync::Arc;
 
+#[cfg(not(wasm))]
 use anyhow::{Context as _, Result};
+#[cfg(not(wasm))]
 use rustls::RootCertStore;
 
-use crate::tunnel::utils::{
-    cert_manager::DynamicCertResolver,
-    rustls::{
-        config::{alpn::Alpn, TlsConfigGenerator},
-        dummy::verifier::DummyServerCertVerifier,
-        ra::server_cert_verifier::LazyServerCertVerifier,
-    },
+#[cfg(unix)]
+use crate::tunnel::utils::cert_manager::DynamicCertResolver;
+#[cfg(not(wasm))]
+use crate::tunnel::utils::rustls::{
+    config::{alpn::Alpn, TlsConfigGenerator},
+    dummy::verifier::DummyServerCertVerifier,
+    ra::server_cert_verifier::LazyServerCertVerifier,
 };
 
+#[cfg(not(wasm))]
 impl TlsConfigGenerator {
     pub async fn get_lazy_one_time_rustls_client_config(
         &self,
@@ -91,8 +95,10 @@ impl TlsConfigGenerator {
     }
 }
 
+#[cfg(not(wasm))]
 pub struct LazyOnetimeTlsClientConfig(rustls::ClientConfig, Option<Arc<LazyServerCertVerifier>>);
 
+#[cfg(not(wasm))]
 impl LazyOnetimeTlsClientConfig {
     /// Perform TLS handshake then verify the peer certificate if a verifier was configured.
     pub async fn handshake_with_stream<S>(

--- a/tng/src/tunnel/utils/rustls/config/mod.rs
+++ b/tng/src/tunnel/utils/rustls/config/mod.rs
@@ -1,11 +1,14 @@
 pub mod alpn;
 pub mod client;
+#[cfg(not(wasm))]
 pub mod server;
 
 use std::sync::Arc;
 
 use crate::tunnel::ra_context::{RaContext, VerifyContext};
-use crate::tunnel::utils::{cert_manager::CertManager, runtime::TokioRuntime};
+#[cfg(unix)]
+use crate::tunnel::utils::cert_manager::CertManager;
+use crate::tunnel::utils::runtime::TokioRuntime;
 use anyhow::Result;
 
 pub enum TlsConfigGenerator {
@@ -18,12 +21,15 @@ pub enum TlsConfigGenerator {
 }
 
 impl TlsConfigGenerator {
+    #[allow(unused_variables)]
     pub async fn new(ra_context: Arc<RaContext>, runtime: TokioRuntime) -> Result<Self> {
         Ok(match ra_context.as_ref() {
+            #[cfg(unix)]
             RaContext::AttestOnly(attest_ctx) => Self::Attest(Arc::new(
                 CertManager::new(attest_ctx.clone(), runtime).await?,
             )),
             RaContext::VerifyOnly(verify_ctx) => Self::Verify(verify_ctx.clone()),
+            #[cfg(unix)]
             RaContext::AttestAndVerify { attest, verify } => Self::AttestAndVerify(
                 Arc::new(CertManager::new(attest.clone(), runtime).await?),
                 verify.clone(),

--- a/tng/src/tunnel/utils/rustls/config/server.rs
+++ b/tng/src/tunnel/utils/rustls/config/server.rs
@@ -3,13 +3,12 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use rustls::ServerConfig;
 
-use crate::tunnel::utils::{
-    cert_manager::DynamicCertResolver,
-    rustls::{
-        config::{alpn::Alpn, TlsConfigGenerator},
-        dummy::RustlsDummyCert,
-        ra::client_cert_verifier::LazyClientCertVerifier,
-    },
+#[cfg(unix)]
+use crate::tunnel::utils::cert_manager::DynamicCertResolver;
+use crate::tunnel::utils::rustls::{
+    config::{alpn::Alpn, TlsConfigGenerator},
+    dummy::RustlsDummyCert,
+    ra::client_cert_verifier::LazyClientCertVerifier,
 };
 
 impl TlsConfigGenerator {
@@ -33,6 +32,7 @@ impl TlsConfigGenerator {
                         .with_cert_resolver(RustlsDummyCert::new_rustls_cert()?);
                 LazyOnetimeTlsServerConfig(tls_server_config, Some(verifier))
             }
+            #[cfg(unix)]
             TlsConfigGenerator::Attest(cert_manager) => {
                 let tls_server_config: ServerConfig =
                     ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
@@ -42,6 +42,7 @@ impl TlsConfigGenerator {
                         )));
                 LazyOnetimeTlsServerConfig(tls_server_config, None)
             }
+            #[cfg(unix)]
             TlsConfigGenerator::AttestAndVerify(cert_manager, verify_ctx) => {
                 let verifier = Arc::new(LazyClientCertVerifier::new(verify_ctx.clone())?);
                 let tls_server_config: ServerConfig =
@@ -120,6 +121,7 @@ impl TlsConfigGenerator {
                         .with_cert_resolver(RustlsDummyCert::new_rustls_cert()?);
                 BlockingOnetimeTlsServerConfig(tls_server_config)
             }
+            #[cfg(unix)]
             TlsConfigGenerator::Attest(cert_manager) => {
                 let tls_server_config: ServerConfig =
                     ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
@@ -129,6 +131,7 @@ impl TlsConfigGenerator {
                         )));
                 BlockingOnetimeTlsServerConfig(tls_server_config)
             }
+            #[cfg(unix)]
             TlsConfigGenerator::AttestAndVerify(cert_manager, verify_ctx) => {
                 let verifier = Arc::new(BlockingClientCertVerifier::new(verify_ctx.clone())?);
                 let tls_server_config: ServerConfig =

--- a/tng/src/tunnel/utils/rustls/ra/mod.rs
+++ b/tng/src/tunnel/utils/rustls/ra/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(not(wasm))]
 pub mod client_cert_verifier;
 pub mod common;
+#[cfg(not(wasm))]
 pub mod server_cert_verifier;

--- a/tng/src/tunnel/utils/socket.rs
+++ b/tng/src/tunnel/utils/socket.rs
@@ -1,9 +1,3 @@
-use std::os::fd::AsFd;
-
-use anyhow::{anyhow, Context, Result};
-use nix::sys::socket::setsockopt;
-use tokio::net::TcpStream;
-
 #[allow(dead_code)]
 pub const TCP_KEEPALIVE_IDLE_SECS: u32 = 10;
 #[allow(dead_code)]
@@ -13,6 +7,12 @@ pub const TCP_KEEPALIVE_PROBE_COUNT: u32 = 3;
 #[allow(dead_code)]
 pub const TCP_CONNECT_SO_MARK_DEFAULT: u32 = 0x235; // 565
 
+#[cfg(not(wasm))]
+use anyhow::{Context, Result};
+#[cfg(not(wasm))]
+use tokio::net::TcpStream;
+
+#[cfg(not(wasm))]
 pub trait SetListenerSockOpts {
     fn set_listener_common_sock_opts(&self) -> Result<()>;
 
@@ -24,15 +24,34 @@ pub trait SetListenerSockOpts {
     ) -> std::io::Result<(TcpStream, std::net::SocketAddr)>;
 }
 
+#[cfg(not(wasm))]
 impl SetListenerSockOpts for tokio::net::TcpListener {
+    #[cfg(unix)]
     fn set_listener_common_sock_opts(&self) -> Result<()> {
         set_tcp_common_sock_opts(self)
     }
 
+    #[cfg(windows)]
+    fn set_listener_common_sock_opts(&self) -> Result<()> {
+        use std::os::windows::io::{AsRawSocket, FromRawSocket};
+
+        let raw_socket = self.as_raw_socket();
+        let socket = unsafe { socket2::Socket::from_raw_socket(raw_socket) };
+        let _ = socket.set_keepalive(true).map_err(|e| {
+            tracing::warn!(error = ?e, "set SO_KEEPALIVE failed");
+            e
+        });
+        std::mem::forget(socket);
+
+        Ok(())
+    }
+
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     fn set_listener_tproxy_sock_opts(&self) -> Result<()> {
+        use std::os::fd::AsFd;
+
         let fd = self.as_fd();
-        setsockopt(&fd, nix::sys::socket::sockopt::IpTransparent, &true)?;
+        nix::sys::socket::setsockopt(&fd, nix::sys::socket::sockopt::IpTransparent, &true)?;
 
         Ok(())
     }
@@ -49,29 +68,32 @@ impl SetListenerSockOpts for tokio::net::TcpListener {
     }
 }
 
-pub fn set_tcp_common_sock_opts(as_fs: impl AsFd) -> Result<()> {
+#[cfg(unix)]
+pub fn set_tcp_common_sock_opts(as_fs: impl std::os::fd::AsFd) -> Result<()> {
     let fd = as_fs.as_fd();
 
     // Enable SO_KEEPALIVE
-    if let Err(error) = setsockopt(&fd, nix::sys::socket::sockopt::KeepAlive, &true) {
+    if let Err(error) =
+        nix::sys::socket::setsockopt(&fd, nix::sys::socket::sockopt::KeepAlive, &true)
+    {
         tracing::warn!(?error, "set SO_KEEPALIVE failed")
     }
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-    if let Err(error) = setsockopt(
+    if let Err(error) = nix::sys::socket::setsockopt(
         &fd,
         nix::sys::socket::sockopt::TcpKeepIdle,
         &TCP_KEEPALIVE_IDLE_SECS,
     ) {
         tracing::warn!(?error, "set TCP_KEEPIDLE failed")
     };
-    if let Err(error) = setsockopt(
+    if let Err(error) = nix::sys::socket::setsockopt(
         &fd,
         nix::sys::socket::sockopt::TcpKeepInterval,
         &TCP_KEEPALIVE_INTERVAL_SECS,
     ) {
         tracing::warn!(?error, "set TCP_KEEPINTVL failed")
     };
-    if let Err(error) = setsockopt(
+    if let Err(error) = nix::sys::socket::setsockopt(
         &fd,
         nix::sys::socket::sockopt::TcpKeepCount,
         &TCP_KEEPALIVE_PROBE_COUNT,
@@ -89,6 +111,19 @@ pub fn set_tcp_common_sock_opts(as_fs: impl AsFd) -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
+pub fn set_tcp_common_sock_opts(socket: &socket2::Socket) -> Result<()> {
+    socket.set_keepalive(true).unwrap_or_else(|e| {
+        tracing::warn!(error = ?e, "set SO_KEEPALIVE failed");
+    });
+
+    // Note: detailed keepalive params (idle/interval/count) are not set on Windows
+    // to avoid platform-specific socket option dependencies.
+
+    Ok(())
+}
+
+#[cfg(not(wasm))]
 pub async fn tcp_connect<T>(
     host: T,
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
@@ -134,5 +169,5 @@ where
         last_result = Some(result);
     }
 
-    last_result.unwrap_or_else(|| Err(anyhow!("No address resolved")))
+    last_result.unwrap_or_else(|| Err(anyhow::anyhow!("No address resolved")))
 }


### PR DESCRIPTION
## Summary

Add Windows target to CI matrix, Makefile, and fix all cross-platform compilation issues.

## Changes

### CI & Build
- Add `x86_64-pc-windows-gnu` to build-binary.yml matrix
- Add `windows-cross-build` Makefile target using cargo zigbuild
- Enable `.zip` artifact upload in release workflow

### Platform Gates
- Gate Unix-only modules with `#[cfg(not(wasm))]` where they are available on both Unix and Windows but not WASM (control_interface, observability, runtime, service, state, endpoint_matcher, forward, http_inspector, hyper, rustls, file_watcher, etc.)
- Gate attestation-only code with `#[cfg(unix)]` since attestation is only available on Unix-like systems (AttestContext, TngAttester, passport_cache, create_attester factory, attestation imports)
- Consolidate redundant cfg patterns: merge separate `#[cfg(unix)]` and `#[cfg(windows)]` blocks with identical code into `#[cfg(not(wasm))]` (trusted.rs runtime creation, maybe_cached.rs imports and boxed futures, ohttp client.rs encryption paths)

### main.rs
- Restore `#[tokio::main] async fn main()` style
- Gate tokio_console (console-subscriber) with `#[cfg(unix)]`
- Warn and ignore `--tokio-console` on non-Unix platforms

### Clippy Fixes for Windows Target
- Allow `clippy::large_enum_variant` on RaArgs (VerifyOnly variant)
- Fix `clippy::needless_return` in ohttp security client
- Add Default impl for UnprotectedStreamManager on non-Linux
- Fix setsockopt value argument types in socket.rs
- Gate Netfilter variants with `target_os = "linux"`
- Gate transport_so_mark with `target_os = "linux"`-like

## Verification

All build targets pass with zero warnings:
- ✅ Linux native `cargo build` + `make clippy`
- ✅ Windows `cargo clippy --target x86_64-pc-windows-gnu -- -D warnings`
- ✅ WASM `make wasm-build-release`
- ✅ macOS compilation
- ✅ `cargo fmt --check`