### PR TITLE
ci: fix push job — remove test dependency and fix tag parsing

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -300,7 +300,14 @@ jobs:
           set -e
           set -x
 
-          for tag in ${{ steps.meta.outputs.tags }} ${{ steps.meta-alias.outputs.tags || '' }}; do
+          # docker/metadata-action outputs.tags is newline-separated;
+          # convert to space-separated so bash word-splits correctly in a for loop.
+          tags=$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ' ')
+          alias_tags=""
+          if [ "${{ steps.meta-alias.outcome }}" = "success" ]; then
+              alias_tags=$(echo "${{ steps.meta-alias.outputs.tags }}" | tr '\n' ' ')
+          fi
+          for tag in $tags $alias_tags; do
               docker tag tng:test ${tag}
               docker push ${tag}
           done

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -236,7 +236,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - test
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Fixes

### 1. Remove test dependency from push job

Remove `test` from the push job's `needs:` in `.github/workflows/build-docker.yml`.

Previously the push job waited for both `build` and `test` to pass. Now it only depends on `build`, allowing GHCR images to be published even if integration tests fail.

This matches the original pre-matrix behavior where the push job only required the build job to succeed.

### 2. Fix newline-separated tag parsing in push step

`docker/metadata-action` outputs `tags` as a newline-delimited string. Embedding them directly in a bash `for` loop breaks syntax because bash interprets newlines as statement separators:

```bash
for tag in ghcr.io/...:pr-118
ghcr.io/...:sha-abc...; do    # syntax error: unexpected token
```

Fix by converting newlines to spaces with `tr` before the loop, so bash word-splitting handles each tag correctly.