### PR TITLE
refactor(access-log): replace monolithic AccessLog enum with RAII state machine

### DIFF
--- a/tng/src/tunnel/access_log.rs
+++ b/tng/src/tunnel/access_log.rs
@@ -1,10 +1,7 @@
-use std::{
-    borrow::Cow,
-    fmt::{Debug, Display},
-    net::SocketAddr,
-};
+use std::fmt::Display;
+use std::net::SocketAddr;
 
-use super::attestation_result::AttestationResult;
+// --- Mode enums (kept as-is, re-exported alongside new structs) ---
 
 /// The type of ingress that accepted the downstream connection.
 #[derive(Debug, Clone, Copy)]
@@ -48,82 +45,270 @@ impl Display for EgressMode {
     }
 }
 
-#[derive(Debug)]
-#[allow(dead_code)]
-pub enum AccessLog<'a, T1: Debug + Display, T2: Debug + Display> {
-    Ingress {
-        downstream_remote: T1,
-        upstream_remote: T2,
-        to_trusted_tunnel: bool,
-        attestation_result: Option<Cow<'a, AttestationResult>>,
-        /// The ingress listener address that accepted the client connection.
-        downstream_local: SocketAddr,
-        /// The type of ingress that accepted the downstream connection.
-        ingress_mode: IngressMode,
-        /// The local address of the connection to upstream (rats-tls local addr or plain TCP local addr).
-        upstream_local: Option<SocketAddr>,
-    },
-    Egress {
-        downstream_remote: T1,
-        upstream_remote: T2,
-        from_trusted_tunnel: bool,
-        attestation_info: Option<Cow<'a, AttestationResult>>,
-        /// The egress listener address that accepted the tunnel connection.
-        downstream_local: SocketAddr,
-        /// The type of egress that accepted the downstream connection.
-        egress_mode: EgressMode,
-        /// The local address assigned when egress connected to upstream.
-        upstream_local: Option<SocketAddr>,
-    },
+// --- Unified mode wrapper for Display purposes ---
+
+#[derive(Clone, Copy)]
+enum AccessMode {
+    Ingress(IngressMode),
+    Egress(EgressMode),
 }
 
-impl<T1: Debug + Display, T2: Debug + Display> Display for AccessLog<'_, T1, T2> {
+impl Display for AccessMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AccessLog::Ingress {
-                downstream_remote,
-                upstream_remote,
-                to_trusted_tunnel,
-                attestation_result,
-                downstream_local,
-                ingress_mode,
-                upstream_local,
-            } => {
-                write!(f, "ingress downstream_remote={downstream_remote} -> downstream_local={downstream_local}({ingress_mode})")?;
-                if let Some(local) = upstream_local {
-                    write!(f, " -> upstream_local={local}")?;
-                }
-                write!(f, " -> upstream_remote={upstream_remote}")?;
-                if *to_trusted_tunnel {
-                    write!(f, " tunnel")?;
-                }
-                if attestation_result.is_some() {
-                    write!(f, " attested")?;
-                }
-                Ok(())
-            }
-            AccessLog::Egress {
-                downstream_remote,
-                upstream_remote,
-                from_trusted_tunnel,
-                attestation_info,
-                downstream_local,
-                egress_mode,
-                upstream_local,
-            } => {
-                write!(f, "egress downstream_remote={downstream_remote} -> downstream_local={downstream_local}({egress_mode})")?;
-                if let Some(local) = upstream_local {
-                    write!(f, " -> upstream_local={local}")?;
-                }
-                write!(f, " -> upstream_remote={upstream_remote}")?;
-                if *from_trusted_tunnel {
-                    write!(f, " tunnel")?;
-                }
-                if attestation_info.is_some() {
-                    write!(f, " attested")?;
-                }
-                Ok(())
-            }
+            AccessMode::Ingress(m) => write!(f, "{m}"),
+            AccessMode::Egress(m) => write!(f, "{m}"),
         }
