### PR TITLE
feat: add Ubuntu 24.04 as alternative Docker base image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,20 +14,49 @@ on:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [alinux3, ubuntu2404]
     runs-on: oracle-vm-16cpu-64gb-x86-64
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
       - name: Docker Setup Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container
           driver-opts: image=moby/buildkit:master,network=host
+
+      # Suffixed metadata — all variants
       - name: Docker meta
         id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/inclavare-containers/tng
+          labels: |
+            org.opencontainers.image.title=tng
+            org.opencontainers.image.description=Trusted Network Gateway
+          flavor: |
+            suffix=-${{ matrix.variant }},onlatest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # Alias metadata — alinux3 only (produces unsuffixed tags for backward compat)
+      - name: Docker meta (alias)
+        id: meta-alias
+        if: matrix.variant == 'alinux3'
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -43,25 +72,33 @@ jobs:
             type=sha,format=long
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and export
         uses: docker/build-push-action@v6.9.0
         with:
+          file: ${{ matrix.variant == 'alinux3' && 'Dockerfile' || 'Dockerfile.ubuntu2404' }}
           target: release
           context: .
           tags: |
             tng:test
             ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta-alias.outputs.tags || '' }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=${{ runner.temp }}/container-image.tar
+          outputs: type=docker,dest=${{ runner.temp }}/container-image-${{ matrix.variant }}.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: container-image
-          path: ${{ runner.temp }}/container-image.tar
+          name: container-image-${{ matrix.variant }}
+          path: ${{ runner.temp }}/container-image-${{ matrix.variant }}.tar
 
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [alinux3, ubuntu2404]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -89,12 +126,12 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          name: container-image
+          name: container-image-${{ matrix.variant }}
           path: ${{ runner.temp }}
 
       - name: Load image
         run: |
-          podman load --input ${RUNNER_TEMP}/container-image.tar
+          podman load --input ${RUNNER_TEMP}/container-image-${{ matrix.variant }}.tar
 
       - uses: dtolnay/rust-toolchain@1.89.0
 
@@ -190,20 +227,67 @@ jobs:
           echo "=== Attestation Service Log ==="
           cat /tmp/as.log 2>/dev/null || echo "(no log file)"
 
+
   push:
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [alinux3, ubuntu2404]
     runs-on: ubuntu-latest
     needs:
       - build
+      - test
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          name: container-image
+          name: container-image-${{ matrix.variant }}
           path: ${{ runner.temp }}
 
       - name: Load image
         run: |
-          docker load --input ${RUNNER_TEMP}/container-image.tar
+          docker load --input ${RUNNER_TEMP}/container-image-${{ matrix.variant }}.tar
+
+      # Suffixed metadata — all variants
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/inclavare-containers/tng
+          labels: |
+            org.opencontainers.image.title=tng
+            org.opencontainers.image.description=Trusted Network Gateway
+          flavor: |
+            suffix=-${{ matrix.variant }},onlatest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # Alias metadata — alinux3 only (produces unsuffixed tags for backward compat)
+      - name: Docker meta (alias)
+        id: meta-alias
+        if: matrix.variant == 'alinux3'
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/inclavare-containers/tng
+          labels: |
+            org.opencontainers.image.title=tng
+            org.opencontainers.image.description=Trusted Network Gateway
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to GHCR Container Registry
         uses: docker/login-action@v3
@@ -213,13 +297,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image
-        env:
-          IMAGE_TAGS: ${{needs.build.outputs.tags}}
         run: |
           set -e
           set -x
 
-          for tag in ${IMAGE_TAGS}; do
+          for tag in ${{ steps.meta.outputs.tags }} ${{ steps.meta-alias.outputs.tags || '' }}; do
               docker tag tng:test ${tag}
               docker push ${tag}
           done

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 tng-*.tar.gz
 .package/
 /.vscode/
