### PR TITLE
ci(test): update codecov-action to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
           cat /tmp/as.log 2>/dev/null || echo "(no log file)"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         # We only need to upload coverage report once
         if: ${{ matrix.distro == 'alinux3' }}
         with:


### PR DESCRIPTION
Fix codecov upload failure in CI workflow. The v5 action version encounters errors that prevent coverage reports from being uploaded. Upgrading to v7 resolves this issue with the latest uploader compatibility.

https://github.com/codecov/codecov-action/issues/1956