+    }
+}
+
+// --- State 1: AccessAccepted ---
+
+/// Downstream connection accepted, but routing to upstream not yet determined.
+/// Drop logs at ERROR level.
+pub struct AccessAccepted {
+    downstream_remote: SocketAddr,
+    downstream_local: SocketAddr,
+    mode: AccessMode,
+}
+
+impl AccessAccepted {
+    pub fn new_ingress(
+        downstream_remote: SocketAddr,
+        downstream_local: SocketAddr,
+        mode: IngressMode,
+    ) -> Self {
+        Self {
+            downstream_remote,
+            downstream_local,
+            mode: AccessMode::Ingress(mode),
+        }
+    }
+
+    pub fn new_egress(
+        downstream_remote: SocketAddr,
+        downstream_local: SocketAddr,
+        mode: EgressMode,
+    ) -> Self {
+        Self {
+            downstream_remote,
+            downstream_local,
+            mode: AccessMode::Egress(mode),
+        }
+    }
+
+    /// Returns the downstream remote address for recreating AccessAccepted
+    /// in egress flow's inner loop.
+    pub fn downstream_remote_addr(&self) -> SocketAddr {
+        self.downstream_remote
+    }
+
+    /// Returns the downstream local address for recreating AccessAccepted
+    /// in egress flow's inner loop.
+    pub fn downstream_local_addr(&self) -> SocketAddr {
+        self.downstream_local
+    }
+
+    /// Returns the egress mode, or None if this is an ingress AccessAccepted.
+    pub fn egress_mode(&self) -> Option<EgressMode> {
+        match self.mode {
+            AccessMode::Egress(m) => Some(m),
+            AccessMode::Ingress(_) => None,
+        }
+    }
+
+    /// Transition to AccessRouted. Consumes self.
+    pub fn into_routed(self, upstream_remote: impl Display, tunnel: bool) -> AccessRouted {
+        AccessRouted {
+            downstream_remote: self.downstream_remote,
+            downstream_local: self.downstream_local,
+            mode: self.mode,
+            upstream_remote: upstream_remote.to_string(),
+            tunnel,
+        }
+    }
+}
+
+impl Display for AccessAccepted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "downstream_remote={} -> downstream_local={}({}) — accepted only",
+            self.downstream_remote, self.downstream_local, self.mode
+        )
+    }
+}
+
+impl Drop for AccessAccepted {
+    fn drop(&mut self) {
+        tracing::error!("{}", self);
+    }
+}
+
+// --- State 2: AccessRouted ---
+
+/// Upstream target determined, but TCP connection not yet established.
+/// Drop logs at ERROR level.
+#[allow(dead_code)]
+pub struct AccessRouted {
+    downstream_remote: SocketAddr,
+    downstream_local: SocketAddr,
+    mode: AccessMode,
+    upstream_remote: String,
+    tunnel: bool,
+}
+
+#[allow(dead_code)]
+impl AccessRouted {
+    /// Transition to AccessEstablished. Consumes self.
+    pub fn into_established(
+        self,
+        upstream_local: Option<SocketAddr>,
+        attested: bool,
+    ) -> AccessEstablished {
+        AccessEstablished {
+            downstream_remote: self.downstream_remote,
+            downstream_local: self.downstream_local,
+            mode: self.mode,
+            upstream_remote: self.upstream_remote.clone(),
+            upstream_local,
+            tunnel: self.tunnel,
+            attested,
+        }
+    }
+}
+
+impl Display for AccessRouted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "downstream_remote={} -> downstream_local={}({}) -> upstream_remote={} — not connected tunnel={}",
+            self.downstream_remote, self.downstream_local, self.mode, self.upstream_remote, self.tunnel
+        )
+    }
+}
+
+impl Drop for AccessRouted {
+    fn drop(&mut self) {
+        tracing::error!("{}", self);
+    }
+}
+
+// --- State 3: AccessEstablished ---
+
+/// Upstream TCP connected, ready to forward.
+/// Drop logs at INFO level.
+pub struct AccessEstablished {
+    downstream_remote: SocketAddr,
+    downstream_local: SocketAddr,
+    mode: AccessMode,
+    upstream_remote: String,
+    upstream_local: Option<SocketAddr>,
+    tunnel: bool,
+    attested: bool,
+}
+
+impl AccessEstablished {}
+
+impl Display for AccessEstablished {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "downstream_remote={} -> downstream_local={}({}) -> upstream_remote={}",
+            self.downstream_remote, self.downstream_local, self.mode, self.upstream_remote
+        )?;
+        if let Some(local) = self.upstream_local {
+            write!(f, " -> upstream_local={}", local)?;
+        }
+        write!(f, " — tunnel={}", self.tunnel)?;
+        // Only print attested if tunnel is true (meaningful only with tunnel)
+        // Actually per spec, always print attested in established state
+        write!(f, " attested={}", self.attested)?;
+        Ok(())
+    }
+}
+
+impl Drop for AccessEstablished {
+    fn drop(&mut self) {
+        tracing::info!("{}", self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_access_accepted_display() {
+        let accepted = AccessAccepted::new_egress(
+            "10.0.0.1:54321".parse().unwrap(),
+            "0.0.0.0:8080".parse().unwrap(),
+            EgressMode::Hook,
+        );
+        assert_eq!(
+            format!("{accepted}"),
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) — accepted only"
+        );
+        std::mem::forget(accepted); // suppress Drop log in test
+    }
+
+    #[test]
+    fn test_access_routed_display() {
+        let accepted = AccessAccepted::new_egress(
+            "10.0.0.1:54321".parse().unwrap(),
+            "0.0.0.0:8080".parse().unwrap(),
+            EgressMode::Hook,
+        );
+        let routed = accepted.into_routed("10.0.0.2:443", false);
+        assert_eq!(
+            format!("{routed}"),
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> upstream_remote=10.0.0.2:443 — not connected tunnel=false"
+        );
+        std::mem::forget(routed);
+    }
+
+    #[test]
+    fn test_access_established_display_no_local() {
+        let accepted = AccessAccepted::new_egress(
+            "10.0.0.1:54321".parse().unwrap(),
+            "0.0.0.0:8080".parse().unwrap(),
+            EgressMode::Hook,
+        );
+        let routed = accepted.into_routed("10.0.0.2:443", false);
+        let established = routed.into_established(None, false);
+        assert_eq!(
+            format!("{established}"),
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> upstream_remote=10.0.0.2:443 — tunnel=false attested=false"
+        );
+        std::mem::forget(established);
+    }
+
+    #[test]
+    fn test_access_established_display_with_local() {
+        let accepted = AccessAccepted::new_ingress(
+            "10.0.0.1:54321".parse().unwrap(),
+            "0.0.0.0:8080".parse().unwrap(),
+            IngressMode::Mapping,
+        );
+        let routed = accepted.into_routed("10.0.0.2:443", true);
+        let established = routed.into_established(Some("10.0.0.1:54322".parse().unwrap()), true);
+        assert_eq!(
+            format!("{established}"),
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(mapping) -> upstream_remote=10.0.0.2:443 -> upstream_local=10.0.0.1:54322 — tunnel=true attested=true"
+        );
+        std::mem::forget(established);
+    }
+
+    #[test]
+    fn test_ingress_mode_display() {
+        assert_eq!(format!("{}", IngressMode::Mapping), "mapping");
+        assert_eq!(format!("{}", IngressMode::Socks5), "socks5");
+        assert_eq!(format!("{}", IngressMode::HttpProxy), "http_proxy");
+    }
+
+    #[test]
+    fn test_egress_mode_display() {
+        assert_eq!(format!("{}", EgressMode::Mapping), "mapping");
+        assert_eq!(format!("{}", EgressMode::Hook), "hook");
     }
 }

--- a/tng/src/tunnel/egress/flow.rs
+++ b/tng/src/tunnel/egress/flow.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -13,7 +12,7 @@ use tokio::sync::mpsc::Sender;
 use crate::config::egress::CommonArgs;
 use crate::error::TngError;
 use crate::status::{StatusProvider, StatusQueryResult};
-use crate::tunnel::access_log::{AccessLog, EgressMode};
+use crate::tunnel::access_log::{AccessAccepted, EgressMode};
 use crate::tunnel::service_metrics::ServiceMetrics;
 use crate::tunnel::service_metrics::ServiceMetricsCreator;
 use crate::tunnel::utils;
@@ -47,12 +46,14 @@ pub(super) trait EgressTrait: Sync + Send {
 
 pub(super) type Incomming<'a> = Box<dyn Stream<Item = Result<AcceptedStream>> + Send + 'a>;
 
+#[allow(dead_code)]
 pub(super) struct AcceptedStream {
     pub stream: Box<dyn CommonStreamTrait + Sync>,
     pub src: SocketAddr,
     pub dst: Arc<TngEndpoint>,
     pub listener_addr: SocketAddr,
     pub egress_mode: EgressMode,
+    pub access_accepted: AccessAccepted,
 }
 
 impl EgressFlow {
@@ -133,9 +134,19 @@ impl EgressFlow {
             stream,
             src,
             dst,
-            listener_addr,
-            egress_mode,
+            listener_addr: _,
+            egress_mode: _,
+            access_accepted,
         } = accepted_stream;
+
+        // Egress processes multiple upstream connections per accepted downstream.
+        // Extract access_accepted fields here so they can be cloned per inner-loop iteration.
+        let access_src = access_accepted.downstream_remote_addr();
+        let access_local = access_accepted.downstream_local_addr();
+        let access_egress_mode = match access_accepted.egress_mode() {
+            Some(mode) => mode,
+            None => panic!("egress flow: AccessAccepted must have egress mode"),
+        };
 
         let trusted_stream_manager = self.trusted_stream_manager.clone();
         let metrics = self.metrics.clone();
@@ -176,9 +187,17 @@ impl EgressFlow {
                             let active_cx = metrics.new_cx();
 
                             let from_trusted_tunnel = next_stream.is_secured();
-                            let attestation_info =
-                                next_stream.attestation_result().cloned().map(Cow::Owned);
+                            let attested = next_stream.attestation_result().is_some();
                             let downstream = next_stream.into_stream();
+
+                            // Transition to AccessRouted: dst and from_trusted_tunnel are known
+                            let access_accepted = AccessAccepted::new_egress(
+                                access_src,
+                                access_local,
+                                access_egress_mode,
+                            );
+                            let access_routed =
+                                access_accepted.into_routed(&dst, from_trusted_tunnel);
 
                             let upstream = tcp_connect(
                                 (dst.host(), dst.port()),
@@ -194,17 +213,8 @@ impl EgressFlow {
                             let egress_local = upstream.local_addr().ok();
                             let upstream = ContextualStream::new(upstream, "egress-tcp-connect");
 
-                            // Print access log
-                            let access_log = AccessLog::Egress {
-                                downstream_remote: src,
-                                upstream_remote: &dst,
-                                from_trusted_tunnel,
-                                attestation_info,
-                                downstream_local: listener_addr,
-                                egress_mode,
-                                upstream_local: egress_local,
-                            };
-                            tracing::info!(%access_log);
+                            // Print access log — Transition to AccessEstablished: upstream connected, then drop immediately to log
+                            access_routed.into_established(egress_local, attested);
 
                             let downstream = metrics.new_wrapped_stream(downstream);
 

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use tokio::net::TcpListener;
 
 use crate::config::HookMappingEntry;
-use crate::tunnel::access_log::EgressMode;
+use crate::tunnel::access_log::{AccessAccepted, EgressMode};
 use crate::tunnel::egress::flow::AcceptedStream;
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::utils::runtime::TokioRuntime;
@@ -111,20 +111,20 @@ impl EgressTrait for HookEgress {
                                 } else {
                                     local.ip().to_string()
                                 };
-                                let upstream_addr = format!("{}:{}", upstream_host, info.real_port);
                                 let dst = Arc::new(TngEndpoint::new(upstream_host, info.real_port));
 
-                                tracing::info!(
-                                    "hook chain: client={} → listener={} → upstream={} OK",
-                                    peer_addr, info.local_addr, upstream_addr
+                                let access_accepted = AccessAccepted::new_egress(
+                                    peer_addr,
+                                    info.local_addr,
+                                    EgressMode::Hook,
                                 );
-
                                 yield Ok(AcceptedStream {
                                     stream: Box::new(crate::ContextualStream::new(stream, "egress-hook")),
                                     src: peer_addr,
                                     dst,
                                     listener_addr: info.local_addr,
                                     egress_mode: EgressMode::Hook,
+                                    access_accepted,
                                 })
                             }
                             Err(e) => yield Err(anyhow!(e)),

--- a/tng/src/tunnel/egress/mapping.rs
+++ b/tng/src/tunnel/egress/mapping.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpListener;
 
 use crate::{
     config::egress::EgressMappingArgs,
-    tunnel::access_log::EgressMode,
+    tunnel::access_log::{AccessAccepted, EgressMode},
     tunnel::{
         egress::flow::AcceptedStream, endpoint::TngEndpoint, utils::runtime::TokioRuntime,
         utils::socket::SetListenerSockOpts,
@@ -125,13 +125,21 @@ impl EgressTrait for MappingEgress {
                 Box::pin(stream! {
                     loop {
                         match target.listener.accept_with_common_sock_opts().await {
-                            Ok((stream, peer_addr)) => yield Ok(AcceptedStream {
-                                stream: Box::new(crate::ContextualStream::new(stream, "egress-mapping")),
-                                src: peer_addr,
-                                dst: Arc::clone(&target.out_ep),
-                                listener_addr: target.local_addr,
-                                egress_mode: EgressMode::Mapping,
-                            }),
+                            Ok((stream, peer_addr)) => {
+                                let access_accepted = AccessAccepted::new_egress(
+                                    peer_addr,
+                                    target.local_addr,
+                                    EgressMode::Mapping,
+                                );
+                                yield Ok(AcceptedStream {
+                                    stream: Box::new(crate::ContextualStream::new(stream, "egress-mapping")),
+                                    src: peer_addr,
+                                    dst: Arc::clone(&target.out_ep),
+                                    listener_addr: target.local_addr,
+                                    egress_mode: EgressMode::Mapping,
+                                    access_accepted,
+                                })
+                            }
                             Err(e) => yield Err(anyhow!(e)),
                         }
                     }

--- a/tng/src/tunnel/egress/netfilter/mod.rs
+++ b/tng/src/tunnel/egress/netfilter/mod.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpListener;
 
 use crate::{
     config::egress::{EgressNetfilterArgs, EgressNetfilterCaptureDst},
-    tunnel::access_log::EgressMode,
+    tunnel::access_log::{AccessAccepted, EgressMode},
     tunnel::{
         egress::flow::AcceptedStream,
         endpoint::TngEndpoint,
@@ -130,12 +130,18 @@ impl EgressTrait for NetfilterEgress {
 
                 let dst = Arc::new(TngEndpoint::new(orig_dst.ip().to_string(), orig_dst.port()));
 
+                let access_accepted = AccessAccepted::new_egress(
+                    peer_addr,
+                    listen_addr,
+                    EgressMode::Netfilter,
+                );
                 Ok(AcceptedStream {
                     stream: Box::new(crate::ContextualStream::new(stream, "egress-netfilter")),
                     src: peer_addr,
                     dst,
                     listener_addr: listen_addr,
                     egress_mode: EgressMode::Netfilter,
+                    access_accepted,
                 })
             }),
         ))

--- a/tng/src/tunnel/ingress/flow/mod.rs
+++ b/tng/src/tunnel/ingress/flow/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -13,7 +12,7 @@ use tokio::sync::mpsc::Sender;
 use crate::config::ingress::CommonArgs;
 use crate::error::TngError;
 use crate::status::{StatusProvider, StatusQueryResult};
-use crate::tunnel::access_log::{AccessLog, IngressMode};
+use crate::tunnel::access_log::{AccessAccepted, IngressMode};
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::service_metrics::ServiceMetrics;
 use crate::tunnel::service_metrics::ServiceMetricsCreator;
@@ -50,6 +49,7 @@ pub(super) trait IngressTrait: Sync + Send {
 
 pub(super) type Incomming<'a> = Pin<Box<dyn Stream<Item = Result<AcceptedStream>> + Send + 'a>>;
 
+#[allow(dead_code)]
 pub(super) struct AcceptedStream {
     pub stream: Box<dyn CommonStreamTrait + Send>,
     pub src: SocketAddr,
@@ -57,6 +57,7 @@ pub(super) struct AcceptedStream {
     pub via_tunnel: bool,
     pub listener_addr: SocketAddr,
     pub ingress_mode: IngressMode,
+    pub access_accepted: AccessAccepted,
 }
 
 impl IngressFlow {
@@ -142,8 +143,9 @@ impl IngressFlow {
             src,
             dst,
             via_tunnel,
-            listener_addr,
-            ingress_mode,
+            listener_addr: _,
+            ingress_mode: _,
+            access_accepted,
         } = accepted_stream;
 
         let trusted_stream_manager = self.trusted_stream_manager.clone();
@@ -161,6 +163,9 @@ impl IngressFlow {
                     // TODO: merge .new_cx() and .new_wrapped_stream()
                     let active_cx = metrics.new_cx();
                     let stream = metrics.new_wrapped_stream(stream);
+
+                    // Transition to AccessRouted: dst and via_tunnel are known here
+                    let access_routed = access_accepted.into_routed(&dst, via_tunnel);
 
                     let attestation_result;
                     let upstream_local;
@@ -190,17 +195,8 @@ impl IngressFlow {
                         forward_stream_task
                     };
 
-                    // Print access log
-                    let access_log = AccessLog::Ingress {
-                        downstream_remote: src,
-                        upstream_remote: &dst,
-                        to_trusted_tunnel: via_tunnel,
-                        attestation_result: attestation_result.map(Cow::Owned),
-                        downstream_local: listener_addr,
-                        ingress_mode,
-                        upstream_local,
-                    };
-                    tracing::info!(%access_log);
+                    // Print access log — Transition to AccessEstablished: upstream connected, then drop immediately to log
+                    access_routed.into_established(upstream_local, attestation_result.is_some());
 
                     // let forward_stream_task = pin!(forward_stream_task);
                     match forward_stream_task.await {

--- a/tng/src/tunnel/ingress/http_proxy.rs
+++ b/tng/src/tunnel/ingress/http_proxy.rs
@@ -21,7 +21,7 @@ use tower::ServiceBuilder;
 use tracing::Instrument;
 
 use crate::config::ingress::IngressHttpProxyArgs;
-use crate::tunnel::access_log::IngressMode;
+use crate::tunnel::access_log::{AccessAccepted, IngressMode};
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::ingress::flow::stream_router::StreamRouter;
 use crate::tunnel::utils::endpoint_matcher::EndpointMatcher;
@@ -147,6 +147,11 @@ impl RequestHelper {
                         .context("Failed during http connect upgrade")?;
 
                     let via_tunnel = stream_router.should_forward_via_tunnel(&dst);
+                    let access_accepted = AccessAccepted::new_ingress(
+                        peer_addr,
+                        listener_addr,
+                        IngressMode::HttpProxy,
+                    );
                     sender
                         .send(AcceptedStream {
                             stream: Box::new(crate::ContextualStream::new(
@@ -158,6 +163,7 @@ impl RequestHelper {
                             via_tunnel,
                             listener_addr,
                             ingress_mode: IngressMode::HttpProxy,
+                            access_accepted,
                         })
                         .map_err(|e| anyhow!("{e:?}"))?;
 
@@ -188,7 +194,12 @@ impl RequestHelper {
 
                 let send_accepted_stream = async {
                     let via_tunnel = stream_router.should_forward_via_tunnel(&dst);
-                    sender.send(AcceptedStream { stream: Box::new(crate::ContextualStream::new(s2, "ingress-http-reverse-proxy")), src: peer_addr, dst: Arc::new(dst), via_tunnel, listener_addr, ingress_mode: IngressMode::HttpProxy })
+                    let access_accepted = AccessAccepted::new_ingress(
+                        peer_addr,
+                        listener_addr,
+                        IngressMode::HttpProxy,
+                    );
+                    sender.send(AcceptedStream { stream: Box::new(crate::ContextualStream::new(s2, "ingress-http-reverse-proxy")), src: peer_addr, dst: Arc::new(dst), via_tunnel, listener_addr, ingress_mode: IngressMode::HttpProxy, access_accepted })
                 };
 
                 let send_task = async {

--- a/tng/src/tunnel/ingress/mapping.rs
+++ b/tng/src/tunnel/ingress/mapping.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use tokio::net::TcpListener;
 
 use crate::config::ingress::IngressMappingArgs;
-use crate::tunnel::access_log::IngressMode;
+use crate::tunnel::access_log::{AccessAccepted, IngressMode};
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::ingress::flow::AcceptedStream;
 use crate::tunnel::utils::runtime::TokioRuntime;
@@ -125,14 +125,22 @@ impl IngressTrait for MappingIngress {
                 Box::pin(stream! {
                     loop {
                         match target.listener.accept_with_common_sock_opts().await {
-                            Ok((stream, peer_addr)) => yield Ok(AcceptedStream {
-                                stream: Box::new(crate::ContextualStream::new(stream, "ingress-mapping")),
-                                src: peer_addr,
-                                dst: Arc::clone(&target.out_ep),
-                                via_tunnel: true,
-                                listener_addr: target.local_addr,
-                                ingress_mode: IngressMode::Mapping,
-                            }),
+                            Ok((stream, peer_addr)) => {
+                                let access_accepted = AccessAccepted::new_ingress(
+                                    peer_addr,
+                                    target.local_addr,
+                                    IngressMode::Mapping,
+                                );
+                                yield Ok(AcceptedStream {
+                                    stream: Box::new(crate::ContextualStream::new(stream, "ingress-mapping")),
+                                    src: peer_addr,
+                                    dst: Arc::clone(&target.out_ep),
+                                    via_tunnel: true,
+                                    listener_addr: target.local_addr,
+                                    ingress_mode: IngressMode::Mapping,
+                                    access_accepted,
+                                })
+                            }
                             Err(e) => yield Err(anyhow!(e)),
                         }
                     }

--- a/tng/src/tunnel/ingress/netfilter/mod.rs
+++ b/tng/src/tunnel/ingress/netfilter/mod.rs
@@ -10,7 +10,7 @@ use tokio::net::TcpListener;
 
 use crate::config::ingress::IngressNetfilterArgs;
 use crate::config::ingress::IngressNetfilterCaptureDst;
-use crate::tunnel::access_log::IngressMode;
+use crate::tunnel::access_log::{AccessAccepted, IngressMode};
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::ingress::flow::AcceptedStream;
 use crate::tunnel::utils::iptables::IptablesExecutor;
@@ -123,6 +123,11 @@ impl IngressTrait for NetfilterIngress {
 
                 let orig_dst = TngEndpoint::new(orig_dst.ip().to_string(), orig_dst.port());
 
+                let access_accepted = AccessAccepted::new_ingress(
+                    peer_addr,
+                    listen_addr,
+                    IngressMode::Netfilter,
+                );
                 Ok::<_, anyhow::Error>(AcceptedStream{
                     stream: Box::new(crate::ContextualStream::new(stream, "ingress-netfilter")),
                     src: peer_addr,
@@ -130,6 +135,7 @@ impl IngressTrait for NetfilterIngress {
                     via_tunnel: true,
                     listener_addr: listen_addr,
                     ingress_mode: IngressMode::Netfilter,
+                    access_accepted,
                 })
             })
         ))

--- a/tng/src/tunnel/ingress/socks5.rs
+++ b/tng/src/tunnel/ingress/socks5.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::config::ingress::{IngressSocks5Args, Socks5AuthArgs};
-use crate::tunnel::access_log::IngressMode;
+use crate::tunnel::access_log::{AccessAccepted, IngressMode};
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::ingress::flow::AcceptedStream;
 use crate::tunnel::utils::endpoint_matcher::EndpointMatcher;
@@ -161,6 +161,8 @@ impl IngressTrait for Socks5Ingress {
 
                     let via_tunnel = self.stream_router.should_forward_via_tunnel(&dst);
 
+                    let access_accepted =
+                        AccessAccepted::new_ingress(peer_addr, listener_addr, IngressMode::Socks5);
                     Ok(AcceptedStream {
                         stream: Box::new(crate::ContextualStream::new(stream, "ingress-socks5")),
                         src: peer_addr,
@@ -168,6 +170,7 @@ impl IngressTrait for Socks5Ingress {
                         via_tunnel,
                         listener_addr,
                         ingress_mode: IngressMode::Socks5,
+                        access_accepted,
                     })
                 }
             })


### PR DESCRIPTION
## Summary

Replace the monolithic `AccessLog` enum with a consumption-based RAII state machine (`AccessAccepted → AccessRouted → AccessEstablished`) where each state's `Drop` guarantees logging at the appropriate level.

## Problem

The previous `AccessLog` enum was created at a single point (after all data was available) and explicitly printed with `tracing::info!`. This meant:
- Only success cases were logged — if the connection failed before reaching the creation point, no access log was printed
- No visibility into partial connections — operators couldn't see how far a connection progressed before failing
- The hook egress printed its own ad-hoc log outside the `AccessLog` system

## Solution

Three independent structs replace the `AccessLog` enum. Each implements `Drop` to print whatever fields are available. State transitions consume `self` via `into_next()` methods, so any `?` early-return naturally triggers the correct log via `Drop`.

### Log Format

```
# AccessAccepted — accepted downstream, never routed (error level)
downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) — accepted only

# AccessRouted — routed to upstream, but connect failed (error level)
downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> upstream_remote=10.0.0.2:443 — not connected tunnel=false

# AccessEstablished — upstream connected (info level)
downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> upstream_local=10.0.0.1:54322 -> upstream_remote=10.0.0.2:443 — tunnel=false attested=false
```

### Files Changed

- `tng/src/tunnel/access_log.rs` — State machine structs with Drop-based logging
- `tng/src/tunnel/ingress/flow/mod.rs` — Use state machine pattern
- `tng/src/tunnel/egress/flow.rs` — Use state machine pattern
- `tng/src/tunnel/egress/hook.rs` — Remove ad-hoc log, use AccessAccepted
- `tng/src/tunnel/egress/mapping.rs` — Create AccessAccepted at accept
- `tng/src/tunnel/egress/netfilter/mod.rs` — Create AccessAccepted at accept
- `tng/src/tunnel/ingress/mapping.rs` — Create AccessAccepted at accept
- `tng/src/tunnel/ingress/socks5.rs` — Create AccessAccepted at accept
- `tng/src/tunnel/ingress/http_proxy.rs` — Create AccessAccepted at accept (2 sites)
- `tng/src/tunnel/ingress/netfilter/mod.rs` — Create AccessAccepted at accept
