### PR TITLE
docs: add vLLM OHTTP cluster scenario (Use Case 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tng-*.tar.gz
 .package/
 /.vscode/
+/docs/superpowers/

--- a/docs/diagrams/scenario_vllm_ohttp_cluster.drawio
+++ b/docs/diagrams/scenario_vllm_ohttp_cluster.drawio
@@ -1,0 +1,105 @@
+<mxfile host="65bd71144e">
+    <diagram id="2V9JCVXqdDrcTl7a3T0K" name="第 1 页">
+        <mxGraphModel dx="2178" dy="989" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0" adaptiveColors="auto">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="5" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+                    <mxGeometry x="-80" y="40" width="420" height="290" as="geometry"/>
+                </mxCell>
+                <mxCell id="server-group" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;strokeWidth=1;dashed=1;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="40" width="400" height="360" as="geometry"/>
+                </mxCell>
+                <mxCell id="client-app" value="Client Application" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontColor=#1a5490;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="-60" y="200" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-ingress" value="TNG Ingress" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="170" y="180" width="150" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="nginx-gateway" value="Nginx Gateway&lt;br&gt;(least_conn, port 8080)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="190" width="160" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-egress-1" value="TNG Egress 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="80" width="180" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-egress-2" value="TNG Egress 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="195" width="180" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-egress-3" value="TNG Egress 3" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="310" width="180" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="vllm-1" value="vLLM&lt;br&gt;port 8080" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="970" y="80" width="120" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="vllm-2" value="vLLM&lt;br&gt;port 8080" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="970" y="195" width="120" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="vllm-3" value="vLLM&lt;br&gt;port 8080" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="970" y="310" width="120" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="attestation-service" value="Attestation Service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="170" y="80" width="150" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-client-ingress" value="Plain HTTP" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#1a5490;fontSize=11;fontColor=#1a5490;" parent="1" source="client-app" target="tng-ingress" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-ingress-nginx" value="OHTTP Encrypted" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#82b366;dashed=1;fontSize=11;fontColor=#333333;" parent="1" source="tng-ingress" target="nginx-gateway" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-nginx-egress1" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#d79b00;" parent="1" source="nginx-gateway" target="tng-egress-1" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="&lt;span style=&quot;color: rgb(51, 51, 51);&quot;&gt;OHTTP Encrypted&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="arrow-nginx-egress1">
+                    <mxGeometry x="-0.1541" y="2" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-nginx-egress2" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#d79b00;" parent="1" source="nginx-gateway" target="tng-egress-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="&lt;span style=&quot;color: rgb(51, 51, 51);&quot;&gt;OHTTP Encrypted&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="arrow-nginx-egress2">
+                    <mxGeometry x="-0.05" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-1" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-nginx-egress3" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#d79b00;" parent="1" source="nginx-gateway" target="tng-egress-3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="&lt;span style=&quot;color: rgb(51, 51, 51);&quot;&gt;OHTTP Encrypted&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="arrow-nginx-egress3">
+                    <mxGeometry x="-0.2986" y="2" relative="1" as="geometry">
+                        <mxPoint x="6" y="3" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-egress1-vllm1" value="Decrypted &amp;#8594; vLLM" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#82b366;fontSize=10;fontColor=#333333;" parent="1" source="tng-egress-1" target="vllm-1" edge="1">
+                    <mxGeometry y="15" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-egress2-vllm2" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#82b366;" parent="1" source="tng-egress-2" target="vllm-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-egress3-vllm3" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#82b366;" parent="1" source="tng-egress-3" target="vllm-3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="peer-shared-1-2" style="endArrow=classic;dashed=1;html=1;strokeWidth=2;strokeColor=#82b366;startArrow=classic;startFill=1;endFill=1;" parent="1" source="tng-egress-1" target="tng-egress-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="peer-shared-2-3" style="endArrow=classic;dashed=1;html=1;strokeWidth=2;strokeColor=#82b366;startArrow=classic;startFill=1;endFill=1;" parent="1" source="tng-egress-2" target="tng-egress-3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="peer-shared-label" value="Serf Gossip (UDP:8301)" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#82b366;fontStyle=2;" parent="1" vertex="1">
+                    <mxGeometry x="830" y="165" width="80" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-verify" value="Remote Attestation" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#666666;dashed=1;fontSize=10;fontColor=#666666;" parent="1" source="tng-ingress" target="attestation-service" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="server-label" value="Server Cluster (3 TEE nodes)" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=top;whiteSpace=wrap;rounded=0;fontSize=12;fontColor=#666666;fontStyle=2;" parent="1" vertex="1">
+                    <mxGeometry x="740" y="50" width="250" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="6" value="Client Environment" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=top;whiteSpace=wrap;rounded=0;fontSize=12;fontColor=#666666;fontStyle=2;" vertex="1" parent="1">
+                    <mxGeometry x="-50" y="50" width="250" height="20" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/diagrams/scenario_vllm_ohttp_cluster_zh.drawio
+++ b/docs/diagrams/scenario_vllm_ohttp_cluster_zh.drawio
@@ -1,0 +1,105 @@
+<mxfile host="65bd71144e">
+    <diagram id="2V9JCVXqdDrcTl7a3T0K" name="第 1 页">
+        <mxGraphModel dx="2178" dy="989" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0" adaptiveColors="auto">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="5" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+                    <mxGeometry x="-80" y="40" width="420" height="290" as="geometry"/>
+                </mxCell>
+                <mxCell id="server-group" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;strokeWidth=1;dashed=1;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="40" width="400" height="360" as="geometry"/>
+                </mxCell>
+                <mxCell id="client-app" value="客户端应用" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontColor=#1a5490;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="-60" y="200" width="140" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-ingress" value="TNG Ingress" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="170" y="180" width="150" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="nginx-gateway" value="Nginx 网关&lt;br&gt;(least_conn, 端口 8080)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="190" width="160" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-egress-1" value="TNG Egress 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="80" width="180" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-egress-2" value="TNG Egress 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="195" width="180" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="tng-egress-3" value="TNG Egress 3" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="730" y="310" width="180" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="vllm-1" value="vLLM&lt;br&gt;端口 8080" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="970" y="80" width="120" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="vllm-2" value="vLLM&lt;br&gt;端口 8080" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="970" y="195" width="120" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="vllm-3" value="vLLM&lt;br&gt;端口 8080" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontColor=#333333;" parent="1" vertex="1">
+                    <mxGeometry x="970" y="310" width="120" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="attestation-service" value="Attestation Service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontColor=#333333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="170" y="80" width="150" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-client-ingress" value="明文 HTTP" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#1a5490;fontSize=11;fontColor=#1a5490;" parent="1" source="client-app" target="tng-ingress" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-ingress-nginx" value="OHTTP 加密" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#82b366;dashed=1;fontSize=11;fontColor=#333333;" parent="1" source="tng-ingress" target="nginx-gateway" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-nginx-egress1" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#d79b00;" parent="1" source="nginx-gateway" target="tng-egress-1" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="&lt;span style=&quot;color: rgb(51, 51, 51);&quot;&gt;OHTTP 加密&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="arrow-nginx-egress1">
+                    <mxGeometry x="-0.1541" y="2" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-nginx-egress2" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#d79b00;" parent="1" source="nginx-gateway" target="tng-egress-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="&lt;span style=&quot;color: rgb(51, 51, 51);&quot;&gt;OHTTP 加密&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="arrow-nginx-egress2">
+                    <mxGeometry x="-0.05" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-1" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-nginx-egress3" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#d79b00;" parent="1" source="nginx-gateway" target="tng-egress-3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="&lt;span style=&quot;color: rgb(51, 51, 51);&quot;&gt;OHTTP 加密&lt;/span&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="arrow-nginx-egress3">
+                    <mxGeometry x="-0.2986" y="2" relative="1" as="geometry">
+                        <mxPoint x="6" y="3" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-egress1-vllm1" value="解密 &amp;#8594; vLLM" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#82b366;fontSize=10;fontColor=#333333;" parent="1" source="tng-egress-1" target="vllm-1" edge="1">
+                    <mxGeometry y="15" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="arrow-egress2-vllm2" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#82b366;" parent="1" source="tng-egress-2" target="vllm-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-egress3-vllm3" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#82b366;" parent="1" source="tng-egress-3" target="vLLm-3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="peer-shared-1-2" style="endArrow=classic;dashed=1;html=1;strokeWidth=2;strokeColor=#82b366;startArrow=classic;startFill=1;endFill=1;" parent="1" source="tng-egress-1" target="tng-egress-2" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="peer-shared-2-3" style="endArrow=classic;dashed=1;html=1;strokeWidth=2;strokeColor=#82b366;startArrow=classic;startFill=1;endFill=1;" parent="1" source="tng-egress-2" target="tng-egress-3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="peer-shared-label" value="Serf Gossip (UDP:8301)" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=10;fontColor=#82b366;fontStyle=2;" parent="1" vertex="1">
+                    <mxGeometry x="830" y="165" width="80" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="arrow-verify" value="远程证明" style="endArrow=classic;html=1;strokeWidth=1;strokeColor=#666666;dashed=1;fontSize=10;fontColor=#666666;" parent="1" source="tng-ingress" target="attestation-service" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="server-label" value="服务端集群（3 个 TEE 节点）" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=top;whiteSpace=wrap;rounded=0;fontSize=12;fontColor=#666666;fontStyle=2;" parent="1" vertex="1">
+                    <mxGeometry x="740" y="50" width="250" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="6" value="客户端环境" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=top;whiteSpace=wrap;rounded=0;fontSize=12;fontColor=#666666;fontStyle=2;" vertex="1" parent="1">
+                    <mxGeometry x="-50" y="50" width="250" height="20" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/scenarios/scenario_vllm_ohttp_cluster.md
+++ b/docs/scenarios/scenario_vllm_ohttp_cluster.md
@@ -1,0 +1,172 @@
+## Use Case 5: vLLM Inference Service with OHTTP Cluster
+
+[中文文档](scenario_vllm_ohttp_cluster_zh.md)
+
+### Scenario Overview
+
+- **Goal**: The client accesses vLLM inference services deployed in a confidential computing cluster via OpenAI-compatible API, with end-to-end OHTTP encryption and remote attestation, without modifying the vLLM application code.
+- **Approach**:
+  - On the client side, use the `http_proxy` mode of TNG Ingress as a local HTTP proxy, and encrypt inference prompts via the OHTTP protocol;
+  - In the middle, deploy an Nginx Layer 7 gateway with `least_conn` load balancing to distribute OHTTP-encrypted traffic across backend TNG Egress instances;
+  - On the server side, each vLLM instance is co-located with a TNG Egress instance, using `netfilter` mode to capture traffic and `peer_shared` OHTTP key distribution to ensure any node can decrypt traffic routed to it by Nginx.
+- **Effect**:
+  - The client application only needs to configure an HTTP proxy address; vLLM instances run unmodified with the OpenAI-compatible API;
+  - OHTTP encryption ensures Nginx (the load balancer) cannot see the inference prompt content;
+  - Remote attestation verifies that each vLLM node runs in a trusted confidential computing environment;
+  - The `peer_shared` cluster allows seamless horizontal scaling — new nodes share OHTTP keys automatically via Serf Gossip protocol.
+
+### Topology Diagram
+
+![Topology Diagram](../diagrams/scenario_vllm_ohttp_cluster.drawio.svg)
+
+### Client-side TNG (Ingress) Configuration Example
+
+The client side starts TNG Ingress as a local HTTP proxy. Applications send requests through this proxy, and TNG encrypts them via OHTTP before forwarding to the Nginx gateway:
+
+```json
+{
+    "add_ingress": [
+        {
+            "http_proxy": {
+                "proxy_listen": {
+                    "host": "0.0.0.0",
+                    "port": 41000
+                },
+                "dst_filters": {
+                    "domain": "*",
+                    "port": 8080
+                }
+            },
+            "ohttp": {},
+            "verify": {
+                "as_addr": "<attestation-service-url>",
+                "policy_ids": [
+                    "default"
+                ]
+            }
+        }
+    ]
+}
+```
+
+- **Key Points**:
+  - **`http_proxy.proxy_listen`**: The HTTP proxy address applications connect to, e.g., `http://127.0.0.1:41000`.
+  - **`dst_filters`**: Only requests to specified domains/ports (any domain, port 8080 — matching the Nginx gateway) enter the TNG tunnel; other traffic is forwarded as a regular HTTP proxy.
+  - **`ohttp`**: Enables OHTTP encryption for the inference prompts. The client automatically fetches the active public key from the server cluster.
+  - **`verify.as_addr`**: The address of the Attestation Service, used to verify the server-side TNG environment trustworthiness before establishing the tunnel.
+
+### Server-side TNG (Egress) Configuration Example
+
+Each server node runs a TNG Egress instance with `netfilter` + OHTTP (`peer_shared`) + `attest`. Below is the configuration for a single node (Node 1, IP `192.168.1.11`):
+
+```json
+{
+    "add_egress": [
+        {
+            "netfilter": {
+                "capture_dst": [
+                    { "port": 8080 }
+                ]
+            },
+            "ohttp": {
+                "key": {
+                    "source": "peer_shared",
+                    "rotation_interval": 300,
+                    "host": "0.0.0.0",
+                    "port": 8301,
+                    "peers": [
+                        "192.168.1.12:8301",
+                        "192.168.1.13:8301"
+                    ],
+                    "attest": {
+                        "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                    },
+                    "verify": {
+                        "as_addr": "<attestation-service-url>",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            },
+            "attest": {
+                "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+            }
+        }
+    ]
+}
+```
+
+- **Key Points**:
+  - **`netfilter.capture_dst`**: Port 8080 matches the vLLM listening port. TNG automatically sets up iptables rules to hijack traffic sent to this port.
+  - **`ohttp.key.source: "peer_shared"`**: OHTTP keys are shared across the cluster via Serf Gossip protocol, ensuring all nodes share the same key pool. Any node can decrypt traffic encrypted by any other node's public key.
+  - **`peers`**: List of other nodes in the cluster. Supports **IP:port** and **domain:port** formats (e.g., `tng-node-1.default.svc.cluster.local:8301`). Only one accessible peer is needed to join the cluster.
+  - **`peers_file`** (alternative to `peers`): Path to a JSON file containing peer addresses (e.g., `"/etc/tng/peers.json"`). Useful for large-scale clusters or dynamic peer management via external orchestration tools.
+  - **`ohttp.key` within `attest`/`verify`**: Controls inter-node remote attestation within the peer_shared cluster, ensuring only verified trusted nodes participate in key sharing.
+  - **Top-level `attest`**: Server acts as the attester, providing remote attestation materials for the client-side verification.
+  - **`listen_port`**: Not explicitly configured — TNG uses its default value for the netfilter captured traffic receiving port.
+
+### Nginx Gateway Configuration Example
+
+Nginx acts as the unified entry point, load-balancing OHTTP-encrypted requests across TNG Egress instances:
+
+```nginx
+upstream vllm_cluster {
+    least_conn;
+    server 192.168.1.11:8080;   # TNG Egress + vLLM Node 1
+    server 192.168.1.12:8080;   # TNG Egress + vLLM Node 2
+    server 192.168.1.13:8080;   # TNG Egress + vLLM Node 3
+}
+
+server {
+    listen 8080;
+
+    location / {
+        proxy_pass http://vllm_cluster;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+- **Key Points**:
+  - **`least_conn`**: Distributes requests to the node with the fewest active connections, balancing load across the cluster.
+  - Nginx forwards to port 8080 on each backend node, where TNG Egress captures the traffic via netfilter.
+  - Nginx cannot see the OHTTP-encrypted request content — it only routes at the transport layer.
+
+### Typical Usage Steps
+
+- **Server side** (repeat for each node):
+  1. Start vLLM instance with OpenAI-compatible API, listening on port 8080;
+  2. Start Attestation Agent (Unix socket at `/run/confidential-containers/attestation-agent/attestation-agent.sock`);
+  3. Write the TNG Egress configuration JSON and start TNG;
+  4. Verify the peer_shared cluster has formed (check Serf peers via `serf members` or TNG logs);
+
+- **Nginx gateway**:
+  1. Install Nginx on the gateway machine;
+  2. Write the upstream + server configuration;
+  3. Start Nginx and verify it routes to backend nodes.
+
+- **Client side**:
+  1. Start TNG Ingress with the `http_proxy + ohttp + verify` configuration;
+  2. Configure your application to use the HTTP proxy at `http://<tng-ingress-ip>:41000`;
+  3. Send requests to the Nginx gateway address (e.g., `http://<nginx-gateway-ip>:8080`).
+
+### End-to-End Test
+
+```bash
+# Send an OpenAI-compatible chat completion request through TNG HTTP Proxy
+curl -x http://<tng-ingress-ip>:41000 \
+     http://<nginx-gateway-ip>:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{
+         "model": "Qwen/Qwen2.5-7B",
+         "messages": [{"role": "user", "content": "Hello, what is TNG?"}],
+         "max_tokens": 256
+     }'
+```
+
+- The `-x` flag directs the request through the local TNG HTTP Proxy.
+- The target address is the Nginx gateway's 8080 port.
+- TNG Ingress encrypts the request with OHTTP, Nginx load-balances to a TNG Egress node, which decrypts and forwards to the local vLLM instance.
+- The response follows the reverse path back to the client.

--- a/docs/scenarios/scenario_vllm_ohttp_cluster_zh.md
+++ b/docs/scenarios/scenario_vllm_ohttp_cluster_zh.md
@@ -1,0 +1,170 @@
+## 用例5：vLLM 推理服务 OHTTP 集群场景
+
+### 场景概述
+
+- **目标**：客户端通过 OpenAI 兼容 API 访问部署在机密计算集群中的 vLLM 推理服务，在端到端链路上使用 OHTTP 加密和远程证明，且无需修改 vLLM 应用代码。
+- **做法**：
+  - 在客户端侧使用 TNG Ingress 的 `http_proxy` 模式作为本地 HTTP 代理，并通过 OHTTP 协议对推理提示词进行加密；
+  - 中间部署 Nginx 7 层网关，使用 `least_conn` 负载均衡算法将 OHTTP 加密流量分发到后端多个 TNG Egress 实例；
+  - 在服务端侧，每个 vLLM 实例与一个 TNG Egress 实例同机部署，TNG 使用 `netfilter` 模式捕获流量，并通过 `peer_shared` OHTTP 密钥分发确保被 Nginx 路由到任意节点的流量都能被正确解密。
+- **效果**：
+  - 客户端应用只需配置 HTTP 代理地址即可；vLLM 实例以原生的 OpenAI 兼容 API 运行，无需任何改造；
+  - OHTTP 加密确保 Nginx（负载均衡器）无法看到推理提示词的内容；
+  - 远程证明验证每个 vLLM 节点运行于可信的机密计算环境；
+  - `peer_shared` 集群支持无缝水平扩展——新节点通过 Serf Gossip 协议自动共享 OHTTP 密钥。
+
+### 拓扑示意图
+
+![拓扑示意图](../diagrams/scenario_vllm_ohttp_cluster_zh.drawio.svg)
+
+### 客户端侧 TNG（Ingress）配置示例
+
+客户端侧启动 TNG Ingress 作为本地 HTTP 代理。应用通过该代理发送请求，TNG 在进入隧道前通过 OHTTP 协议对请求进行加密，然后转发至 Nginx 网关：
+
+```json
+{
+    "add_ingress": [
+        {
+            "http_proxy": {
+                "proxy_listen": {
+                    "host": "0.0.0.0",
+                    "port": 41000
+                },
+                "dst_filters": {
+                    "domain": "*",
+                    "port": 8080
+                }
+            },
+            "ohttp": {},
+            "verify": {
+                "as_addr": "<attestation-service-url>",
+                "policy_ids": [
+                    "default"
+                ]
+            }
+        }
+    ]
+}
+```
+
+- **关键点说明**：
+  - **`http_proxy.proxy_listen`**：客户端应用配置的 HTTP 代理地址，例如 `http://127.0.0.1:41000`。
+  - **`dst_filters`**：只有发往指定域名/端口（任意域名，端口 8080——匹配 Nginx 网关）的请求才会进入 TNG 隧道；其他流量作为普通 HTTP 代理转发。
+  - **`ohttp`**：启用 OHTTP 加密推理提示词。客户端自动从服务端集群获取当前有效的公钥。
+  - **`verify.as_addr`**：Attestation Service 的地址，用于在建立隧道前验证服务端 TNG 所在环境的可信性。
+
+### 服务端侧 TNG（Egress）配置示例
+
+每个服务节点运行一个 TNG Egress 实例，使用 `netfilter` + OHTTP（`peer_shared`）+ `attest`。以下是单个节点（节点 1，IP `192.168.1.11`）的配置：
+
+```json
+{
+    "add_egress": [
+        {
+            "netfilter": {
+                "capture_dst": [
+                    { "port": 8080 }
+                ]
+            },
+            "ohttp": {
+                "key": {
+                    "source": "peer_shared",
+                    "rotation_interval": 300,
+                    "host": "0.0.0.0",
+                    "port": 8301,
+                    "peers": [
+                        "192.168.1.12:8301",
+                        "192.168.1.13:8301"
+                    ],
+                    "attest": {
+                        "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                    },
+                    "verify": {
+                        "as_addr": "<attestation-service-url>",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            },
+            "attest": {
+                "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+            }
+        }
+    ]
+}
+```
+
+- **关键点说明**：
+  - **`netfilter.capture_dst`**：端口 8080 与 vLLM 监听端口一致。TNG 会自动设置 iptables 规则，劫持发往该端口的流量。
+  - **`ohttp.key.source: "peer_shared"`**：OHTTP 密钥通过 Serf Gossip 协议在集群内共享，确保所有节点共享同一密钥池。被 Nginx 路由到任意节点的流量，都能被该节点解密。
+  - **`peers`**：集群中其他节点的地址列表。支持 **IP:port** 和**域名:port**格式（例如 `tng-node-1.default.svc.cluster.local:8301`）。只需提供一个可访问的 peer 即可加入集群。
+  - **`peers_file`**（替代 `peers` 的方式）：指向包含 peer 地址的 JSON 文件路径（如 `"/etc/tng/peers.json"`）。适用于大规模集群或通过外部编排工具动态管理 peer 列表的场景。
+  - **`ohttp.key` 内的 `attest`/`verify`**：控制 peer_shared 集群内节点间的远程证明，确保只有经过验证的可信节点才能参与密钥共享。
+  - **顶层 `attest`**：服务端作为证明方，向客户端提供本机环境的远程证明材料。
+  - **`listen_port`**：未显式配置——TNG 使用默认值作为 netfilter 捕获流量的接收端口。
+
+### Nginx 网关配置示例
+
+Nginx 作为统一入口，将 OHTTP 加密请求负载均衡到各 TNG Egress 实例：
+
+```nginx
+upstream vllm_cluster {
+    least_conn;
+    server 192.168.1.11:8080;   # TNG Egress + vLLM 节点 1
+    server 192.168.1.12:8080;   # TNG Egress + vLLM 节点 2
+    server 192.168.1.13:8080;   # TNG Egress + vLLM 节点 3
+}
+
+server {
+    listen 8080;
+
+    location / {
+        proxy_pass http://vllm_cluster;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+- **关键点说明**：
+  - **`least_conn`**：将请求分发到当前连接数最少的节点，在集群间均衡负载。
+  - Nginx 转发到各后端节点的 8080 端口，由 TNG Egress 通过 netfilter 捕获流量。
+  - Nginx 无法看到 OHTTP 加密的请求内容——它仅在传输层做路由。
+
+### 典型使用步骤
+
+- **服务端侧**（每个节点重复）：
+  1. 启动 vLLM 实例，使用 OpenAI 兼容 API，监听端口 8080；
+  2. 启动 Attestation Agent（Unix socket 位于 `/run/confidential-containers/attestation-agent/attestation-agent.sock`）；
+  3. 编写 TNG Egress 配置 JSON 并启动 TNG；
+  4. 验证 peer_shared 集群已形成（通过 `serf members` 或 TNG 日志检查）。
+
+- **Nginx 网关**：
+  1. 在网关机器上安装 Nginx；
+  2. 写入 upstream + server 配置；
+  3. 启动 Nginx 并验证其能正确路由到后端节点。
+
+- **客户端侧**：
+  1. 启动 TNG Ingress，加载 `http_proxy + ohttp + verify` 配置；
+  2. 在应用中配置 HTTP 代理（指向 `http://<tng-ingress-ip>:41000`）；
+  3. 向 Nginx 网关地址发起请求（如 `http://<nginx-gateway-ip>:8080`）。
+
+### 端到端测试
+
+```bash
+# 通过 TNG HTTP Proxy 发送 OpenAI 兼容 API 请求
+curl -x http://<tng-ingress-ip>:41000 \
+     http://<nginx-gateway-ip>:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{
+         "model": "Qwen/Qwen2.5-7B",
+         "messages": [{"role": "user", "content": "Hello, what is TNG?"}],
+         "max_tokens": 256
+     }'
+```
+
+- `-x` 参数将请求通过本地 TNG HTTP Proxy 发送。
+- 目标地址为 Nginx 网关的 8080 端口。
+- TNG Ingress 使用 OHTTP 加密请求，Nginx 负载均衡到某个 TNG Egress 节点，该节点解密后转发给本地 vLLM 实例。
+- 响应沿反向路径返回客户端。


### PR DESCRIPTION
## Summary

Add a new scenario document (Use Case 5) describing how to deploy vLLM inference services behind an Nginx load-balanced gateway with TNG OHTTP encryption and peer_shared key distribution.

## Architecture

```
Client App → TNG Ingress(http_proxy:41000 + OHTTP + verify)
                  ↓ (OHTTP encrypted)
            Nginx Gateway (least_conn, :8080)
              /      |      \
   [TNG Egress + vLLM:8080] × 3  (netfilter + OHTTP peer_shared)
```

## Files Added

| File | Description |
|------|-------------|
| `docs/scenarios/scenario_vllm_ohttp_cluster.md` | English scenario document |
| `docs/scenarios/scenario_vllm_ohttp_cluster_zh.md` | Chinese scenario document |
| `docs/diagrams/scenario_vllm_ohttp_cluster.drawio` | English topology diagram |
| `docs/diagrams/scenario_vllm_ohttp_cluster_zh.drawio` | Chinese topology diagram |
| `.gitignore` | Exclude `docs/superpowers/` |

## Key Features

- **Client**: TNG Ingress in `http_proxy` mode (port 41000) with OHTTP encryption and unilateral RA verification
- **Gateway**: Nginx with `least_conn` load balancing across 3 backend TNG Egress instances
- **Server**: Multiple vLLM instances, each co-located with a TNG Egress instance using `netfilter` + OHTTP (`peer_shared`) + attestation
- **peer_shared**: Documents both `peers` (IP:port / domain:port) and `peers_file` configuration options
- **End-to-end test**: curl example with OpenAI-compatible `/v1/chat/completions` API