### PR TITLE
refactor(testsuite,ohttp): tracing spans, ShellMode 2D semantics, serf watcher fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,11 @@ Wait until both services are ready before running tests. The e2E CoCo tests (`te
 
 The `test_e2e_asr_flow` test additionally requires an ASR (Attestation Service Router) HTTP proxy listening on `127.0.0.1:8006`, which is NOT started by the `make test-dep-*` targets. If ASR is not available, this test will fail with "Connection refused".
 
+## Running Integration Tests
+
+- **Always use `make run-test`** to run integration tests. Running individual `cargo test -p tng-testsuite --test <name>` commands manually is fine for debugging, but **do NOT run multiple tests in parallel** — they share iptables rules and network namespaces, so concurrent execution causes conflicts. `make run-test` runs tests sequentially to prevent this.
+- If a test fails with "Connection refused" on a netfilter test, check for stale `TNG_EGRESS_*` iptables rules and clean them up before re-running.
+
 ## Pre-Push Checks
 
 Before pushing, verify the following:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "memberlist"
 version = "0.8.2"
-source = "git+https://github.com/inclavare-containers/memberlist?rev=b91b5658c435348563a2c2fe5a1211f52d92abbe#b91b5658c435348563a2c2fe5a1211f52d92abbe"
+source = "git+https://github.com/al8n/memberlist?rev=ac5a2798655c066f065aaa231702240776b32b7a#ac5a2798655c066f065aaa231702240776b32b7a"
 dependencies = [
  "agnostic",
  "agnostic-lite",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "memberlist-core"
 version = "0.8.3"
-source = "git+https://github.com/inclavare-containers/memberlist?rev=b91b5658c435348563a2c2fe5a1211f52d92abbe#b91b5658c435348563a2c2fe5a1211f52d92abbe"
+source = "git+https://github.com/al8n/memberlist?rev=ac5a2798655c066f065aaa231702240776b32b7a#ac5a2798655c066f065aaa231702240776b32b7a"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "memberlist-net"
 version = "0.8.3"
-source = "git+https://github.com/inclavare-containers/memberlist?rev=b91b5658c435348563a2c2fe5a1211f52d92abbe#b91b5658c435348563a2c2fe5a1211f52d92abbe"
+source = "git+https://github.com/al8n/memberlist?rev=ac5a2798655c066f065aaa231702240776b32b7a#ac5a2798655c066f065aaa231702240776b32b7a"
 dependencies = [
  "agnostic",
  "async-channel",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "memberlist-proto"
 version = "0.3.3"
-source = "git+https://github.com/inclavare-containers/memberlist?rev=b91b5658c435348563a2c2fe5a1211f52d92abbe#b91b5658c435348563a2c2fe5a1211f52d92abbe"
+source = "git+https://github.com/al8n/memberlist?rev=ac5a2798655c066f065aaa231702240776b32b7a#ac5a2798655c066f065aaa231702240776b32b7a"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "memberlist-quic"
 version = "0.8.3"
-source = "git+https://github.com/inclavare-containers/memberlist?rev=b91b5658c435348563a2c2fe5a1211f52d92abbe#b91b5658c435348563a2c2fe5a1211f52d92abbe"
+source = "git+https://github.com/al8n/memberlist?rev=ac5a2798655c066f065aaa231702240776b32b7a#ac5a2798655c066f065aaa231702240776b32b7a"
 dependencies = [
  "agnostic",
  "agnostic-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,11 +178,11 @@ rev = "6fde2c7c2e00b4fc1b9e31b827654230f488630f"
 
 [patch.crates-io]
 hyper-util = {path = "./deps/hyper-util-shim"}
-memberlist = {git = "https://github.com/inclavare-containers/memberlist", rev = "b91b5658c435348563a2c2fe5a1211f52d92abbe"}
-memberlist-core = {git = "https://github.com/inclavare-containers/memberlist", rev = "b91b5658c435348563a2c2fe5a1211f52d92abbe"}
-memberlist-net = {git = "https://github.com/inclavare-containers/memberlist", rev = "b91b5658c435348563a2c2fe5a1211f52d92abbe"}
-memberlist-proto = {git = "https://github.com/inclavare-containers/memberlist", rev = "b91b5658c435348563a2c2fe5a1211f52d92abbe"}
-memberlist-quic = {git = "https://github.com/inclavare-containers/memberlist", rev = "b91b5658c435348563a2c2fe5a1211f52d92abbe"}
+memberlist = {git = "https://github.com/al8n/memberlist", rev = "ac5a2798655c066f065aaa231702240776b32b7a"}
+memberlist-core = {git = "https://github.com/al8n/memberlist", rev = "ac5a2798655c066f065aaa231702240776b32b7a"}
+memberlist-net = {git = "https://github.com/al8n/memberlist", rev = "ac5a2798655c066f065aaa231702240776b32b7a"}
+memberlist-proto = {git = "https://github.com/al8n/memberlist", rev = "ac5a2798655c066f065aaa231702240776b32b7a"}
+memberlist-quic = {git = "https://github.com/al8n/memberlist", rev = "ac5a2798655c066f065aaa231702240776b32b7a"}
 
 [profile.release.package.tng-wasm]
 # Tell `rustc` to optimize for small code size.

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -21,7 +21,6 @@ IP_S="10.200.1.2"
 
 # Ports
 IPERF_PORT=5201
-STUNNEL_SERVER_PORT=5601
 STUNNEL_CLIENT_PORT=9001
 
 TNG_EGRESS_LISTEN=40000
@@ -267,8 +266,8 @@ for streams in "${STREAM_COUNTS[@]}"; do
     c_ns "$CLIENT_NS" pkill -f stunnel 2>/dev/null || true
     sleep 0.5
 
-    c_ns "$SERVER_NS" $STUNNEL_BIN /tmp/tng-bench-stunnel-server.conf &
-    c_ns "$CLIENT_NS" $STUNNEL_BIN /tmp/tng-bench-stunnel-client.conf &
+    c_ns "$SERVER_NS" "$STUNNEL_BIN" /tmp/tng-bench-stunnel-server.conf &
+    c_ns "$CLIENT_NS" "$STUNNEL_BIN" /tmp/tng-bench-stunnel-client.conf &
     sleep 1
 
     STUNNEL_RESULTS[$streams]=$(run_iperf "$IP_C" "$STUNNEL_CLIENT_PORT" "$CLIENT_NS" "stunnel ($streams streams)" "$streams")

--- a/tng-testsuite/run-test.sh
+++ b/tng-testsuite/run-test.sh
@@ -180,10 +180,22 @@ for case_name in $test_cases; do
         continue
     fi
 
+    # Some tests require additional features
+    extra_features=""
+    if [[ "$case_name" == "js_sdk_http" ]]; then
+        extra_features="js-sdk"
+    fi
+
+    if [[ -n "$extra_features" ]]; then
+        features="on-source-code,$extra_features"
+    else
+        features="on-source-code"
+    fi
+
     integ_args=(
         --no-report
         --no-default-features
-        --features on-source-code
+        --features "$features"
         --package tng-testsuite
         --test "$case_name"
         --

--- a/tng-testsuite/src/task/mod.rs
+++ b/tng-testsuite/src/task/mod.rs
@@ -61,7 +61,7 @@ where
 
     /// Launch the task, wait until the task is ready and return a handle to the task.
     async fn launch(&self, token: CancellationToken) -> Result<JoinHandle<Result<()>>> {
-        self.1.launch(token).await
+        self.1.launch_with_node_type(token, self.0).await
     }
 }
 
@@ -73,6 +73,18 @@ pub trait Task: Send + Sync + 'static {
 
     /// Launch the task, wait until the task is ready and return a handle to the task.
     async fn launch(&self, token: CancellationToken) -> Result<JoinHandle<Result<()>>>;
+
+    /// Launch the task with an explicit node type for output tagging.
+    /// Default implementation delegates to `launch`.
+    /// Override this to use the provided node type for the output prefix.
+    async fn launch_with_node_type(
+        &self,
+        token: CancellationToken,
+        node_type: NodeType,
+    ) -> Result<JoinHandle<Result<()>>> {
+        let _ = node_type; // default impl ignores it
+        self.launch(token).await
+    }
 
     fn boxed(self) -> Box<dyn Task>
     where

--- a/tng-testsuite/src/task/shell.rs
+++ b/tng-testsuite/src/task/shell.rs
@@ -7,17 +7,33 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 /// Controls how a shell script is executed within a test.
+///
+/// Two independent dimensions are covered:
+///
+/// 1. **Execution style**: foreground (blocks `launch()`) vs background (returns immediately)
+/// 2. **Finish policy**: stop (cancels the test token on finish) vs continue
+///
+/// | Variant                        | Blocks `launch()`? | On finish → cancel token? |
+/// |--------------------------------|--------------------|----------------------------|
+/// | `ForegroundStop`               | Yes                | Yes                        |
+/// | `ForegroundContinue`           | Yes                | No                         |
+/// | `BackgroundContinue`           | No                 | No                         |
+/// | `BackgroundStop`               | No                 | Yes                        |
 #[derive(Clone, Copy)]
 pub enum ShellMode {
-    /// Run the script synchronously. If it fails, the test fails.
-    Blocking,
-    /// Spawn the script in the background. Errors are logged but do not stop the test.
-    /// Use for fire-and-forget scripts that are not critical to test outcome.
-    FireAndForget,
-    /// Spawn the script in the background and wait for it to complete before continuing
-    /// to the next stage of the test. Errors are logged but do not stop the test.
-    /// Use for setup / barrier scripts that must complete before subsequent tasks run.
-    Barrier,
+    /// Run the script synchronously (blocks `launch()`). On finish, the test token is
+    /// cancelled so all other tasks wind down.
+    ForegroundStop,
+    /// Run the script synchronously (blocks `launch()`). On finish, the error is
+    /// propagated but the test token is NOT cancelled — other tasks continue running
+    /// and the harness collects all errors to report at the end.
+    ForegroundContinue,
+    /// Spawn the script in the background (`launch()` returns immediately). On finish,
+    /// the error is logged but the test token is NOT cancelled.
+    BackgroundContinue,
+    /// Spawn the script in the background (`launch()` returns immediately). On finish,
+    /// the test token is cancelled so all other tasks wind down.
+    BackgroundStop,
 }
 
 pub struct ShellTask {
@@ -39,7 +55,6 @@ impl Task for ShellTask {
 
     async fn launch(&self, token: CancellationToken) -> Result<JoinHandle<Result<()>>> {
         let script = self.script.clone();
-        let name = self.name.clone();
         let mode = self.mode;
 
         let shell_task = async move {
@@ -77,27 +92,15 @@ impl Task for ShellTask {
             };
 
             match mode {
-                ShellMode::Blocking => {
+                ShellMode::ForegroundStop | ShellMode::BackgroundStop => {
                     let _drop_guard = token.drop_guard();
                     task.await?;
                 }
-                ShellMode::FireAndForget => {
+                ShellMode::ForegroundContinue | ShellMode::BackgroundContinue => {
                     tokio::select! {
                         _ = token.cancelled() => {}
                         res = task => {
-                            if let Err(e) = res {
-                                tracing::debug!("Background shell task '{name}' completed with error: {e}");
-                            }
-                        }
-                    }
-                }
-                ShellMode::Barrier => {
-                    tokio::select! {
-                        _ = token.cancelled() => {}
-                        res = task => {
-                            if let Err(e) = res {
-                                tracing::debug!("Barrier shell task '{name}' completed with error: {e}");
-                            }
+                            res?;
                         }
                     }
                 }
@@ -109,14 +112,14 @@ impl Task for ShellTask {
         let parent_span = tracing::Span::current();
 
         match mode {
-            ShellMode::Blocking => {
+            ShellMode::ForegroundStop | ShellMode::ForegroundContinue => {
                 let _handle = shell_task.await?;
                 // The task completed synchronously, return a no-op spawned task.
                 Ok(tokio::task::spawn(
                     async move { Ok(()) }.instrument(parent_span),
                 ))
             }
-            ShellMode::FireAndForget | ShellMode::Barrier => {
+            ShellMode::BackgroundContinue | ShellMode::BackgroundStop => {
                 // Spawn the shell task in the background and return immediately.
                 Ok(tokio::task::spawn(shell_task.instrument(parent_span)))
             }

--- a/tng-testsuite/src/task/tagged_spawn.rs
+++ b/tng-testsuite/src/task/tagged_spawn.rs
@@ -2,12 +2,13 @@ use std::io;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
+use tracing::Instrument;
 
-/// Spawn a command with its stdout and stderr captured and re-emitted
-/// with a `[tag]` prefix on each line.
+/// Spawn a command with its stdout and stderr captured and logged
+/// via `tracing::info!` under the current tracing span.
 ///
-/// The child process inherits stdin (set to null), while stdout and stderr
-/// are piped through `BufReader::lines()` for real-time line-by-line tagging.
+/// The child process has its stdin set to null, while stdout and stderr
+/// are piped through `BufReader::lines()` for real-time line-by-line logging.
 /// Background tokio tasks handle the streaming and will exit when the
 /// process closes its pipes.
 ///
@@ -15,33 +16,37 @@ use tokio::process::{Child, Command};
 /// the spawned task before the child process fully exits, some trailing
 /// output may be lost. This is acceptable since this function is used
 /// exclusively for debugging test output in the integration test framework.
-pub async fn spawn_with_tagged_output(cmd: &mut Command, tag: &str) -> io::Result<Child> {
-    let tag = tag.to_owned();
+pub async fn spawn_with_span_output(cmd: &mut Command) -> io::Result<Child> {
     let mut child = cmd
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
 
-    // Stream stdout with tag prefix
+    // Stream stdout with span prefix
     if let Some(stdout) = child.stdout.take() {
-        let tag_clone = tag.clone();
-        tokio::spawn(async move {
-            let mut reader = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                println!("[{}] {}", tag_clone, line);
+        tokio::spawn(
+            async move {
+                let mut reader = BufReader::new(stdout).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    tracing::info!(target: "spawn", "{}", line);
+                }
             }
-        });
+            .instrument(tracing::Span::current()),
+        );
     }
 
-    // Stream stderr with tag prefix
+    // Stream stderr with span prefix
     if let Some(stderr) = child.stderr.take() {
-        tokio::spawn(async move {
-            let mut reader = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                eprintln!("[{}] {}", tag, line);
+        tokio::spawn(
+            async move {
+                let mut reader = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    tracing::info!(target: "spawn", "{}", line);
+                }
             }
-        });
+            .instrument(tracing::Span::current()),
+        );
     }
 
     Ok(child)

--- a/tng-testsuite/src/task/tng/external/mod.rs
+++ b/tng-testsuite/src/task/tng/external/mod.rs
@@ -5,8 +5,9 @@ use serde_json::json;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
-use crate::task::tagged_spawn::spawn_with_tagged_output;
+use crate::task::tagged_spawn::spawn_with_span_output;
 
 use super::TngInstance;
 
@@ -42,7 +43,6 @@ impl TngInstance {
     pub(super) async fn launch_inner(
         &self,
         token: CancellationToken,
-        tag: &str,
     ) -> Result<JoinHandle<Result<()>>> {
         let config_json = match self {
             TngInstance::TngClient(config_json) | TngInstance::TngServer(config_json) => {
@@ -62,9 +62,9 @@ impl TngInstance {
                 .get_tokio_command(&config_json)
                 .await
                 .context("Failed to get command line for creating tng process")?;
-            spawn_with_tagged_output(&mut cmd, tag)
+            spawn_with_span_output(&mut cmd)
                 .await
-                .context("Failed to spawn tagged tng process")?
+                .context("Failed to spawn tng process")?
         };
 
         // Wait for the tng process to be ready by polling the ready signal from 127.0.0.1:50000/readyz.
@@ -87,6 +87,7 @@ impl TngInstance {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
+        let parent_span = tracing::Span::current();
         let join_handle = tokio::task::spawn(async move {
             tokio::select! {
                 status = process.wait() => {
@@ -107,7 +108,7 @@ impl TngInstance {
             }
 
             Ok::<_, anyhow::Error>(())
-        });
+        }.instrument(parent_span));
 
         return Ok(join_handle);
     }

--- a/tng-testsuite/src/task/tng/mod.rs
+++ b/tng-testsuite/src/task/tng/mod.rs
@@ -37,7 +37,26 @@ impl Task for TngInstance {
     }
 
     async fn launch(&self, token: CancellationToken) -> Result<JoinHandle<Result<()>>> {
-        let tag = format!("{}@{}", self.name(), self.node_type().ip());
+        self.launch_with_node_type(token, self.node_type()).await
+    }
+
+    #[cfg(any(feature = "on-bin", feature = "on-podman"))]
+    async fn launch_with_node_type(
+        &self,
+        token: CancellationToken,
+        node_type: NodeType,
+    ) -> Result<JoinHandle<Result<()>>> {
+        let tag = format!("{}@{}", self.name(), node_type.ip());
         self.launch_inner(token, &tag).await
+    }
+
+    #[cfg(feature = "on-source-code")]
+    async fn launch_with_node_type(
+        &self,
+        token: CancellationToken,
+        node_type: NodeType,
+    ) -> Result<JoinHandle<Result<()>>> {
+        let _ = node_type; // source_code mode doesn't use tag prefixes
+        self.launch_inner(token, "").await
     }
 }

--- a/tng-testsuite/src/task/tng/mod.rs
+++ b/tng-testsuite/src/task/tng/mod.rs
@@ -37,26 +37,6 @@ impl Task for TngInstance {
     }
 
     async fn launch(&self, token: CancellationToken) -> Result<JoinHandle<Result<()>>> {
-        self.launch_with_node_type(token, self.node_type()).await
-    }
-
-    #[cfg(any(feature = "on-bin", feature = "on-podman"))]
-    async fn launch_with_node_type(
-        &self,
-        token: CancellationToken,
-        node_type: NodeType,
-    ) -> Result<JoinHandle<Result<()>>> {
-        let tag = format!("{}@{}", self.name(), node_type.ip());
-        self.launch_inner(token, &tag).await
-    }
-
-    #[cfg(feature = "on-source-code")]
-    async fn launch_with_node_type(
-        &self,
-        token: CancellationToken,
-        node_type: NodeType,
-    ) -> Result<JoinHandle<Result<()>>> {
-        let _ = node_type; // source_code mode doesn't use tag prefixes
-        self.launch_inner(token, "").await
+        self.launch_inner(token).await
     }
 }

--- a/tng-testsuite/src/task/tng/source_code.rs
+++ b/tng-testsuite/src/task/tng/source_code.rs
@@ -12,7 +12,6 @@ impl TngInstance {
     pub(super) async fn launch_inner(
         &self,
         token: CancellationToken,
-        _tag: &str,
     ) -> Result<JoinHandle<Result<()>>> {
         let config_json = match self {
             TngInstance::TngClient(config_json) | TngInstance::TngServer(config_json) => {

--- a/tng-testsuite/tests/http/http_proxy_ingress_recursion_detect.rs
+++ b/tng-testsuite/tests/http/http_proxy_ingress_recursion_detect.rs
@@ -52,7 +52,7 @@ async fn test() -> Result<()> {
                 fi
             "#
             .to_owned(),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
         }
         .boxed(),
     ])

--- a/tng-testsuite/tests/netfilter/client_netfilter_server_netfilter.rs
+++ b/tng-testsuite/tests/netfilter/client_netfilter_server_netfilter.rs
@@ -268,7 +268,7 @@ async fn test_ipset_and_port() -> Result<()> {
                     ipset list myset
                 "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
         }
         .boxed(),
         TNG_SERVER_INSTANCE.clone().boxed(),
@@ -325,7 +325,7 @@ async fn test_ipset_and_port_bad_case() -> Result<()> {
                     ipset list myset
                 "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
         }
         .boxed(),
         TNG_SERVER_INSTANCE.clone().boxed(),
@@ -384,7 +384,7 @@ async fn test_ipset_only() -> Result<()> {
                     ipset list myset
                 "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
         }
         .boxed(),
         TNG_SERVER_INSTANCE.clone().boxed(),

--- a/tng-testsuite/tests/netfilter/client_socks5_server_netfilter.rs
+++ b/tng-testsuite/tests/netfilter/client_socks5_server_netfilter.rs
@@ -71,7 +71,7 @@ async fn test() -> Result<()> {
                 curl --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
             "#
             .to_owned(),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),
@@ -121,7 +121,7 @@ async fn test() -> Result<()> {
                 curl --socks5 user:ppppppwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
             "#
             .to_owned(),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),
@@ -177,7 +177,7 @@ async fn test() -> Result<()> {
                 curl --socks5 user:ppppppwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
             "#
             .to_owned(),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
 
         }
@@ -237,7 +237,7 @@ async fn test() -> Result<()> {
                 curl --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:40001/foo/bar/www?type=1&case=1"
             "#
             .to_owned(),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),

--- a/tng-testsuite/tests/netfilter/egress_netfilter_cgroup.rs
+++ b/tng-testsuite/tests/netfilter/egress_netfilter_cgroup.rs
@@ -89,7 +89,7 @@ async fn test_egress_netfilter_cgroup_capture() -> Result<()> {
                 echo "cgroup capture test passed"
             "#
             ),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),
@@ -187,7 +187,7 @@ async fn test_egress_netfilter_cgroup_nocapture() -> Result<()> {
                 sleep 30
             "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),
@@ -273,7 +273,7 @@ async fn test_egress_netfilter_cgroup_and_capture_dst() -> Result<()> {
                 echo "cgroup + capture_dst combo test passed"
             "#
             ),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),
@@ -358,7 +358,7 @@ async fn test_egress_netfilter_cgroup_only_all_tcp() -> Result<()> {
                 echo "cgroup-only all-TCP test passed"
             "#
             ),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),

--- a/tng-testsuite/tests/netfilter/ingress_netfilter_capture.rs
+++ b/tng-testsuite/tests/netfilter/ingress_netfilter_capture.rs
@@ -202,7 +202,7 @@ async fn test_ipset_and_port() -> Result<()> {
                     ipset list myset
                 "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
         }
         .boxed(),
         TNG_SERVER_INSTANCE.clone().boxed(),

--- a/tng-testsuite/tests/netfilter/ingress_netfilter_cgroup.rs
+++ b/tng-testsuite/tests/netfilter/ingress_netfilter_cgroup.rs
@@ -79,7 +79,7 @@ async fn test_ingress_netfilter_cgroup_capture() -> Result<()> {
                 echo "ingress cgroup capture test passed"
             "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),
@@ -177,7 +177,7 @@ async fn test_ingress_netfilter_cgroup_nocapture() -> Result<()> {
                 echo "ingress nocapture test passed"
             "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),
@@ -257,7 +257,7 @@ async fn test_ingress_netfilter_cgroup_and_capture_dst() -> Result<()> {
                 echo "ingress cgroup + capture_dst combo test passed"
             "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),
@@ -334,7 +334,7 @@ async fn test_ingress_netfilter_cgroup_only_all_tcp() -> Result<()> {
                 echo "ingress cgroup-only all-TCP test passed"
             "#
             .to_owned(),
-            mode: ShellMode::FireAndForget,
+            mode: ShellMode::BackgroundContinue,
 
         }
         .boxed(),

--- a/tng-testsuite/tests/netfilter/netfilter_ingress_recursion_detect.rs
+++ b/tng-testsuite/tests/netfilter/netfilter_ingress_recursion_detect.rs
@@ -48,7 +48,7 @@ async fn test() -> Result<()> {
                 fi
             "#
             .to_owned(),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
         }
         .boxed(),
     ])

--- a/tng-testsuite/tests/ohttp/ohttp.rs
+++ b/tng-testsuite/tests/ohttp/ohttp.rs
@@ -707,7 +707,7 @@ async fn test_server_attest_passport_cache() -> Result<()> {
             script: check_rotation_script(
                 r#"{"attestation_request":{"model":"passport"}}"#
             ),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),
@@ -756,7 +756,7 @@ async fn test_server_attest_passport_rotation_interval() -> Result<()> {
             script: check_rotation_script(
                 r#"{"attestation_request":{"model":"passport"}}"#
             ),
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),
@@ -825,7 +825,7 @@ echo "SUCCESS: All tests passed"
                     call_api_fn()
                 )
             },
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),
@@ -1042,7 +1042,7 @@ EOF
                     "#
                 )
             },
-            mode: ShellMode::Blocking,
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),
@@ -1261,25 +1261,6 @@ async fn test_egress_key_from_peer_shared_with_peers_file() -> Result<()> {
 
     tasks.extend(vec![
         ShellTask {
-            name: "waiting for tng cluster keys sharing and peers file monitoring".to_owned(),
-            node_type: NodeType::Client,
-            script: {
-                format!(
-                    r#"
-                    set -euo pipefail
-
-                    echo "Waiting 5 seconds for TNG cluster to establish and file watcher to start..."
-                    sleep 3
-
-                    echo "Initial cluster setup complete"
-                    "#
-                )
-            },
-            mode: ShellMode::FireAndForget,
-
-        }
-        .boxed(),
-        ShellTask {
             name: "update peers file and verify new peer joins".to_owned(),
             node_type: NodeType::Client,
             script: {
@@ -1305,7 +1286,12 @@ EOF
                     peers_file_path
                 )
             },
-            mode: ShellMode::FireAndForget,
+            // The peers file update triggers new nodes to join a cluster that may still be
+            // converging from a split-brain state. During this convergence window, even the
+            // fallback Serf query mechanism can fail to reach other nodes' keys. We use
+            // Blocking here to ensure the key synchronization completes before subsequent
+            // tasks (LoadBalancer, TngClient) begin sending requests.
+            mode: ShellMode::ForegroundStop,
 
         }
         .boxed(),

--- a/tng-testsuite/tests/ohttp/ohttp.rs
+++ b/tng-testsuite/tests/ohttp/ohttp.rs
@@ -1289,10 +1289,9 @@ EOF
             // The peers file update triggers new nodes to join a cluster that may still be
             // converging from a split-brain state. During this convergence window, even the
             // fallback Serf query mechanism can fail to reach other nodes' keys. We use
-            // Blocking here to ensure the key synchronization completes before subsequent
+            // ForegroundContinue here to ensure the key synchronization completes before subsequent
             // tasks (LoadBalancer, TngClient) begin sending requests.
-            mode: ShellMode::ForegroundStop,
-
+            mode: ShellMode::ForegroundContinue,
         }
         .boxed(),
         AppType::LoadBalancer {
@@ -1328,7 +1327,7 @@ EOF
                         }
                     }
                 ]
-            }"#
+            }"#,
         )
         .boxed(),
         AppType::HttpClient {

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
@@ -600,6 +600,20 @@ impl PeerSharedKeyManager {
 
                     match event {
                         Event::Query(query) => {
+                            {
+                                let Some(serf) = serf.upgrade() else {
+                                    tracing::debug!(
+                                        "stop serf watcher since serf has been dropped"
+                                    );
+                                    return;
+                                };
+
+                                // Skip queries from ourselves
+                                if query.from().id() == serf.local_id() {
+                                    continue;
+                                }
+                            }
+
                             if let Err(error) = Self::handle_query(&query, &inner).await {
                                 tracing::warn!(
                                     ?error,

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
@@ -600,6 +600,12 @@ impl PeerSharedKeyManager {
 
                     match event {
                         Event::Query(query) => {
+                            tracing::trace!(
+                                name = query.name().as_str(),
+                                from = query.from().to_string(),
+                                "Handling query"
+                            );
+
                             {
                                 let Some(serf) = serf.upgrade() else {
                                     tracing::debug!(
@@ -624,6 +630,11 @@ impl PeerSharedKeyManager {
                             }
                         }
                         Event::User(user_event) => {
+                            tracing::trace!(
+                                name = user_event.name().as_str(),
+                                "Handling user event"
+                            );
+
                             if let Err(error) = Self::handle_user_event(
                                 user_event.name().as_str(),
                                 user_event.payload(),
@@ -639,6 +650,12 @@ impl PeerSharedKeyManager {
                             }
                         }
                         Event::Member(member_event) => {
+                            tracing::trace!(
+                                type = member_event.ty().as_str(),
+                                members = ?member_event.members().iter().map(|m| m.node()).collect::<Vec<_>>(),
+                                "Handling member event"
+                            );
+
                             if matches!(member_event.ty(), MemberEventType::Leave) {
                                 tracing::info!("Member left, triggering key rotation check");
                                 {
@@ -807,6 +824,19 @@ impl PeerSharedKeyManager {
 
         Ok(None)
     }
+
+    /// Join a set of peers after construction.
+    ///
+    /// This mirrors the file watcher scenario: when new peers are discovered,
+    /// only `join_serf_cluster` is called — no `QueryClusterKeySetRequest` is sent.
+    /// Key synchronization must happen through subsequent Serf queries.
+    #[cfg(test)]
+    pub(crate) async fn join_peers(&self, peers: &[String]) -> Result<(), TngError> {
+        if peers.is_empty() {
+            return Ok(());
+        }
+        join_serf_cluster(&self.serf, peers).await
+    }
 }
 
 async fn resolve_peer_addresses(addr: &String) -> Result<Vec<SocketAddr>, TngError> {
@@ -945,6 +975,7 @@ mod tests {
     use crate::tests::run_test_with_tokio_runtime;
     use crate::tunnel::egress::protocol::ohttp::security::key_manager::KeyManager;
     use anyhow::{anyhow, Result};
+    use hex;
     use std::time::Duration;
 
     // -----------------------------------------------------------------------
@@ -1022,6 +1053,98 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
+    }
+
+    /// Collect all public keys from every node, then verify that on every node
+    /// each key is reachable via `query_key_from_cluster`.
+    ///
+    /// Before collecting keys, verify Serf connectivity between all node pairs.
+    ///
+    /// After all queries succeed, also verifies that every node's local
+    /// `ClusterKeySet` contains the full union of keys.
+    async fn verify_all_keys_reachable(nodes: &[(&str, &PeerSharedKeyManager)]) -> Result<()> {
+        // --- Step 1: Verify Serf connectivity — ping every expected node pair ---
+        // For each pinger, check that all other expected nodes are visible in its
+        // member list, then ping each one to confirm connectivity.
+        for (pinger_name, mgr) in nodes {
+            let members = mgr.serf.members().await;
+            let local_id = mgr.serf.local_id();
+
+            // Build a map from node ID to the member's Node (for ping).
+            // Use string IDs as keys to avoid Borrow trait issues with NodeId.
+            let member_map: std::collections::HashMap<_, _> = members
+                .iter()
+                .filter(|m| m.node().id() != local_id)
+                .map(|m| (m.node().id().clone(), m.node().clone()))
+                .collect();
+
+            for (target_name, target_mgr) in nodes {
+                if target_name == pinger_name {
+                    continue;
+                }
+                let target_id = target_mgr.serf.local_id();
+
+                let Some(target_node) = member_map.get(target_id) else {
+                    return Err(anyhow!(
+                        "membership check failed: {pinger_name} does not see {target_name} ({target_id}) in its member list"
+                    ));
+                };
+
+                if let Err(error) = mgr.serf.memberlist().ping(target_node.clone()).await {
+                    return Err(anyhow!(
+                        "ping failed: {pinger_name} -> {target_name}: {error:?}"
+                    ));
+                }
+                tracing::info!(from = pinger_name, to = target_name, "Serf ping OK");
+            }
+        }
+
+        // --- Step 2: Collect the full set of public keys across all nodes ---
+        // mapping each public key to all nodes that own it.
+        let mut pk_to_nodes: std::collections::HashMap<PublicKeyData, Vec<&str>> =
+            std::collections::HashMap::new();
+        let mut all_pks = std::collections::HashSet::new();
+        for (name, mgr) in nodes {
+            let cks = mgr.inner.cluster_key_set.read().await;
+            for (pk, _) in cks.iter_keys() {
+                pk_to_nodes.entry(pk.clone()).or_default().push(name);
+                all_pks.insert(pk.clone());
+            }
+        }
+
+        assert!(
+            all_pks.len() >= 2,
+            "Cluster should have at least 2 distinct keys, got {}",
+            all_pks.len()
+        );
+
+        // On each node, call `get_key_by_public_key` for every key.
+        for (querier_name, mgr) in nodes {
+            for pk in &all_pks {
+                let owners = pk_to_nodes
+                    .get(pk)
+                    .map(|v| v.join(","))
+                    .unwrap_or_else(|| "?".into());
+                let pk_hex = hex::encode(pk.as_ref());
+                tracing::info!(
+                    querier = querier_name,
+                    key_owners = %owners,
+                    public_key_hex = %pk_hex,
+                    "Verifying key reachability"
+                );
+
+                let key_info = mgr.get_key_by_public_key(pk).await?;
+                let got_pk = key_info.key_config.public_key()?;
+                assert_eq!(
+                    &got_pk,
+                    pk,
+                    "Node {querier_name} returned wrong key: expected {pk_hex}, got {}",
+                    hex::encode(got_pk.as_ref())
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Wait until the target's cluster_key_set no longer contains the given public key,
@@ -1747,6 +1870,165 @@ mod tests {
     // -----------------------------------------------------------------------
     // Group 5: Split-brain / convergence / edge case tests
     // -----------------------------------------------------------------------
+
+    /// Test that immediately after C joins both A and B (bridging a split brain),
+    /// every node can retrieve every key from the cluster via query.
+    ///
+    /// Scenario:
+    ///   A (bootstrap) → generates key_A
+    ///   B (bootstrap) → generates key_B (different from A)
+    ///   C (join A, B) → preboot merges key_A + key_B from both peers
+    ///
+    /// After C's `new()` returns (no artificial sleep), collect the full key set
+    /// from each node. Then, on each node, use `query_key_from_cluster` to fetch
+    /// every key (including keys the node doesn't have locally). Finally verify
+    /// that the union of all keys is reachable from every node.
+    ///
+    /// rotation_interval is set to 1 hour to prevent key rotation from
+    /// interfering with this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_split_brain_cross_node_key_query() {
+        run_test_with_tokio_runtime(async |runtime| {
+            let rotation_interval = 3600; // 1 hour — no rotation during test
+
+            // --- Phase 1: A and B bootstrap independently (split brain) ---
+
+            let port_a = portpicker::pick_unused_port().unwrap();
+            let args_a = make_peer_shared_args(port_a, vec![], rotation_interval);
+            let manager_a = PeerSharedKeyManager::new(runtime.clone(), args_a).await?;
+
+            let a_pk = manager_a
+                .get_client_visible_key()
+                .await?
+                .key_config
+                .public_key()?;
+
+            let port_b = portpicker::pick_unused_port().unwrap();
+            let args_b = make_peer_shared_args(port_b, vec![], rotation_interval);
+            let manager_b = PeerSharedKeyManager::new(runtime.clone(), args_b).await?;
+
+            let b_pk = manager_b
+                .get_client_visible_key()
+                .await?
+                .key_config
+                .public_key()?;
+
+            assert_ne!(
+                a_pk, b_pk,
+                "A and B should have different keys when bootstrapped independently"
+            );
+
+            // --- Phase 2: C joins both A and B, bridging the split brain ---
+
+            let port_c = portpicker::pick_unused_port().unwrap();
+            let args_c = make_peer_shared_args(
+                port_c,
+                vec![
+                    format!("127.0.0.1:{}", port_a),
+                    format!("127.0.0.1:{}", port_b),
+                ],
+                rotation_interval,
+            );
+            let manager_c = PeerSharedKeyManager::new(runtime.clone(), args_c).await?;
+
+            // --- Phase 3: Verify cross-node key accessibility ---
+
+            {
+                let c_keys: Vec<_> = manager_c
+                    .inner
+                    .cluster_key_set
+                    .read()
+                    .await
+                    .iter_keys()
+                    .map(|(pk, _)| pk.clone())
+                    .collect();
+                assert!(
+                    c_keys.len() >= 2,
+                    "C should have at least 2 keys after merging A and B, got {}",
+                    c_keys.len()
+                );
+            }
+
+            verify_all_keys_reachable(&[("A", &manager_a), ("B", &manager_b), ("C", &manager_c)])
+                .await?;
+
+            Ok(())
+        })
+        .await
+        .expect("test_split_brain_cross_node_key_query failed");
+    }
+
+    /// Test that after C bootstraps independently and later joins A + B,
+    /// every key becomes reachable from every node via query.
+    ///
+    /// Unlike `test_split_brain_cross_node_key_query` where C joins A/B during
+    /// construction (preboot merges keys automatically), this test has C start
+    /// as a fully independent third node, then explicitly call `join_peers_and_sync`
+    /// **after** `new()` returns. No artificial sleep is used.
+    ///
+    /// Rotation interval is 1 hour to prevent key rotation from interfering.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_split_brain_cross_node_key_query_deferred_join() {
+        run_test_with_tokio_runtime(async |runtime| {
+            let rotation_interval = 3600; // 1 hour
+
+            // --- Phase 1: A, B, C all bootstrap independently ---
+
+            let port_a = portpicker::pick_unused_port().unwrap();
+            let args_a = make_peer_shared_args(port_a, vec![], rotation_interval);
+            let manager_a = PeerSharedKeyManager::new(runtime.clone(), args_a).await?;
+
+            let a_pk = manager_a
+                .get_client_visible_key()
+                .await?
+                .key_config
+                .public_key()?;
+
+            let port_b = portpicker::pick_unused_port().unwrap();
+            let args_b = make_peer_shared_args(port_b, vec![], rotation_interval);
+            let manager_b = PeerSharedKeyManager::new(runtime.clone(), args_b).await?;
+
+            let b_pk = manager_b
+                .get_client_visible_key()
+                .await?
+                .key_config
+                .public_key()?;
+
+            let port_c = portpicker::pick_unused_port().unwrap();
+            let args_c = make_peer_shared_args(port_c, vec![], rotation_interval);
+            let manager_c = PeerSharedKeyManager::new(runtime.clone(), args_c).await?;
+
+            let c_pk = manager_c
+                .get_client_visible_key()
+                .await?
+                .key_config
+                .public_key()?;
+
+            assert_ne!(a_pk, b_pk, "A and B should have different keys");
+            assert_ne!(a_pk, c_pk, "A and C should have different keys");
+            assert_ne!(b_pk, c_pk, "B and C should have different keys");
+
+            // --- Phase 2: C explicitly joins A and B after construction ---
+            // This mirrors the file watcher scenario: only join_serf_cluster is called.
+            // No QueryClusterKeySetRequest is sent. A and B do NOT join C.
+
+            manager_c
+                .join_peers(&[
+                    format!("127.0.0.1:{}", port_a),
+                    format!("127.0.0.1:{}", port_b),
+                ])
+                .await?;
+
+            // --- Phase 3: Verify cross-node key accessibility ---
+
+            verify_all_keys_reachable(&[("A", &manager_a), ("B", &manager_b), ("C", &manager_c)])
+                .await?;
+
+            Ok(())
+        })
+        .await
+        .expect("test_split_brain_cross_node_key_query_deferred_join failed");
+    }
 
     /// Test the "two instances start simultaneously but cannot see each other" scenario.
     ///

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
@@ -193,52 +193,51 @@ impl PeerSharedKeyManager {
             let mut file_watcher = FileWatcher::new(peers_file_path_for_watcher.clone())
                 .map_err(|e| TngError::WatchFileFailed(peers_file_path_for_watcher.clone(), e))?;
 
-            runtime.spawn_supervised_task_current_span(async move {
-                    defer!{
-                        tracing::info!(peers_file = ?peers_file_path_for_watcher, "Peers file watcher stopped");
-                    }
+            runtime.spawn_supervised_task_with_span(tracing::info_span!("cluster_join_task"), async move {
+                defer! {
+                    tracing::info!(peers_file = ?peers_file_path_for_watcher, "Peers file watcher stopped");
+                }
 
-                    while let Some(result) = file_watcher.recv().await {
-                        match result {
-                            Ok(()) => {
-                                tracing::info!(peers_file = ?peers_file_path_for_watcher, "Peers file changed, reloading and joining new peers");
+                while let Some(result) = file_watcher.recv().await {
+                    match result {
+                        Ok(()) => {
+                            tracing::info!(peers_file = ?peers_file_path_for_watcher, "Peers file changed, reloading and joining new peers");
 
-                                match load_peers_from_file(&peers_file_path_for_watcher.to_string_lossy()).await {
-                                    Ok(new_peers) => {
-                                        tracing::info!(peers_count = new_peers.len(), "Loaded peers from file");
+                            match load_peers_from_file(&peers_file_path_for_watcher.to_string_lossy()).await {
+                                Ok(new_peers) => {
+                                    tracing::info!(peers_count = new_peers.len(), "Loaded peers from file");
 
-                                        // Join using newly loaded peers
-                                        let Some(serf_clone) = serf_weak_for_watcher.upgrade() else {
-                                            tracing::debug!(
-                                                "stop watching peers file since serf has been dropped"
-                                            );
-                                            break;
-                                        };
-
-                                        if let Err(error) = join_serf_cluster(&serf_clone, &new_peers).await {
-                                            tracing::warn!(?error, "Some peers from file failed to join, continuing...");
-                                        }
-                                    }
-                                    Err(error) => {
-                                        tracing::error!(
-                                            peers_file = ?peers_file_path_for_watcher,
-                                            ?error,
-                                            "Failed to load peers from updated file"
+                                    // Join using newly loaded peers
+                                    let Some(serf_clone) = serf_weak_for_watcher.upgrade() else {
+                                        tracing::debug!(
+                                            "stop watching peers file since serf has been dropped"
                                         );
+                                        break;
+                                    };
+
+                                    if let Err(error) = join_serf_cluster(&serf_clone, &new_peers).await {
+                                        tracing::warn!(?error, "Some peers from file failed to join, continuing...");
                                     }
                                 }
-                            }
-                            Err(error) => {
-                                tracing::error!(
-                                    peers_file = ?peers_file_path_for_watcher,
-                                    ?error,
-                                    "Internal error in peers file watcher"
-                                );
+                                Err(error) => {
+                                    tracing::error!(
+                                        peers_file = ?peers_file_path_for_watcher,
+                                        ?error,
+                                        "Failed to load peers from updated file"
+                                    );
+                                }
                             }
                         }
+                        Err(error) => {
+                            tracing::error!(
+                                peers_file = ?peers_file_path_for_watcher,
+                                ?error,
+                                "Internal error in peers file watcher"
+                            );
+                        }
                     }
-
-                });
+                }
+            });
         }
 
         Ok(())
@@ -285,9 +284,18 @@ impl PeerSharedKeyManager {
                     if let Ok(pb_response) =
                         pb::QueryClusterKeySetResponse::decode(response.payload().as_ref())
                     {
-                        if let Some(cks) = pb_response.cluster_key_set {
-                            if let Ok(remote_key_set) = ClusterKeySet::try_from(cks) {
-                                tracing::info!("Received cluster key set from peer");
+                        if let Some(pb_cks) = pb_response.cluster_key_set {
+                            if let Ok(remote_key_set) = ClusterKeySet::try_from(pb_cks) {
+                                let remote_keys: Vec<String> = remote_key_set
+                                    .iter_keys()
+                                    .map(|(pk, _)| hex::encode(pk.as_ref()))
+                                    .collect();
+                                tracing::info!(
+                                    peer_node_id = ?response.from(),
+                                    key_count = remote_keys.len(),
+                                    public_key_hex = ?remote_keys,
+                                    "Received cluster key set from peer"
+                                );
 
                                 if let Some(ref mut local) = merged_key_set {
                                     local.merge(remote_key_set);
@@ -300,7 +308,15 @@ impl PeerSharedKeyManager {
                 }
 
                 if let Some(key_set) = merged_key_set {
-                    tracing::info!("Preboot completed with synchronized cluster key set");
+                    let key_hex: Vec<String> = key_set
+                        .iter_keys()
+                        .map(|(pk, _)| hex::encode(pk.as_ref()))
+                        .collect();
+                    tracing::info!(
+                        key_count = key_hex.len(),
+                        public_key_hex = ?key_hex,
+                        "Preboot completed with synchronized cluster key set"
+                    );
                     return Ok(key_set);
                 }
 
@@ -322,7 +338,6 @@ impl PeerSharedKeyManager {
         }
 
         // Bootstrap: create initial active key
-        tracing::info!("Creating initial active key");
         let initial_key = KeyInfo::generate(
             0,
             KeyStatus::Active,
@@ -332,8 +347,11 @@ impl PeerSharedKeyManager {
         .map_err(|e| {
             TngError::KeyUpdateMessageDecodeError(anyhow!("Failed to generate initial key: {}", e))
         })?;
-
         let public_key = initial_key.key_config.public_key()?;
+        tracing::info!(
+            public_key_hex = %hex::encode(public_key.as_ref()),
+            "Created initial active key"
+        );
         Ok(ClusterKeySet::new(
             public_key,
             initial_key,
@@ -347,7 +365,7 @@ impl PeerSharedKeyManager {
         inner: Arc<PeerSharedKeyManagerInner>,
         serf: Weak<SerfGracefulShutdown>,
     ) {
-        runtime.spawn_supervised_task_current_span(async move {
+        runtime.spawn_supervised_task_with_span(tracing::info_span!("key_watcher"), async move {
             defer! {
                 tracing::info!("Key watcher stopped");
             }
@@ -362,15 +380,51 @@ impl PeerSharedKeyManager {
 
                     // 1. Handle pending -> active transition (first, as it triggers check_and_key_rotation)
                     let activated = cks.transition_pending_to_active(now);
+                    if activated > 0 {
+                        let active_keys: Vec<String> = cks
+                            .iter_keys()
+                            .filter(|(_, ki)| ki.status == KeyStatus::Active)
+                            .map(|(pk, _)| hex::encode(pk.as_ref()))
+                            .collect();
+                        tracing::info!(
+                            key_count = activated,
+                            active_keys_hex = ?active_keys,
+                            "Pending key transitioned to active"
+                        );
+                    }
 
                     // 2. Handle active -> stale transition
                     //    Capture the count of keys transitioned to stale — needed to trigger
                     //    rotation when the bootstrap-created initial key (which skips the
                     //    Pending->Active path) becomes stale.
                     let stale_transitioned = cks.transition_active_to_stale(now);
+                    if stale_transitioned > 0 {
+                        let stale_keys: Vec<String> = cks
+                            .iter_keys()
+                            .filter(|(_, ki)| ki.status == KeyStatus::Stale)
+                            .map(|(pk, _)| hex::encode(pk.as_ref()))
+                            .collect();
+                        tracing::info!(
+                            key_count = stale_transitioned,
+                            stale_keys_hex = ?stale_keys,
+                            "Active key(s) transitioned to stale"
+                        );
+                    }
 
                     // 3. Remove expired stale keys
-                    cks.remove_expired_keys(now);
+                    let removed_count = cks.remove_expired_keys(now);
+                    if removed_count > 0 {
+                        let remaining_keys: Vec<String> = cks
+                            .iter_keys()
+                            .map(|(pk, _)| hex::encode(pk.as_ref()))
+                            .collect();
+                        tracing::info!(
+                            removed_count,
+                            remaining_key_count = remaining_keys.len(),
+                            remaining_keys_hex = ?remaining_keys,
+                            "Removed expired stale key(s)"
+                        );
+                    }
 
                     // 4. Detect if all active keys are stale-eligible but were preserved
                     //    by transition_active_to_stale (which preserves the last active key
@@ -459,6 +513,7 @@ impl PeerSharedKeyManager {
         if let Some(public_key) = generated {
             tracing::info!(
                 ?public_key,
+                public_key_hex = %hex::encode(public_key.as_ref()),
                 "Master node generated new pending key, broadcasting to cluster"
             );
 
@@ -528,53 +583,65 @@ impl PeerSharedKeyManager {
         inner: Arc<PeerSharedKeyManagerInner>,
         serf: Weak<SerfGracefulShutdown>,
     ) {
-        runtime.spawn_unsupervised_task_current_span(async move {
-            defer! {
-                tracing::info!("Serf watcher stopped");
-            }
+        runtime.spawn_unsupervised_task_with_span(
+            tracing::info_span!("serf_watcher"),
+            async move {
+                defer! {
+                    tracing::info!("Serf watcher stopped");
+                }
 
-            tracing::info!("Starting serf watcher");
+                tracing::info!("Starting serf watcher");
 
-            loop {
-                let Ok(event) = subscriber.recv().await else {
-                    tracing::debug!("Serf event channel closed, task quit");
-                    break;
-                };
+                loop {
+                    let Ok(event) = subscriber.recv().await else {
+                        tracing::debug!("Serf event channel closed, task quit");
+                        break;
+                    };
 
-                match event {
-                    Event::Query(query) => {
-                        if let Err(error) = Self::handle_query(&query, &inner).await {
-                            tracing::warn!(?error, "Error handling query");
+                    match event {
+                        Event::Query(query) => {
+                            if let Err(error) = Self::handle_query(&query, &inner).await {
+                                tracing::warn!(
+                                    ?error,
+                                    name = query.name().as_str(),
+                                    from = query.from().to_string(),
+                                    "Error handling query"
+                                );
+                            }
                         }
-                    }
-                    Event::User(user_event) => {
-                        if let Err(error) = Self::handle_user_event(
-                            user_event.name().as_str(),
-                            user_event.payload(),
-                            &inner,
-                        )
-                        .await
-                        {
-                            tracing::warn!(?error, "Error handling user event");
-                        }
-                    }
-                    Event::Member(member_event) => {
-                        if matches!(member_event.ty(), MemberEventType::Leave) {
-                            tracing::info!("Member left, triggering key rotation check");
+                        Event::User(user_event) => {
+                            if let Err(error) = Self::handle_user_event(
+                                user_event.name().as_str(),
+                                user_event.payload(),
+                                &inner,
+                            )
+                            .await
                             {
-                                let Some(serf) = serf.upgrade() else {
-                                    tracing::debug!(
-                                        "stop serf watcher since serf has been dropped"
-                                    );
-                                    break;
-                                };
-                                Self::check_and_key_rotation(&serf, &inner).await;
+                                tracing::warn!(
+                                    ?error,
+                                    name = user_event.name().as_str(),
+                                    "Error handling user event"
+                                );
+                            }
+                        }
+                        Event::Member(member_event) => {
+                            if matches!(member_event.ty(), MemberEventType::Leave) {
+                                tracing::info!("Member left, triggering key rotation check");
+                                {
+                                    let Some(serf) = serf.upgrade() else {
+                                        tracing::debug!(
+                                            "stop serf watcher since serf has been dropped"
+                                        );
+                                        break;
+                                    };
+                                    Self::check_and_key_rotation(&serf, &inner).await;
+                                }
                             }
                         }
                     }
                 }
-            }
-        });
+            },
+        );
     }
 
     /// Handle incoming query requests.
@@ -635,13 +702,21 @@ impl PeerSharedKeyManager {
 
                 if let Some(pb_cluster_key_set) = event.cluster_key_set {
                     let remote_key_set: ClusterKeySet = pb_cluster_key_set.try_into()?;
+                    let merged_keys: Vec<String> = remote_key_set
+                        .iter_keys()
+                        .map(|(pk, _)| hex::encode(pk.as_ref()))
+                        .collect();
 
                     {
                         let mut cks = inner.cluster_key_set.write().await;
                         cks.merge(remote_key_set);
                     }
 
-                    tracing::info!("Merged broadcasted cluster key set");
+                    tracing::info!(
+                        key_count = merged_keys.len(),
+                        public_key_hex = ?merged_keys,
+                        "Merged broadcasted cluster key set"
+                    );
                 }
             }
             _ => {
@@ -694,6 +769,7 @@ impl PeerSharedKeyManager {
                                 tracing::info!(
                                     node_id = ?response.from(),
                                     ?public_key,
+                                    public_key_hex = %hex::encode(public_key.as_ref()),
                                     "Received key from peer via query"
                                 );
                                 return Ok(Some(key_info));


### PR DESCRIPTION
## Summary

This branch includes a collection of improvements to the test framework, OHTTP tracing, and dependency updates:

### Test Framework Refactoring
- **`ShellMode` restored to 2D semantics** — Two independent dimensions: execution style (foreground vs background) and finish policy (stop vs continue), with a clear truth table in the docs
- **`spawn_with_tagged_output` → `spawn_with_span_output`** — Replaced `[tag]` log prefix with `tracing::info!` under the current span, providing structured context instead of ad-hoc string prefixes
- **`launch_with_node_type`** — New trait method for explicit node type propagation to output tagging
- **Test runner improvements** — Better sequential execution, integration test guidelines added to CLAUDE.md

### OHTTP / Serf
- **Skip self-originated queries** in serf watcher to avoid spurious deadline exceeded logs
- **Improved tracing logs** with explicit spans and key details
- **Split-brain cross-node key query tests** and tracing coverage

### Other
- **chore(deps)**: Switch `memberlist` crates to merged upstream `al8n/memberlist`
- **fix(scripts/bench.sh)**: Fix shellcheck warnings SC2034 and SC2086

## Commits

- 188c781 fix(scripts/bench.sh): fix shellcheck warnings SC2034 and SC2086
- 58160a6 chore: improve test runner and add integration test guidelines
- a4474be fix(testsuite): fix output tag prefix for tasks with overridden node type
- 43417a6 refactor(testsuite): restore 2D semantics for ShellMode
- f46b9f3 refactor(testsuite): replace [tag] log prefix with tracing span instrumentation
- 3534da9 chore(deps): switch memberlist crates to merged upstream al8n/memberlist
- ecdf3ad refactor(ohttp): improve tracing logs with explicit spans and key details
- 09764bd fix(ohttp): skip self-originated queries in serf watcher to avoid spurious deadline logs
- a95ce5e fix(testsuite): update comment to match ForegroundContinue mode in ohttp test
- 1ec79e8 feat(ohttp): add split-brain cross-node key query tests and tracing