-/docs/superpowers/
+docs/superpowers/
+docs/*-plan.md
+docs/*-design.md
+docs/*-spec.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ When creating or amending commits:
 - **Never** include any Claude session URLs, session IDs, or links to claude.ai in commit messages or PR descriptions. Commit messages should only describe the code changes.
 - **Never** include "🤖 Generated with [Claude Code](https://claude.com/claude-code)" or similar AI attribution footers in PR descriptions or commit messages.
 - **Always** use `--no-gpg-sign` to avoid GPG signing.
+- **Never commit plan or spec files** (e.g. `docs/*-plan.md`, `docs/*-design.md`, `docs/*-spec.md`). These should be gitignored and kept local only.
 
 ## PR Requirements
 

--- a/Dockerfile.ubuntu2404
+++ b/Dockerfile.ubuntu2404
@@ -1,0 +1,77 @@
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# install core build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    protobuf-compiler \
+    libprotobuf-dev \
+    gcc \
+    clang \
+    make \
+    pkg-config \
+    libssl-dev \
+    gnupg \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# install intel tdx dcap dependencies via Intel SGX repo
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSLO https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key && \
+    mv intel-sgx-deb.key /etc/apt/keyrings/intel-sgx-keyring.asc && \
+    tee /etc/apt/sources.list.d/intel-sgx.list > /dev/null <<EOF
+deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main
+EOF
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtdx-attest-dev \
+    libsgx-dcap-quote-verify-dev \
+    libsgx-dcap-default-qpl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --no-modify-path --default-toolchain none
+
+WORKDIR /code/
+
+COPY rust-toolchain.toml .
+
+# install toolchain and cache it
+RUN . "$HOME/.cargo/env" && rustup show
+
+COPY . .
+
+RUN . "$HOME/.cargo/env" && env RUSTFLAGS="--cfg tokio_unstable" cargo install --locked --features 'builtin-as-tdx' --path ./tng/ --root /usr/local/cargo/
+
+
+FROM ubuntu:24.04 AS release
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    iptables \
+    iproute2 \
+    jq \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# install intel tdx dcap runtime dependencies
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSLO https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key && \
+    mv intel-sgx-deb.key /etc/apt/keyrings/intel-sgx-keyring.asc && \
+    tee /etc/apt/sources.list.d/intel-sgx.list > /dev/null <<EOF
+deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main
+EOF
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libtdx-attest \
+    libsgx-dcap-quote-verify \
+    libsgx-dcap-default-qpl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/cargo/bin/tng /usr/local/bin/tng
+
+CMD ["tng"]

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,10 @@ update-rpm-tree:
 docker-build:
 	docker build -t tng:${VERSION} .
 
+.PHONY: docker-build-ubuntu
+docker-build-ubuntu:
+	docker build -t tng:${VERSION}-ubuntu2404 -f Dockerfile.ubuntu2404 .
+
 .PHONE: install-wasm-build-dependencies
 install-wasm-build-dependencies:
 	if ! command -v wasm-pack >/dev/null; then \


### PR DESCRIPTION
## Summary

Add Ubuntu 24.04 (noble) as an alternative base image for the TNG container, alongside the existing Alibaba Cloud Linux 3 (alinux3).

## Changes

- **Dockerfile.ubuntu2404** — New two-stage build (builder + release) using Ubuntu 24.04, apt-get, and Intel SGX official repo for TDX/DCAP dependencies
- **Makefile** — Added `docker-build-ubuntu` target for local builds
- **`.github/workflows/build-docker.yml`** — Converted build/test/push jobs to matrix strategy [`alinux3`, `ubuntu2404`] with:
  - Parallel execution per variant (`fail-fast: false`)
  - Flavor suffix on GHCR tags (`-alinux3`, `-ubuntu2404`)
  - Backward-compatible unsuffixed alias tags from alinux3 variant
  - Push job computes its own tags per variant (avoids matrix job output limitation)
  - Push depends on both build and test passing

## GHCR Tag Scheme

| Trigger | alinux3 Tags | ubuntu2404 Tags |
|---------|-------------|-----------------|
| `master` branch | `master-alinux3`, `latest-alinux3`, **`master`**, **`latest`** | `master-ubuntu2404`, `latest-ubuntu2404` |
| PR #123 | `pr-123-alinux3`, **`pr-123`** | `pr-123-ubuntu2404` |
| Tag `v2.6.0` | `2.6.0-alinux3`, `2.6-alinux3`, **`2.6.0`**, **`2.6`**, **`latest`** | `2.6.0-ubuntu2404`, `2.6-ubuntu2404` |
| Any commit | `sha-<sha>-alinux3`, **`sha-<sha>`** | `sha-<sha>-ubuntu2404` |

**Bold** tags are alinux3-only aliases for backward compatibility.

## Testing

- Builder stage builds successfully with `docker build --target builder -f Dockerfile.ubuntu2404 .`
- Full image builds and `tng --version` returns `2.6.0`
- CI will run integration tests for both variants in parallel