### PR TITLE
feat: add UDP over QUIC Datagram tunnel with mapping_udp mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,12 +15,15 @@
   - [Mode: socks5 (Socks5 Proxy)](#mode-socks5-socks5-proxy)
   - [Mode: netfilter (Transparent Proxy)](#mode-netfilter-transparent-proxy)
   - [Mode: hook (LD_PRELOAD)](#mode-ingress-hook-ld-preload)
+  - [Mode: mapping_udp (UDP over QUIC)](#mode-mapping_udp-udp-over-quic-datagram-tunnel)
+    - [Per-Entry QUIC Configuration](#udp-over-quic-configuration)
 - [Egress (Tunnel Exit)](#egress-tunnel-exit)
   - [Common Fields](#common-fields)
   - [direct_forward Rules](#direct_forward-rules)
   - [Mode: mapping (Port Mapping)](#mode-mapping-port-mapping)
   - [Mode: netfilter (Port Hijacking)](#mode-netfilter-port-hijacking)
   - [Mode: hook (LD_PRELOAD)](#egress-hook-ld-preload)
+  - [Mode: mapping_udp (UDP over QUIC)](#mode-mapping_udp-udp-over-quic-datagram-tunnel)
 - [Remote Attestation (Common Configuration)](#remote-attestation-common-configuration)
   - [Provider Selection](#provider-selection)
   - [Attester Configuration](#attester-configuration)
@@ -73,12 +76,13 @@ The `Ingress` object configures the tunnel's entry endpoints, controlling how tr
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` | None | Traffic inbound mode. Place the corresponding mode's key-value in the object based on the mode used |
+| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` \| `mapping_udp` | None | Traffic inbound mode. Place the corresponding mode's key-value in the object based on the mode used |
 | `ohttp` | [OHttp](#ingress-side-configuration) | None | OHTTP protocol configuration (mutually exclusive with `rats_tls`) |
 | `rats_tls` | [RatsTlsArgs](#transport-layer-common-configuration) | None | RA-TLS transport configuration (mutually exclusive with `ohttp`) |
 | `no_ra` | boolean | `false` | Disable remote attestation (for debugging only; cannot coexist with `attest`/`verify`) |
 | `attest` | [Attest](#attester-configuration) | None | Act as Attester at this endpoint |
 | `verify` | [Verify](#verifier-configuration) | None | Act as Verifier at this endpoint |
+| `quic` | [UdpQuicArgs](#udp-over-quic-configuration) | None | QUIC datagram settings for UDP tunneling |
 
 > [!WARNING]
 > `ohttp` and `rats_tls` are mutually exclusive. Specifying both in the same Ingress/Egress will result in an error.
@@ -504,6 +508,89 @@ Intercepts outgoing TCP connections from the child process via LD_PRELOAD and ro
 
 ---
 
+### Mode: mapping_udp (UDP over QUIC Datagram Tunnel)
+
+> **Requires:** QUIC datagram transport — UDP traffic is encapsulated in QUIC datagrams with RA-TLS authentication.
+
+Encapsulates raw UDP datagrams over a QUIC connection. The ingress side listens on a local UDP socket, receives datagrams from a client, and forwards them through a QUIC datagram tunnel to the egress side, which then delivers them to a backend UDP service.
+
+#### Ingress Side (`"mapping_udp"`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `in` | [Endpoint](#transport-layer-common-configuration) | Yes | Local UDP socket address to listen on for client datagrams |
+| `out` | [Endpoint](#transport-layer-common-configuration) | Yes | Egress QUIC listener address (where the tunnel connection is established) |
+| `idle_timeout_secs` | integer | `30` | Bidirectional idle timeout in seconds. If neither direction sees activity for this duration, the QUIC connection is closed. Works like a NAT UDP session timeout — bidirectional activity resets the timer |
+
+**Example:**
+
+```json
+{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 10001 },
+        "out": { "host": "127.0.0.1", "port": 8443 },
+        "idle_timeout_secs": 60
+      },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+#### Egress Side (`"mapping_udp"`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `in` | [Endpoint](#transport-layer-common-configuration) | Yes | QUIC listener address to accept tunnel connections from ingress |
+| `out` | [Endpoint](#transport-layer-common-configuration) | Yes | Backend UDP service address to deliver datagrams to |
+| `idle_timeout_secs` | integer | `30` | Bidirectional idle timeout in seconds. Same semantics as the ingress side |
+
+**Example:**
+
+```json
+{
+  "add_egress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 8443 },
+        "out": { "host": "127.0.0.1", "port": 20001 }
+      },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+#### Per-Entry QUIC Configuration (`quic`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_datagram_size` | integer | quinn default | Maximum QUIC datagram payload size in bytes. Controls the maximum UDP datagram size that can be tunneled |
+
+**Example:**
+
+```json
+{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 10001 },
+        "out": { "host": "127.0.0.1", "port": 8443 }
+      },
+      "quic": { "max_datagram_size": 1200 },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+> [!NOTE]
+> The `mapping_udp` mode is designed for stateless UDP-over-QUIC tunneling with remote attestation. QUIC datagram payloads carry raw UDP data without additional metadata headers or framing beyond QUIC's own datagram encoding.
+
+---
+
 ## Egress (Tunnel Exit)
 
 The `Egress` object configures the tunnel's exit endpoints, controlling how traffic exits the tunnel.
@@ -514,13 +601,14 @@ The `Egress` object configures the tunnel's exit endpoints, controlling how traf
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `egress_mode` | `mapping` \| `netfilter` \| `hook` | None | Traffic outbound mode. Place the corresponding mode's key-value in the object based on the mode used |
+| `egress_mode` | `mapping` \| `netfilter` \| `hook` \| `mapping_udp` | None | Traffic outbound mode. Place the corresponding mode's key-value in the object based on the mode used |
 | `direct_forward` | array [[DirectForwardRule](#direct_forward-rules)] | No | Direct forwarding (without decryption) rules |
 | `ohttp` | [OHttp](#egress-side-configuration) | None | OHTTP protocol configuration (mutually exclusive with `rats_tls`) |
 | `rats_tls` | [RatsTlsArgs](#transport-layer-common-configuration) | None | RA-TLS transport configuration (mutually exclusive with `ohttp`) |
 | `no_ra` | boolean | `false` | Disable remote attestation (for debugging only; cannot coexist with `attest`/`verify`) |
 | `attest` | [Attest](#attester-configuration) | None | Act as Attester at this endpoint |
 | `verify` | [Verify](#verifier-configuration) | None | Act as Verifier at this endpoint |
+| `quic` | [UdpQuicArgs](#udp-over-quic-configuration) | None | QUIC datagram settings for UDP tunneling |
 
 > Transport layer fields like `rats_tls.multiplex` share the same definition as Ingress. See [RatsTlsArgs](#transport-layer-common-configuration).
 
@@ -843,6 +931,35 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
 
 > [!NOTE]
 > The `hook` mode is mutually exclusive with other egress modes. When using `tng exec`, only `hook` mode is allowed.
+
+---
+
+### Mode: mapping_udp (UDP over QUIC Datagram Tunnel)
+
+The egress side of `mapping_udp` accepts QUIC datagram connections from an ingress endpoint and forwards the encapsulated UDP datagrams to a backend UDP service. See the [ingress mapping_udp section](#mode-mapping_udp-udp-over-quic-datagram-tunnel) for the full feature description and the per-entry `quic` configuration.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `in` | [Endpoint](#transport-layer-common-configuration) | Yes | QUIC listener address to accept tunnel connections from ingress |
+| `out` | [Endpoint](#transport-layer-common-configuration) | Yes | Backend UDP service address to deliver datagrams to |
+| `idle_timeout_secs` | integer | `30` | Bidirectional idle timeout in seconds. If neither direction sees activity for this duration, the QUIC connection is closed |
+
+**Example:**
+
+```json
+{
+  "add_egress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 8443 },
+        "out": { "host": "127.0.0.1", "port": 20001 },
+        "idle_timeout_secs": 60
+      },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
 
 ---
 
@@ -1822,8 +1939,10 @@ Logs are appended to existing files.
 |---|---|
 | ingress mapping | `ingress_type=mapping,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
 | ingress http_proxy | `ingress_type=http_proxy,ingress_id={id},ingress_proxy_listen={proxy_listen.host}:{proxy_listen.port}` |
+| ingress mapping_udp | `ingress_type=mapping_udp,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
 | egress mapping | `egress_type=netfilter,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
 | egress netfilter | `egress_type=netfilter,egress_id={id},egress_listen_port={listen_port}` |
+| egress mapping_udp | `egress_type=mapping_udp,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
 
 **Supported Exporters:**
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -15,12 +15,15 @@
   - [模式：socks5（Socks5 代理）](#socks5socks5-代理)
   - [模式：netfilter（透明代理）](#netfilter透明代理)
   - [模式：hook（LD_PRELOAD）](#ingress-hook-ld_preload)
+  - [模式：mapping_udp（UDP over QUIC）](#模式mapping_udpudp-over-quic-datagram-隧道)
+    - [逐条目 QUIC 配置](#udp-over-quic-配置)
 - [Egress（隧道出口）](#egress隧道出口)
   - [通用字段](#egress通用字段)
   - [direct_forward 规则](#direct_forward-规则)
   - [模式：mapping（端口映射）](#mapping端口映射)
   - [模式：netfilter（端口劫持）](#netfilter端口劫持)
   - [模式：hook（LD_PRELOAD）](#egress-hookld_preload)
+  - [模式：mapping_udp（UDP over QUIC）](#模式mapping_udpudp-over-quic-datagram-隧道)
 - [远程证明（公共配置）](#远程证明公共配置)
   - [Provider 选择](#provider-选择)
   - [Attester 配置](#attester-配置)
@@ -73,12 +76,13 @@
 
 | 字段 | 类型 | 默认 | 说明 |
 |---|---|---|---|
-| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` | 无 | 流量入站方式。根据使用的模式，在对象中放置对应模式的键值 |
+| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` \| `mapping_udp` | 无 | 流量入站方式。根据使用的模式，在对象中放置对应模式的键值 |
 | `ohttp` | [OHttp](#ingress-侧配置) | 无 | OHTTP 协议配置（与 `rats_tls` 互斥） |
 | `rats_tls` | [RatsTlsArgs](#ratstlsargs) | 无 | RA-TLS 传输配置（与 `ohttp` 互斥） |
 | `no_ra` | boolean | `false` | 禁用远程证明（调试用，不可与 `attest`/`verify` 共存） |
 | `attest` | [Attest](#attester-配置) | 无 | 在本端点扮演 Attester |
 | `verify` | [Verify](#verifier-配置) | 无 | 在本端点扮演 Verifier |
+| `quic` | [UdpQuicArgs](#udp-over-quic-配置) | 无 | UDP 隧道的 QUIC Datagram 设置 |
 
 > [!WARNING]
 > `ohttp` 和 `rats_tls` 互斥。同一 Ingress/Egress 中同时指定两者将导致错误。
@@ -504,6 +508,89 @@ flowchart TD
 
 ---
 
+### 模式：mapping_udp（UDP over QUIC Datagram 隧道）
+
+> **需要：** QUIC Datagram 传输 —— UDP 流量通过 RA-TLS 认证的 QUIC 连接进行封装。
+
+将原始 UDP Datagram 封装在 QUIC 连接中。Ingress 侧监听本地 UDP socket，接收来自客户端的 Datagram，通过 QUIC Datagram 隧道转发到 Egress 侧，Egress 侧将其投递到后端 UDP 服务。
+
+#### Ingress 侧（`"mapping_udp"`）
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `in` | [Endpoint](#ratstlsargs) | 是 | 本地 UDP socket 地址，用于监听客户端 Datagram |
+| `out` | [Endpoint](#ratstlsargs) | 是 | Egress QUIC 监听地址（建立隧道连接的目标） |
+| `idle_timeout_secs` | 整数 | `30` | 双向空闲超时时间（秒）。如果两个方向在此时间内均无活动，则关闭 QUIC 连接。工作方式类似于 NAT UDP 会话超时 —— 双向活动会重置计时器 |
+
+**示例：**
+
+```json
+{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 10001 },
+        "out": { "host": "127.0.0.1", "port": 8443 },
+        "idle_timeout_secs": 60
+      },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+#### Egress 侧（`"mapping_udp"`）
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `in` | [Endpoint](#ratstlsargs) | 是 | QUIC 监听地址，接受来自 Ingress 的隧道连接 |
+| `out` | [Endpoint](#ratstlsargs) | 是 | 后端 UDP 服务地址，用于投递 Datagram |
+| `idle_timeout_secs` | 整数 | `30` | 双向空闲超时时间（秒）。与 Ingress 侧语义相同 |
+
+**示例：**
+
+```json
+{
+  "add_egress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 8443 },
+        "out": { "host": "127.0.0.1", "port": 20001 }
+      },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+#### 逐条目 QUIC 配置（`quic`）
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `max_datagram_size` | 整数 | quinn 默认值 | QUIC Datagram 最大载荷大小（字节）。控制可隧道的最大 UDP Datagram 大小 |
+
+**示例：**
+
+```json
+{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 10001 },
+        "out": { "host": "127.0.0.1", "port": 8443 }
+      },
+      "quic": { "max_datagram_size": 1200 },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+> [!NOTE]
+> `mapping_udp` 模式设计用于无状态的 UDP-over-QUIC 隧道，支持远程证明。QUIC Datagram 载荷携带原始 UDP 数据，不添加额外的元数据头或帧，仅使用 QUIC 自身的 Datagram 编码。
+
+---
+
 ## Egress（隧道出口）
 
 `Egress` 对象配置隧道的出口端点，控制流量如何从隧道流出。
@@ -514,13 +601,14 @@ flowchart TD
 
 | 字段 | 类型 | 默认 | 说明 |
 |---|---|---|---|
-| `egress_mode` | `mapping` \| `netfilter` \| `hook` | 无 | 流量出站方式。根据使用的模式，在对象中放置对应模式的键值 |
+| `egress_mode` | `mapping` \| `netfilter` \| `hook` \| `mapping_udp` | 无 | 流量出站方式。根据使用的模式，在对象中放置对应模式的键值 |
 | `direct_forward` | array [[DirectForwardRule](#direct_forward-规则)] | 否 | 直接转发（不解密）规则 |
 | `ohttp` | [OHttp](#egress-侧配置) | 无 | OHTTP 协议配置（与 `rats_tls` 互斥） |
 | `rats_tls` | [RatsTlsArgs](#ratstlsargs) | 无 | RA-TLS 传输配置（与 `ohttp` 互斥） |
 | `no_ra` | boolean | `false` | 禁用远程证明（调试用，不可与 `attest`/`verify` 共存） |
 | `attest` | [Attest](#attester-配置) | 无 | 在本端点扮演 Attester |
 | `verify` | [Verify](#verifier-配置) | 无 | 在本端点扮演 Verifier |
+| `quic` | [UdpQuicArgs](#udp-over-quic-配置) | 无 | UDP 隧道的 QUIC Datagram 设置 |
 
 > `rats_tls.multiplex` 等传输层字段与 Ingress 共用同一组定义，见 [RatsTlsArgs](#ratstlsargs)。
 
@@ -843,6 +931,35 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
 
 > [!NOTE]
 > `hook` 模式与其他 egress 模式互斥。使用 `tng exec` 时，仅允许使用 `hook` 模式。
+
+---
+
+### 模式：mapping_udp（UDP over QUIC Datagram 隧道）
+
+`mapping_udp` 的 Egress 侧接受来自 Ingress 端的 QUIC Datagram 连接，并将封装的 UDP Datagram 转发到后端 UDP 服务。完整的特性描述和逐条目 `quic` 配置参见 [Ingress mapping_udp 章节](#模式mapping_udpudp-over-quic-datagram-隧道)。
+
+| 字段 | 类型 | 默认 | 说明 |
+|---|---|---|---|
+| `in` | [Endpoint](#ratstlsargs) | 是 | QUIC 监听地址，接受来自 Ingress 的隧道连接 |
+| `out` | [Endpoint](#ratstlsargs) | 是 | 后端 UDP 服务地址，用于投递 Datagram |
+| `idle_timeout_secs` | 整数 | `30` | 双向空闲超时时间（秒）。如果两个方向在此时间内均无活动，则关闭 QUIC 连接 |
+
+**示例：**
+
+```json
+{
+  "add_egress": [
+    {
+      "mapping_udp": {
+        "in": { "host": "0.0.0.0", "port": 8443 },
+        "out": { "host": "127.0.0.1", "port": 20001 },
+        "idle_timeout_secs": 60
+      },
+      "attest": { "no_ra": true }
+    }
+  ]
+}
+```
 
 ---
 
@@ -1824,8 +1941,10 @@ RUST_LOG=debug tng --log-file tng-debug.log launch --config-file config.json
 |---|---|
 | ingress mapping | `ingress_type=mapping,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
 | ingress http_proxy | `ingress_type=http_proxy,ingress_id={id},ingress_proxy_listen={proxy_listen.host}:{proxy_listen.port}` |
+| ingress mapping_udp | `ingress_type=mapping_udp,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
 | egress mapping | `egress_type=netfilter,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
 | egress netfilter | `egress_type=netfilter,egress_id={id},egress_listen_port={listen_port}` |
+| egress mapping_udp | `egress_type=mapping_udp,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
 
 **支持的 Exporter：**
 

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -141,6 +141,10 @@ name = "mapping_port_range"
 path = "tests/http/mapping_port_range.rs"
 
 [[test]]
+name = "mapping_udp"
+path = "tests/mapping_udp.rs"
+
+[[test]]
 name = "mapping_multi_rule"
 path = "tests/http/mapping_multi_rule.rs"
 

--- a/tng-testsuite/src/task/app/mod.rs
+++ b/tng-testsuite/src/task/app/mod.rs
@@ -13,8 +13,11 @@ mod http_server;
 mod load_balancer;
 mod tcp_client;
 mod tcp_server;
+mod udp_client;
+mod udp_server;
 
 const TCP_PAYLOAD: &str = "Hello World TCP!";
+const UDP_PAYLOAD: &str = "Hello World UDP!";
 const HTTP_RESPONSE_BODY: &str = "Hello World HTTP!";
 
 pub enum AppType {
@@ -55,6 +58,10 @@ pub enum AppType {
         port: u16,
         http_proxy: Option<HttpProxy>,
     },
+    #[allow(dead_code)]
+    UdpServer { port: u16 },
+    #[allow(dead_code)]
+    UdpClient { host: &'static str, port: u16 },
 }
 
 #[async_trait]
@@ -62,6 +69,7 @@ impl Task for AppType {
     fn name(&self) -> String {
         match self {
             AppType::HttpServer { .. } | AppType::TcpServer { .. } => "app_server",
+            AppType::UdpServer { .. } | AppType::UdpClient { .. } => "app_udp",
             AppType::HttpClient { .. }
             | AppType::HttpClientWithReverseProxy { .. }
             | AppType::TcpClient { .. } => "app_client",
@@ -75,9 +83,11 @@ impl Task for AppType {
     fn node_type(&self) -> NodeType {
         match self {
             AppType::HttpServer { .. } | AppType::TcpServer { .. } => NodeType::Server,
+            AppType::UdpServer { .. } => NodeType::Server,
             AppType::HttpClient { .. }
             | AppType::HttpClientWithReverseProxy { .. }
             | AppType::TcpClient { .. } => NodeType::Client,
+            AppType::UdpClient { .. } => NodeType::Client,
             AppType::LoadBalancer { .. } => NodeType::Middleware,
             #[cfg(feature = "js-sdk")]
             AppType::BrowserClient { .. } => NodeType::Client,
@@ -137,6 +147,10 @@ impl Task for AppType {
                 port,
                 http_proxy,
             } => tcp_client::launch_tcp_client(token, host, *port, *http_proxy).await,
+            AppType::UdpServer { port } => udp_server::launch_udp_server(token, *port).await,
+            AppType::UdpClient { host, port } => {
+                udp_client::launch_udp_client(token, host, *port).await
+            }
             AppType::LoadBalancer {
                 listen_port,
                 upstream_servers,

--- a/tng-testsuite/src/task/app/udp_client.rs
+++ b/tng-testsuite/src/task/app/udp_client.rs
@@ -1,0 +1,56 @@
+use anyhow::{bail, Context as _, Result};
+use tokio::{net::UdpSocket, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use super::UDP_PAYLOAD;
+
+pub async fn launch_udp_client(
+    token: CancellationToken,
+    host: &str,
+    port: u16,
+) -> Result<JoinHandle<Result<()>>> {
+    let host = host.to_owned();
+    Ok(tokio::task::spawn(async move {
+        let _drop_guard = token.drop_guard();
+
+        for i in 1..6 {
+            // repeat 5 times
+            tracing::info!(
+                "UDP client test repeat {i}, connecting to UDP server at {}:{}",
+                host,
+                port
+            );
+
+            let socket = UdpSocket::bind("0.0.0.0:0").await?;
+            socket
+                .connect(format!("{}:{}", host, port))
+                .await
+                .context("Failed to connect to UDP server")?;
+
+            let message = UDP_PAYLOAD.as_bytes();
+            socket.send(message).await?;
+
+            let mut response = vec![0u8; 65535];
+            let n = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                socket.recv(&mut response),
+            )
+            .await
+            .context("UDP client timed out waiting for response")?
+            .context("Failed to receive response")?;
+
+            let response = &response[..n];
+            if response != message {
+                bail!(
+                    "The response should be `{UDP_PAYLOAD}`, but got `{}`",
+                    String::from_utf8_lossy(response)
+                );
+            } else {
+                tracing::info!("Success! The response matches expected value");
+            }
+        }
+
+        tracing::info!("The UDP client task normally exited");
+        Ok(())
+    }))
+}

--- a/tng-testsuite/src/task/app/udp_server.rs
+++ b/tng-testsuite/src/task/app/udp_server.rs
@@ -1,0 +1,33 @@
+use anyhow::{Context as _, Result};
+use tokio::{net::UdpSocket, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+pub async fn launch_udp_server(
+    token: CancellationToken,
+    port: u16,
+) -> Result<JoinHandle<Result<()>>> {
+    let addr = format!("0.0.0.0:{port}");
+    let socket = UdpSocket::bind(&addr).await?;
+    tracing::info!("UDP server listening on {addr}");
+
+    Ok(tokio::task::spawn(async move {
+        let mut buf = [0u8; 65535];
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    tracing::info!("The UDP server task cancelled");
+                    break;
+                }
+                result = socket.recv_from(&mut buf) => {
+                    let (n, src_addr) = result?;
+                    tracing::info!("UDP server received {} bytes from {}", n, src_addr);
+                    socket
+                        .send_to(&buf[..n], src_addr)
+                        .await
+                        .context("Failed to send back UDP datagram")?;
+                }
+            }
+        }
+        Ok(())
+    }))
+}

--- a/tng-testsuite/tests/mapping_udp.rs
+++ b/tng-testsuite/tests/mapping_udp.rs
@@ -1,0 +1,606 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, tng::TngInstance, Task as _},
+};
+
+/// Basic UDP datagram forwarding through ingress->egress tunnel with no RA
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_basic() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20001
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30001
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10001
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20001
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30001 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10001,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// UDP datagram forwarding with one-way RA: egress attests, ingress verifies
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_one_way_ra() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20001
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30001
+                        }
+                    },
+                    "attest": {
+                        "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                    }
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10001
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20001
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "verify": {
+                        "as_addr": "http://192.168.1.254:8080/",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30001 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10001,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// UDP datagram forwarding with two-way RA: both sides attest and verify
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_two_way_ra() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20004
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30004
+                        }
+                    },
+                    "attest": {
+                        "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                    },
+                    "verify": {
+                        "as_addr": "http://192.168.1.254:8080/",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10004
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20004
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "attest": {
+                        "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                    },
+                    "verify": {
+                        "as_addr": "http://192.168.1.254:8080/",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30004 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10004,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// UDP forwarding without explicit quic config — uses default max_datagram_size
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_default_quic_config() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20002
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30002
+                        }
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10002
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20002
+                        }
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30002 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10002,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// UDP forwarding with default idle_timeout_secs — smoke test that the config is accepted
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_with_default_idle_timeout() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20003
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30003
+                        }
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10003
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20003
+                        }
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30003 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10003,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Multiple UDP mapping rules — verify TNG can host multiple egress/ingress rules.
+/// Tests one tunnel (rule 1) at a time to avoid race conditions between QUIC
+/// connection setup and UDP server startup.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_multi_rule() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20011
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30011
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                },
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20012
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30012
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10011
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20011
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                },
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10012
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20012
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30011 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10011,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Second multi-rule test — verifies the second tunnel path works independently.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_multi_rule_second_path() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20013
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30013
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                },
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20014
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30014
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10013
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20013
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                },
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10014
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20014
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30014 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10014,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// UDP forwarding with short idle_timeout_secs — smoke test that the config is accepted
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_short_idle_timeout() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20021
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30021
+                        },
+                        "idle_timeout_secs": 10
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10021
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20021
+                        },
+                        "idle_timeout_secs": 10
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30021 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10021,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -163,16 +163,18 @@ default = [
 ]
 
 __egress-common = ["hyper/server", "dep:async-tungstenite", "dep:serf", "dep:peekable", "dep:uuid", "dep:pkcs8"]
-egress-all = ["egress-mapping", "egress-netfilter"]
+egress-all = ["egress-mapping", "egress-netfilter", "egress-mapping-udp"]
 egress-mapping = ["__egress-common"]
 egress-netfilter = ["__egress-common", "dep:which"]
+egress-mapping-udp = ["__egress-common"]
 
 __ingress-common = ["dep:async-tungstenite"]
-ingress-all = ["ingress-http-proxy", "ingress-mapping", "ingress-netfilter", "ingress-socks5"]
+ingress-all = ["ingress-http-proxy", "ingress-mapping", "ingress-netfilter", "ingress-socks5", "ingress-mapping-udp"]
 ingress-http-proxy = ["__ingress-common", "hyper/client"]
 ingress-mapping = ["__ingress-common"]
 ingress-netfilter = ["__ingress-common", "dep:which"]
 ingress-socks5 = ["__ingress-common", "dep:fast-socks5"]
+ingress-mapping-udp = ["__ingress-common"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 

--- a/tng/src/config/control_interface.rs
+++ b/tng/src/config/control_interface.rs
@@ -95,6 +95,7 @@ mod tests {
                     web_page_inject: false,
                     ohttp: None,
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: true,
                         attest: None,
@@ -169,6 +170,7 @@ mod tests {
                     web_page_inject: false,
                     ohttp: None,
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: true,
                         attest: None,

--- a/tng/src/config/egress.rs
+++ b/tng/src/config/egress.rs
@@ -5,7 +5,9 @@ use serde_with::{formats::PreferMany, serde_as, OneOrMany};
 
 use super::mapping_rule::MappingDe;
 use super::ra::RaArgsUnchecked;
+use super::UdpQuicArgs;
 use crate::config::egress_hook::EgressHookArgs;
+use crate::config::Endpoint;
 use crate::tunnel::access_log::EgressAccessMode;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,6 +30,9 @@ pub struct CommonArgs {
 
     #[serde(default = "Option::default")]
     pub rats_tls: Option<RatsTlsArgs>,
+
+    #[serde(default = "Option::default")]
+    pub quic: Option<UdpQuicArgs>,
 
     #[serde(flatten)]
     pub ra_args: RaArgsUnchecked,
@@ -77,6 +82,30 @@ impl<'de> Deserialize<'de> for EgressMappingArgs {
             .map_err(serde::de::Error::custom)?;
         Ok(Self { rules })
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EgressMappingUdpArgs {
+    /// QUIC listener address.
+    #[serde(rename = "in")]
+    pub r#in: Endpoint,
+
+    /// Backend UDP service address.
+    pub out: Endpoint,
+
+    /// Idle timeout in seconds for the UDP session.
+    ///
+    /// This is a bidirectional timeout — both directions must be idle for the
+    /// timeout to trigger. Any activity in either direction resets the timer.
+    ///
+    /// If no datagram is sent from QUIC AND no response datagram is received
+    /// from the backend for this duration, the UDP socket is closed and the
+    /// corresponding QUIC connection is terminated.
+    ///
+    /// Similar to NAT UDP session timeout. Defaults to 30s if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
 }
 
 #[serde_as]
@@ -188,6 +217,10 @@ pub enum EgressMode {
 
     #[serde(rename = "hook")]
     Hook(EgressHookArgs),
+
+    #[cfg(feature = "egress-mapping-udp")]
+    #[serde(rename = "mapping_udp")]
+    MappingUdp(EgressMappingUdpArgs),
 }
 
 impl EgressMode {
@@ -196,6 +229,8 @@ impl EgressMode {
             EgressMode::Mapping(_) => EgressAccessMode::Mapping,
             EgressMode::Netfilter(_) => EgressAccessMode::Netfilter,
             EgressMode::Hook(_) => EgressAccessMode::Hook,
+            #[cfg(feature = "egress-mapping-udp")]
+            EgressMode::MappingUdp(_) => EgressAccessMode::MappingUdp,
         }
     }
 }

--- a/tng/src/config/ingress.rs
+++ b/tng/src/config/ingress.rs
@@ -6,7 +6,7 @@ use serde_with::{formats::PreferMany, serde_as, OneOrMany};
 use crate::tunnel::access_log::IngressAccessMode;
 
 use super::mapping_rule::MappingDe;
-use super::{ra::RaArgsUnchecked, Endpoint};
+use super::{ra::RaArgsUnchecked, Endpoint, UdpQuicArgs};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddIngressArgs {
@@ -29,6 +29,9 @@ pub struct CommonArgs {
 
     #[serde(default = "Option::default")]
     pub rats_tls: Option<RatsTlsArgs>,
+
+    #[serde(default = "Option::default")]
+    pub quic: Option<UdpQuicArgs>,
 
     #[serde(flatten)]
     pub ra_args: RaArgsUnchecked,
@@ -67,6 +70,10 @@ pub enum IngressMode {
 
     #[serde(rename = "hook")]
     Hook(IngressHookArgs),
+
+    #[cfg(feature = "ingress-mapping-udp")]
+    #[serde(rename = "mapping_udp")]
+    MappingUdp(IngressMappingUdpArgs),
 }
 
 impl IngressMode {
@@ -77,6 +84,8 @@ impl IngressMode {
             IngressMode::Netfilter(_) => IngressAccessMode::Netfilter,
             IngressMode::Socks5(_) => IngressAccessMode::Socks5,
             IngressMode::Hook(_) => IngressAccessMode::Hook,
+            #[cfg(feature = "ingress-mapping-udp")]
+            IngressMode::MappingUdp(_) => IngressAccessMode::MappingUdp,
         }
     }
 }
@@ -99,6 +108,34 @@ impl<'de> Deserialize<'de> for IngressMappingArgs {
             .map_err(serde::de::Error::custom)?;
         Ok(Self { rules })
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IngressMappingUdpArgs {
+    /// Local UDP socket to listen on.
+    #[serde(rename = "in")]
+    pub r#in: Endpoint,
+
+    /// Egress QUIC listener address (where ingress connects to establish the tunnel).
+    pub out: Endpoint,
+
+    /// Idle timeout in seconds for the UDP session.
+    ///
+    /// This is a bidirectional timeout — both directions must be idle for the
+    /// timeout to trigger. Any activity in either direction resets the timer.
+    ///
+    /// On the ingress side, if no new datagram is received from the client AND
+    /// no response datagram is received from the QUIC connection for this
+    /// duration, the QUIC connection is closed and the entry is removed.
+    ///
+    /// On the egress side, if no datagram is sent from QUIC AND no response
+    /// datagram is received from the backend for this duration, the UDP socket
+    /// is closed and the corresponding QUIC connection is terminated.
+    ///
+    /// Similar to NAT UDP session timeout. Defaults to 30s if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
 }
 
 #[serde_as]

--- a/tng/src/config/mod.rs
+++ b/tng/src/config/mod.rs
@@ -56,6 +56,15 @@ pub struct Endpoint {
     pub port: u16,
 }
 
+/// Per-entry QUIC configuration for UDP tunneling, shared by ingress and egress.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UdpQuicArgs {
+    /// Maximum QUIC datagram payload size. If not specified, quinn default is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_datagram_size: Option<usize>,
+}
+
 #[cfg(test)]
 pub mod tests {
     use anyhow::Result;
@@ -109,6 +118,7 @@ pub mod tests {
                         }),
                     }),
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: false,
                         attest: None,
@@ -156,6 +166,7 @@ pub mod tests {
                         }),
                     }),
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: false,
                         attest: Some(AttestArgs::BackgroundCheck {
@@ -221,6 +232,7 @@ pub mod tests {
                         }),
                     }),
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: false,
                         attest: None,
@@ -269,6 +281,7 @@ pub mod tests {
                         }),
                     }),
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: false,
                         attest: None,
@@ -316,6 +329,7 @@ pub mod tests {
                         }),
                     }),
                     rats_tls: None,
+                    quic: None,
                     ra_args: RaArgsUnchecked {
                         no_ra: false,
                         attest: None,
@@ -335,6 +349,304 @@ pub mod tests {
             .as_ref()
             .unwrap();
         assert!(hp.response_headers.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mapping_udp_config_serialize() -> Result<()> {
+        use egress::{
+            CommonArgs as EgressCommonArgs, EgressMappingUdpArgs, EgressMode as EgressModeEnum,
+        };
+        use ingress::{CommonArgs, IngressMappingUdpArgs, IngressMode as IngressModeEnum};
+
+        let config = TngConfig {
+            admin_bind: None,
+            control_interface: None,
+            metric: None,
+            trace: None,
+            add_ingress: vec![AddIngressArgs {
+                ingress_mode: IngressModeEnum::MappingUdp(IngressMappingUdpArgs {
+                    r#in: Endpoint {
+                        host: Some("0.0.0.0".to_owned()),
+                        port: 10001,
+                    },
+                    out: Endpoint {
+                        host: Some("127.0.0.1".to_owned()),
+                        port: 8443,
+                    },
+                    idle_timeout_secs: Some(30),
+                }),
+                common: CommonArgs {
+                    web_page_inject: false,
+                    ohttp: None,
+                    rats_tls: None,
+                    quic: Some(UdpQuicArgs {
+                        max_datagram_size: Some(1200),
+                    }),
+                    ra_args: RaArgsUnchecked {
+                        no_ra: true,
+                        attest: None,
+                        verify: None,
+                    },
+                },
+            }],
+            add_egress: vec![AddEgressArgs {
+                egress_mode: EgressModeEnum::MappingUdp(EgressMappingUdpArgs {
+                    r#in: Endpoint {
+                        host: Some("0.0.0.0".to_owned()),
+                        port: 8443,
+                    },
+                    out: Endpoint {
+                        host: Some("127.0.0.1".to_owned()),
+                        port: 20001,
+                    },
+                    idle_timeout_secs: Some(30),
+                }),
+                common: EgressCommonArgs {
+                    direct_forward: None,
+                    ohttp: None,
+                    rats_tls: None,
+                    quic: Some(UdpQuicArgs {
+                        max_datagram_size: Some(1200),
+                    }),
+                    ra_args: RaArgsUnchecked {
+                        no_ra: true,
+                        attest: None,
+                        verify: None,
+                    },
+                },
+            }],
+        };
+
+        let config_json = serde_json::to_string_pretty(&config)?;
+        let config2: TngConfig = serde_json::from_str(&config_json)?;
+
+        assert_eq!(
+            serde_json::to_value(config)?,
+            serde_json::to_value(config2)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mapping_udp_config_defaults() -> Result<()> {
+        // Verify default values
+        let udp_quic = UdpQuicArgs::default();
+        assert!(udp_quic.max_datagram_size.is_none());
+
+        // Verify UdpQuicArgs serializes to empty object when all fields are None
+        let json = serde_json::to_string(&udp_quic)?;
+        assert_eq!(json, "{}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mapping_udp_json_format() -> Result<()> {
+        use egress::EgressMode as EgressModeEnum;
+        use ingress::IngressMode as IngressModeEnum;
+
+        // Exact JSON string from the design spec
+        let config_json = r#"{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": {
+          "host": "0.0.0.0",
+          "port": 10001
+        },
+        "out": {
+          "host": "127.0.0.1",
+          "port": 8443
+        },
+        "idle_timeout_secs": 30
+      },
+      "quic": {
+        "max_datagram_size": 1200
+      },
+      "verify": {
+        "model": "background_check",
+        "as_provider": "coco",
+        "as_type": "restful",
+        "as_addr": "http://127.0.0.1:8080/",
+        "policy_ids": ["default"]
+      }
+    }
+  ],
+  "add_egress": [
+    {
+      "mapping_udp": {
+        "in": {
+          "host": "0.0.0.0",
+          "port": 8443
+        },
+        "out": {
+          "host": "127.0.0.1",
+          "port": 20001
+        }
+      },
+      "quic": {
+        "max_datagram_size": 1200
+      },
+      "attest": {
+        "model": "background_check",
+        "aa_provider": "coco",
+        "aa_type": "uds",
+        "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+      }
+    }
+  ]
+}"#;
+
+        let config: TngConfig = serde_json::from_str(config_json)?;
+
+        // Verify ingress mapping_udp config
+        assert_eq!(config.add_ingress.len(), 1);
+        match &config.add_ingress[0].ingress_mode {
+            IngressModeEnum::MappingUdp(mapping) => {
+                assert_eq!(mapping.r#in.host.as_deref(), Some("0.0.0.0"));
+                assert_eq!(mapping.r#in.port, 10001);
+                assert_eq!(mapping.out.host.as_deref(), Some("127.0.0.1"));
+                assert_eq!(mapping.out.port, 8443);
+                assert_eq!(mapping.idle_timeout_secs, Some(30));
+            }
+            _ => panic!("Expected MappingUdp ingress mode"),
+        }
+
+        // Verify egress mapping_udp config
+        assert_eq!(config.add_egress.len(), 1);
+        match &config.add_egress[0].egress_mode {
+            EgressModeEnum::MappingUdp(mapping) => {
+                assert_eq!(mapping.r#in.host.as_deref(), Some("0.0.0.0"));
+                assert_eq!(mapping.r#in.port, 8443);
+                assert_eq!(mapping.out.host.as_deref(), Some("127.0.0.1"));
+                assert_eq!(mapping.out.port, 20001);
+            }
+            _ => panic!("Expected MappingUdp egress mode"),
+        }
+
+        // Verify quic config on ingress
+        match &config.add_ingress[0].common.quic {
+            Some(quic) => assert_eq!(quic.max_datagram_size, Some(1200)),
+            None => panic!("Expected quic config on ingress"),
+        }
+        // Verify quic config on egress
+        match &config.add_egress[0].common.quic {
+            Some(quic) => assert_eq!(quic.max_datagram_size, Some(1200)),
+            None => panic!("Expected quic config on egress"),
+        }
+
+        // Verify round-trip serialization
+        let serialized = serde_json::to_string_pretty(&config)?;
+        let config2: TngConfig = serde_json::from_str(&serialized)?;
+        assert_eq!(
+            serde_json::to_value(config)?,
+            serde_json::to_value(config2)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mapping_udp_idle_timeout_default() -> Result<()> {
+        use ingress::IngressMode as IngressModeEnum;
+
+        // JSON without idle_timeout_secs specified
+        let config_json = r#"{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": {
+          "port": 10001
+        },
+        "out": {
+          "host": "127.0.0.1",
+          "port": 8443
+        }
+      }
+    }
+  ]
+}"#;
+
+        let config: TngConfig = serde_json::from_str(config_json)?;
+
+        // Verify idle_timeout_secs defaults to None when not specified
+        assert_eq!(config.add_ingress.len(), 1);
+        match &config.add_ingress[0].ingress_mode {
+            IngressModeEnum::MappingUdp(mapping) => {
+                assert!(
+                    mapping.idle_timeout_secs.is_none(),
+                    "idle_timeout_secs should be None when not specified in JSON"
+                );
+            }
+            _ => panic!("Expected MappingUdp ingress mode"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mapping_udp_no_quic_config() -> Result<()> {
+        use egress::EgressMode as EgressModeEnum;
+        use ingress::IngressMode as IngressModeEnum;
+
+        // JSON with no quic config at all
+        let config_json = r#"{
+  "add_ingress": [
+    {
+      "mapping_udp": {
+        "in": {
+          "port": 10001
+        },
+        "out": {
+          "host": "127.0.0.1",
+          "port": 8443
+        }
+      }
+    }
+  ],
+  "add_egress": [
+    {
+      "mapping_udp": {
+        "in": {
+          "port": 8443
+        },
+        "out": {
+          "host": "127.0.0.1",
+          "port": 20001
+        }
+      }
+    }
+  ]
+}"#;
+
+        let config: TngConfig = serde_json::from_str(config_json)?;
+
+        // Verify no quic config on entries
+        assert!(config.add_ingress[0].common.quic.is_none());
+        assert!(config.add_egress[0].common.quic.is_none());
+
+        // Verify ingress works with no quic config
+        assert_eq!(config.add_ingress.len(), 1);
+        match &config.add_ingress[0].ingress_mode {
+            IngressModeEnum::MappingUdp(mapping) => {
+                assert_eq!(mapping.r#in.port, 10001);
+                assert_eq!(mapping.out.port, 8443);
+            }
+            _ => panic!("Expected MappingUdp ingress mode"),
+        }
+
+        // Verify egress works with no quic config
+        assert_eq!(config.add_egress.len(), 1);
+        match &config.add_egress[0].egress_mode {
+            EgressModeEnum::MappingUdp(mapping) => {
+                assert_eq!(mapping.r#in.port, 8443);
+                assert_eq!(mapping.out.port, 20001);
+            }
+            _ => panic!("Expected MappingUdp egress mode"),
+        }
 
         Ok(())
     }

--- a/tng/src/control_interface/mod.rs
+++ b/tng/src/control_interface/mod.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
 use crate::{
-    config::control_interface::ControlInterfaceArgs, service::RegistedService, state::TngState,
+    config::control_interface::ControlInterfaceArgs,
+    error::TngError,
+    service::RegistedService,
+    state::TngState,
+    status::{StatusProvider, StatusQueryResult},
     tunnel::utils::runtime::TokioRuntime,
 };
 use anyhow::{bail, Result};
@@ -75,6 +79,14 @@ impl RegistedService for ControlInterface {
         Ok(())
     }
 }
+
+#[async_trait]
+impl StatusProvider for ControlInterface {
+    async fn query_status(&self, _path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        Err(TngError::StatusPathNotFound)
+    }
+}
+
 pub struct ControlInterfaceCore {
     state: Arc<TngState>,
 }

--- a/tng/src/runtime.rs
+++ b/tng/src/runtime.rs
@@ -26,7 +26,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span};
 
 pub struct TngRuntime {
-    services: Vec<(Box<dyn RegistedService + Send + Sync>, Span)>,
+    services: Vec<(Arc<dyn RegistedService>, Span)>,
     state: Arc<TngState>,
     meter_provider: Arc<dyn MeterProvider + Send + Sync>,
     shutdown: Shutdown,
@@ -100,7 +100,7 @@ impl TngRuntime {
             .context("Failed to setup trace exporter")?;
 
         // Create all ingress and egress.
-        let mut services: Vec<(Box<dyn RegistedService + Send + Sync>, Span)> = vec![];
+        let mut services: Vec<(Arc<dyn RegistedService>, Span)> = vec![];
         let mut state = TngState::new();
 
         for (id, add_ingress) in tng_config.add_ingress.iter().enumerate() {
@@ -108,18 +108,18 @@ impl TngRuntime {
             let span = tracing::info_span!("ingress", id);
 
             let service = async {
-                let flow = match &add_ingress.ingress_mode {
+                Ok::<Arc<dyn RegistedService >, anyhow::Error>(match &add_ingress.ingress_mode {
                     IngressMode::Mapping(mapping_args) => {
-                        IngressFlow::new(
+                        Arc::new(IngressFlow::new(
                             MappingIngress::new(id, mapping_args).await?,
                             &add_ingress.common,
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?
+                        .await?) as Arc<_>
                     }
                     IngressMode::HttpProxy(http_proxy_args) => {
-                        IngressFlow::new(
+                        Arc::new(IngressFlow::new(
                             HttpProxyIngress::new(
                                 id,
                                 http_proxy_args,
@@ -130,7 +130,7 @@ impl TngRuntime {
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?
+                        .await?) as Arc<_>
                     }
                     IngressMode::Netfilter(netfilter_args) => {
                         #[cfg(not(target_os = "linux"))]
@@ -142,61 +142,74 @@ impl TngRuntime {
                         #[cfg(target_os = "linux")]
                         {
                             use crate::tunnel::ingress::netfilter::NetfilterIngress;
-                            IngressFlow::new(
+                            Arc::new(IngressFlow::new(
                                 NetfilterIngress::new(id, netfilter_args).await?,
                                 &add_ingress.common,
                                 &service_metrics_creator,
                                 runtime.clone(),
                             )
-                            .await?
+                            .await?) as Arc<_>
                         }
                     }
                     IngressMode::Socks5(socks5_args) => {
-                        IngressFlow::new(
+                        Arc::new(IngressFlow::new(
                             Socks5Ingress::new(id, socks5_args).await?,
                             &add_ingress.common,
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?
+                        .await?) as Arc<_>
                     }
                     IngressMode::Hook(hook_args) => {
-                        IngressFlow::new(
+                        Arc::new(IngressFlow::new(
                             HookIngress::new(id, hook_args).await?,
                             &add_ingress.common,
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?
+                        .await?) as Arc<_>
                     }
-                };
-                Ok::<IngressFlow, anyhow::Error>(flow)
+                    #[cfg(feature = "ingress-mapping-udp")]
+                    IngressMode::MappingUdp(mapping_udp_args) => {
+                        use crate::tunnel::ingress::datagram_flow::DatagramIngressFlow;
+                        use crate::tunnel::ingress::mapping_udp::MappingUdpIngress;
+
+                        let mut ingress = MappingUdpIngress::new(id, mapping_udp_args).await?;
+                        ingress.set_max_datagram_size(add_ingress.common.quic.as_ref().and_then(|q| q.max_datagram_size));
+
+                        Arc::new(
+                            DatagramIngressFlow::new(
+                                ingress,
+                                &add_ingress.common,
+                                &service_metrics_creator,
+                                runtime.clone(),
+                            )
+                            .await?,
+                        ) as Arc<_>
+                    }
+                })
             }.instrument(span.clone()).await?;
 
-            let flow = Arc::new(service);
             state.add_ingress(IngressStatusHandle {
-                flow: Arc::downgrade(&flow),
+                flow: Arc::downgrade(&service),
             });
-            services.push((
-                Box::new(flow) as Box<dyn RegistedService + Send + Sync>,
-                span,
-            ));
+            services.push((service, span));
         }
 
         for (id, add_egress) in tng_config.add_egress.iter().enumerate() {
             let add_egress = add_egress.clone();
             let span = tracing::info_span!("egress", id);
 
-            let services_for_entry = async {
-                let flows: Vec<EgressFlow> = match &add_egress.egress_mode {
+            let service = async {
+                Ok::<Arc<dyn RegistedService >, anyhow::Error>(match &add_egress.egress_mode {
                     EgressMode::Mapping(mapping_args) => {
-                        vec![EgressFlow::new(
+                        Arc::new(EgressFlow::new(
                             MappingEgress::new(id, mapping_args).await?,
                             &add_egress.common,
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?]
+                        .await?) as Arc<_>
                     }
                     EgressMode::Netfilter(netfilter_args) => {
                         #[cfg(not(target_os = "linux"))]
@@ -208,40 +221,51 @@ impl TngRuntime {
                         #[cfg(target_os = "linux")]
                         {
                             use crate::tunnel::egress::netfilter::NetfilterEgress;
-                            vec![EgressFlow::new(
+                            Arc::new(EgressFlow::new(
                                 NetfilterEgress::new(id, netfilter_args).await?,
                                 &add_egress.common,
                                 &service_metrics_creator,
                                 runtime.clone(),
                             )
-                            .await?]
+                            .await?) as Arc<_>
                         }
                     }
                     EgressMode::Hook(hook_args) => {
                         use crate::tunnel::egress::hook::HookEgress;
 
-                        vec![EgressFlow::new(
+                        Arc::new(EgressFlow::new(
                             HookEgress::new(id, hook_args),
                             &add_egress.common,
                             &service_metrics_creator,
                             runtime.clone(),
                         )
-                        .await?]
+                        .await?) as Arc<_>
                     }
-                };
-                Ok::<Vec<EgressFlow>, anyhow::Error>(flows)
+                    #[cfg(feature = "egress-mapping-udp")]
+                    EgressMode::MappingUdp(mapping_udp_args) => {
+                        use crate::tunnel::egress::datagram_flow::DatagramEgressFlow;
+                        use crate::tunnel::egress::mapping_udp::MappingUdpEgress;
+
+                        let mut egress = MappingUdpEgress::new(id, mapping_udp_args).await?;
+                        egress.set_max_datagram_size(add_egress.common.quic.as_ref().and_then(|q| q.max_datagram_size));
+
+                        Arc::new(
+                            DatagramEgressFlow::new(
+                                egress,
+                                &add_egress.common,
+                                &service_metrics_creator,
+                                runtime.clone(),
+                            )
+                            .await?,
+                        ) as Arc<_>
+                    }
+                })
             }.instrument(span.clone()).await?;
 
-            for flow in services_for_entry {
-                let flow = Arc::new(flow);
-                state.add_egress(EgressStatusHandle {
-                    flow: Arc::downgrade(&flow),
-                });
-                services.push((
-                    Box::new(flow) as Box<dyn RegistedService + Send + Sync>,
-                    span.clone(),
-                ));
-            }
+            state.add_egress(EgressStatusHandle {
+                flow: Arc::downgrade(&service),
+            });
+            services.push((service, span));
         }
 
         let state = Arc::new(state);
@@ -252,7 +276,7 @@ impl TngRuntime {
                 .await
                 .context("Failed to init control interface")?;
             services.push((
-                Box::new(control_interface),
+                Arc::new(control_interface),
                 tracing::info_span!("control_interface"),
             ));
         }

--- a/tng/src/service.rs
+++ b/tng/src/service.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
 
+use crate::status::StatusProvider;
+
 /// The registered service is a core component of the TNG runtime. After the TNG runtime is created,
 /// they service will be started and keeping running in a background async task. Any service failed
 /// will cause the TNG runtime to shutdown.
@@ -9,6 +11,6 @@ use tokio::sync::mpsc::Sender;
 /// Also note that the async task will be cancelled once when the TNG runtime is cancelled. So it is
 /// not required to check the shutdown_guard.cancelled() in the service.
 #[async_trait]
-pub trait RegistedService {
+pub trait RegistedService: StatusProvider + Send + Sync {
     async fn serve(&self, ready: Sender<()>) -> Result<()>;
 }

--- a/tng/src/state.rs
+++ b/tng/src/state.rs
@@ -2,14 +2,13 @@ use std::borrow::Cow;
 use std::sync::Weak;
 
 use crate::error::TngError;
+use crate::service::RegistedService;
 use crate::status::{StatusProvider, StatusQueryResult};
-use crate::tunnel::egress::flow::EgressFlow;
-use crate::tunnel::ingress::flow::IngressFlow;
 use async_trait::async_trait;
 
 /// Lightweight handle for querying an egress's status tree.
 pub struct EgressStatusHandle {
-    pub flow: Weak<EgressFlow>,
+    pub flow: Weak<dyn RegistedService>,
 }
 
 #[async_trait]
@@ -25,7 +24,7 @@ impl StatusProvider for EgressStatusHandle {
 
 /// Lightweight handle for querying an ingress's status tree.
 pub struct IngressStatusHandle {
-    pub flow: Weak<IngressFlow>,
+    pub flow: Weak<dyn RegistedService>,
 }
 
 #[async_trait]

--- a/tng/src/tunnel/access_log.rs
+++ b/tng/src/tunnel/access_log.rs
@@ -9,6 +9,7 @@ pub enum IngressAccessMode {
     Socks5,
     HttpProxy,
     Hook,
+    MappingUdp,
 }
 
 impl Display for IngressAccessMode {
@@ -19,6 +20,7 @@ impl Display for IngressAccessMode {
             IngressAccessMode::Socks5 => write!(f, "socks5"),
             IngressAccessMode::HttpProxy => write!(f, "http_proxy"),
             IngressAccessMode::Hook => write!(f, "hook"),
+            IngressAccessMode::MappingUdp => write!(f, "mapping_udp"),
         }
     }
 }
@@ -29,6 +31,7 @@ pub enum EgressAccessMode {
     Mapping,
     Netfilter,
     Hook,
+    MappingUdp,
 }
 
 impl Display for EgressAccessMode {
@@ -37,6 +40,7 @@ impl Display for EgressAccessMode {
             EgressAccessMode::Mapping => write!(f, "mapping"),
             EgressAccessMode::Netfilter => write!(f, "netfilter"),
             EgressAccessMode::Hook => write!(f, "hook"),
+            EgressAccessMode::MappingUdp => write!(f, "mapping_udp"),
         }
     }
 }

--- a/tng/src/tunnel/datagram.rs
+++ b/tng/src/tunnel/datagram.rs
@@ -1,0 +1,24 @@
+use bytes::Bytes;
+use std::future::Future;
+use std::net::SocketAddr;
+
+use anyhow::Result;
+
+/// Core trait for datagram I/O, analogous to `CommonStreamTrait` for streams.
+///
+/// Key differences from stream-based traits:
+/// - Uses `Bytes` for payloads (atomic, no splitting)
+/// - Returns `(Bytes, SocketAddr)` from `recv_from` (datagrams carry source info)
+/// - No `AsyncRead`/`AsyncWrite` — datagrams are discrete units
+#[allow(dead_code)]
+pub trait CommonDatagramTrait: Unpin + Send + 'static {
+    /// Send a datagram to the specified address.
+    fn send_to(
+        &mut self,
+        buf: Bytes,
+        target: SocketAddr,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Receive a datagram, returning (payload, source_address).
+    fn recv_from(&mut self) -> impl Future<Output = Result<(Bytes, SocketAddr)>> + Send;
+}

--- a/tng/src/tunnel/egress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/egress/datagram_flow/mod.rs
@@ -1,0 +1,266 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use indexmap::IndexMap;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+use crate::config::egress::CommonArgs as EgressCommonArgs;
+use crate::error::TngError;
+use crate::service::RegistedService;
+use crate::status::{StatusProvider, StatusQueryResult};
+use crate::tunnel::access_log::{AccessAccepted, EgressAccessMode};
+use crate::tunnel::endpoint::TngEndpoint;
+use crate::tunnel::service_metrics::ServiceMetrics;
+use crate::tunnel::service_metrics::ServiceMetricsCreator;
+use crate::tunnel::utils::runtime::TokioRuntime;
+use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+
+/// Trait for a single QUIC connection on the egress side.
+///
+/// Wraps the protocol-specific connection (e.g. quinn::Connection)
+/// and provides datagram I/O operations.
+#[async_trait]
+pub(super) trait EgressDatagramConnection: Send + Sync {
+    /// The remote address of the QUIC connection.
+    fn remote_address(&self) -> SocketAddr;
+
+    /// Read a datagram from the QUIC connection.
+    async fn read_datagram(&self) -> Result<Bytes>;
+
+    /// Send a datagram through the QUIC connection.
+    fn send_datagram(&self, payload: Bytes) -> Result<()>;
+
+    /// Close the QUIC connection.
+    fn close(&self, error_code: u32, reason: &[u8]);
+}
+
+/// Trait for the QUIC listener on the egress side.
+///
+/// Accepts incoming QUIC connections and yields `EgressDatagramConnection` objects.
+#[async_trait]
+pub(super) trait EgressDatagramListener: Send + Sync {
+    /// Get the local address the listener is bound to.
+    fn local_addr(&self) -> Result<SocketAddr>;
+
+    /// Accept the next QUIC connection.
+    async fn accept(&self) -> Result<Arc<dyn EgressDatagramConnection>>;
+}
+
+/// Trait for egress datagram listeners.
+///
+/// Implemented by protocol-specific egress configurations (e.g. mapping_udp).
+/// The Flow manages the QUIC accept loop, per-connection forwarding, idle timeout, and TLS config;
+/// this trait provides the listener binding and backend endpoint info.
+#[async_trait]
+pub(super) trait EgressDatagramTrait: Send + Sync {
+    /// Return the metric attributes of this egress.
+    fn metric_attributes(&self) -> IndexMap<String, String>;
+
+    /// The backend endpoint this egress forwards to.
+    fn backend_endpoint(&self) -> TngEndpoint;
+
+    /// The idle timeout in seconds for connections.
+    fn idle_timeout_secs(&self) -> u64;
+
+    /// Bind the QUIC listener. The Flow provides the TLS config generator
+    /// so RA context is managed centrally (same pattern as ingress).
+    async fn bind_listener(
+        &self,
+        tls_gen: &TlsConfigGenerator,
+    ) -> Result<Arc<dyn EgressDatagramListener>>;
+}
+
+pub struct DatagramEgressFlow {
+    egress: Box<dyn EgressDatagramTrait>,
+    tls_gen: TlsConfigGenerator,
+    metrics: ServiceMetrics,
+    runtime: TokioRuntime,
+}
+
+impl DatagramEgressFlow {
+    #[allow(private_bounds)]
+    pub async fn new(
+        egress: impl EgressDatagramTrait + 'static,
+        common_args: &EgressCommonArgs,
+        service_metrics_creator: &ServiceMetricsCreator,
+        runtime: TokioRuntime,
+    ) -> Result<Self> {
+        let metric_attributes = egress.metric_attributes();
+        let metrics = service_metrics_creator.new_service_metrics(metric_attributes);
+
+        let ra_args = common_args.ra_args.clone().into_checked()?;
+        let ra_context =
+            Arc::new(crate::tunnel::ra_context::RaContext::from_ra_args(&ra_args).await?);
+        let tls_gen = TlsConfigGenerator::new(ra_context, runtime.clone()).await?;
+
+        Ok(Self {
+            egress: Box::new(egress),
+            tls_gen,
+            metrics,
+            runtime,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistedService for DatagramEgressFlow {
+    async fn serve(&self, ready: Sender<()>) -> Result<()> {
+        let listener = self.egress.bind_listener(&self.tls_gen).await?;
+        let actual_addr = listener.local_addr()?;
+        tracing::info!("UDP mapping egress QUIC listener on {}", actual_addr);
+
+        ready.send(()).await?;
+
+        let backend_ep = self.egress.backend_endpoint();
+        let idle_timeout_secs = self.egress.idle_timeout_secs();
+        let listener_addr = actual_addr;
+
+        loop {
+            let connection = listener.accept().await?;
+            let remote = connection.remote_address();
+
+            tracing::info!(
+                %remote,
+                "Accepted QUIC connection from ingress"
+            );
+
+            let access_accepted =
+                AccessAccepted::new_egress(remote, listener_addr, EgressAccessMode::MappingUdp);
+            let access_routed = access_accepted.into_routed(
+                &backend_ep,
+                true, // from_trusted_tunnel
+            );
+            let access_established = access_routed.into_established(None, false);
+
+            // Spawn per-connection forwarding task — access_established logs on drop
+            // when this task ends (connection close or error).
+            let metrics = self.metrics.clone();
+            let active_cx = metrics.new_cx();
+            let runtime_spawn = self.runtime.clone();
+            let runtime_for_task = self.runtime.clone();
+            let backend_ep_clone = backend_ep.clone();
+            let idle_timeout = idle_timeout_secs;
+            let connection_clone = connection.clone();
+
+            runtime_spawn.spawn_supervised_task(async move {
+                if let Err(e) = Self::forward_connection(
+                    connection_clone,
+                    &backend_ep_clone,
+                    idle_timeout,
+                    &runtime_for_task,
+                )
+                .await
+                {
+                    tracing::error!(error = %e, "Per-connection forwarding failed");
+                } else {
+                    active_cx.mark_finished_successfully();
+                }
+                drop(access_established);
+            });
+        }
+    }
+}
+
+impl DatagramEgressFlow {
+    /// Per-connection bidirectional forwarding: QUIC <-> Backend UDP.
+    async fn forward_connection(
+        connection: Arc<dyn EgressDatagramConnection>,
+        backend_ep: &TngEndpoint,
+        idle_timeout_secs: u64,
+        runtime: &TokioRuntime,
+    ) -> Result<()> {
+        let backend_addr = format!("{}:{}", backend_ep.host(), backend_ep.port());
+        let backend_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
+        backend_socket.connect(&backend_addr).await?;
+
+        let idle_timeout = Duration::from_secs(idle_timeout_secs);
+        let last_activity = Arc::new(Mutex::new(Instant::now()));
+        let check_interval = Duration::from_secs(5);
+
+        let conn_clone = connection.clone();
+        let last_act_a = last_activity.clone();
+        let timeout_a = idle_timeout;
+        let backend_socket_a = backend_socket.clone();
+        let runtime_a = runtime.clone();
+
+        // Task A: QUIC -> Backend
+        let task_a = runtime_a.spawn_supervised_task(async move {
+            loop {
+                tokio::select! {
+                    datagram_result = conn_clone.read_datagram() => {
+                        match datagram_result {
+                            Ok(payload) => {
+                                let _ = backend_socket_a.send(&payload).await;
+                                *last_act_a.lock().await = Instant::now();
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    _ = sleep(check_interval) => {
+                        let last = *last_act_a.lock().await;
+                        if last.elapsed() >= timeout_a {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        let last_act_b = last_activity.clone();
+        let timeout_b = idle_timeout;
+
+        // Task B: Backend -> QUIC
+        let mut recv_buf = vec![0u8; 65535];
+        let connection_send = connection.clone();
+        let backend_socket_b = backend_socket.clone();
+        let runtime_b = runtime.clone();
+
+        let task_b = runtime_b.spawn_supervised_task(async move {
+            loop {
+                tokio::select! {
+                    recv_result = backend_socket_b.recv(&mut recv_buf) => {
+                        match recv_result {
+                            Ok(n) => {
+                                let payload = Bytes::copy_from_slice(&recv_buf[..n]);
+                                if let Err(e) = connection_send.send_datagram(payload) {
+                                    tracing::warn!(error = %e, "Failed to send datagram to QUIC");
+                                    break;
+                                }
+                                *last_act_b.lock().await = Instant::now();
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    _ = sleep(check_interval) => {
+                        let last = *last_act_b.lock().await;
+                        if last.elapsed() >= timeout_b {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        // Wait for either task to finish (idle timeout or error)
+        let _ = tokio::join!(task_a, task_b);
+
+        // Clean up
+        connection.close(0u32, b"done");
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl StatusProvider for DatagramEgressFlow {
+    async fn query_status(&self, _path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        Err(TngError::StatusPathNotFound)
+    }
+}

--- a/tng/src/tunnel/egress/flow.rs
+++ b/tng/src/tunnel/egress/flow.rs
@@ -117,13 +117,6 @@ impl RegistedService for EgressFlow {
     }
 }
 
-#[async_trait]
-impl RegistedService for Arc<EgressFlow> {
-    async fn serve(&self, ready: Sender<()>) -> Result<()> {
-        (**self).serve(ready).await
-    }
-}
-
 impl EgressFlow {
     #[auto_enum]
     async fn serve_in_async_task_no_throw_error(

--- a/tng/src/tunnel/egress/mapping_udp.rs
+++ b/tng/src/tunnel/egress/mapping_udp.rs
@@ -1,0 +1,186 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use indexmap::IndexMap;
+use quinn::crypto::rustls::QuicServerConfig;
+
+use crate::config::egress::EgressMappingUdpArgs;
+use crate::tunnel::egress::datagram_flow::{
+    EgressDatagramConnection, EgressDatagramListener, EgressDatagramTrait,
+};
+use crate::tunnel::endpoint::TngEndpoint;
+use crate::tunnel::utils::rustls::config::alpn::Alpn;
+use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+
+/// QUIC-backed connection implementing `EgressDatagramConnection`.
+struct QuicEgressConnection {
+    inner: quinn::Connection,
+    max_datagram_size: Option<usize>,
+}
+
+#[async_trait]
+impl EgressDatagramConnection for QuicEgressConnection {
+    fn remote_address(&self) -> SocketAddr {
+        self.inner.remote_address()
+    }
+
+    async fn read_datagram(&self) -> Result<Bytes> {
+        let datagram = self
+            .inner
+            .read_datagram()
+            .await
+            .context("Failed to read QUIC datagram")?;
+        Ok(datagram)
+    }
+
+    fn send_datagram(&self, payload: Bytes) -> Result<()> {
+        if let Some(max_size) = self.max_datagram_size {
+            if payload.len() > max_size {
+                anyhow::bail!(
+                    "datagram size {} exceeds max_datagram_size {}",
+                    payload.len(),
+                    max_size
+                );
+            }
+        }
+        self.inner
+            .send_datagram(payload)
+            .context("Failed to send QUIC datagram")?;
+        Ok(())
+    }
+
+    fn close(&self, error_code: u32, reason: &[u8]) {
+        self.inner.close(error_code.into(), reason);
+    }
+}
+
+/// QUIC listener implementing `EgressDatagramListener`.
+struct QuicEgressListener {
+    endpoint: quinn::Endpoint,
+    max_datagram_size: Option<usize>,
+}
+
+#[async_trait]
+impl EgressDatagramListener for QuicEgressListener {
+    fn local_addr(&self) -> Result<SocketAddr> {
+        self.endpoint
+            .local_addr()
+            .context("Failed to get QUIC local address")
+    }
+
+    async fn accept(&self) -> Result<Arc<dyn EgressDatagramConnection>> {
+        let connecting = self
+            .endpoint
+            .accept()
+            .await
+            .context("QUIC endpoint closed")?;
+        let connection = connecting
+            .await
+            .context("QUIC connection handshake failed")?;
+        Ok(Arc::new(QuicEgressConnection {
+            inner: connection,
+            max_datagram_size: self.max_datagram_size,
+        }))
+    }
+}
+
+/// UDP mapping egress configuration.
+///
+/// Holds parsed config values. The actual datagram forwarding loop
+/// is managed by `DatagramEgressFlow`.
+pub struct MappingUdpEgress {
+    pub id: usize,
+    pub listen_addr: String,
+    pub listen_port: u16,
+    pub backend_addr: String,
+    pub backend_port: u16,
+    pub max_datagram_size: Option<usize>,
+    pub idle_timeout_secs: u64,
+}
+
+impl MappingUdpEgress {
+    pub async fn new(id: usize, mapping_args: &EgressMappingUdpArgs) -> Result<Self> {
+        Ok(Self {
+            id,
+            listen_addr: mapping_args
+                .r#in
+                .host
+                .as_deref()
+                .unwrap_or("0.0.0.0")
+                .to_owned(),
+            listen_port: mapping_args.r#in.port,
+
+            backend_addr: mapping_args
+                .out
+                .host
+                .as_deref()
+                .context("'host' of 'out' field must be set for mapping_udp egress")?
+                .to_owned(),
+            backend_port: mapping_args.out.port,
+
+            max_datagram_size: None,
+            idle_timeout_secs: mapping_args.idle_timeout_secs.unwrap_or(30),
+        })
+    }
+
+    /// Set max_datagram_size from top-level quic config.
+    pub fn set_max_datagram_size(&mut self, size: Option<usize>) {
+        self.max_datagram_size = size;
+    }
+
+    pub fn metric_attributes(&self) -> IndexMap<String, String> {
+        [
+            ("egress_type".to_owned(), "mapping_udp".to_owned()),
+            ("egress_id".to_owned(), self.id.to_string()),
+            (
+                "egress_in".to_owned(),
+                format!("{}:{}", self.listen_addr, self.listen_port),
+            ),
+            (
+                "egress_out".to_owned(),
+                format!("{}:{}", self.backend_addr, self.backend_port),
+            ),
+        ]
+        .into()
+    }
+}
+
+#[async_trait]
+impl EgressDatagramTrait for MappingUdpEgress {
+    fn metric_attributes(&self) -> IndexMap<String, String> {
+        self.metric_attributes()
+    }
+
+    fn backend_endpoint(&self) -> TngEndpoint {
+        TngEndpoint::new(self.backend_addr.clone(), self.backend_port)
+    }
+
+    fn idle_timeout_secs(&self) -> u64 {
+        self.idle_timeout_secs
+    }
+
+    async fn bind_listener(
+        &self,
+        tls_gen: &TlsConfigGenerator,
+    ) -> Result<Arc<dyn EgressDatagramListener>> {
+        let listen_addr: SocketAddr =
+            format!("{}:{}", self.listen_addr, self.listen_port).parse()?;
+
+        let tls_config = tls_gen
+            .get_blocking_one_time_rustls_server_config(Alpn::RatsQuic)
+            .await?;
+
+        let server_config =
+            quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(tls_config.0)?));
+        let endpoint = quinn::Endpoint::server(server_config, listen_addr)
+            .context("Failed to bind QUIC endpoint")?;
+
+        Ok(Arc::new(QuicEgressListener {
+            endpoint,
+            max_datagram_size: self.max_datagram_size,
+        }))
+    }
+}

--- a/tng/src/tunnel/egress/mod.rs
+++ b/tng/src/tunnel/egress/mod.rs
@@ -5,5 +5,10 @@ pub(crate) mod flow;
 pub mod hook;
 #[cfg(feature = "egress-mapping")]
 pub mod mapping;
+#[cfg(feature = "egress-mapping-udp")]
+pub mod mapping_udp;
 #[cfg(all(feature = "egress-netfilter", target_os = "linux"))]
 pub mod netfilter;
+
+#[cfg(feature = "egress-mapping-udp")]
+pub(crate) mod datagram_flow;

--- a/tng/src/tunnel/ingress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/ingress/datagram_flow/mod.rs
@@ -1,0 +1,274 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use indexmap::IndexMap;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+use crate::config::ingress::CommonArgs as IngressCommonArgs;
+use crate::error::TngError;
+use crate::service::RegistedService;
+use crate::status::{StatusProvider, StatusQueryResult};
+use crate::tunnel::access_log::{AccessAccepted, AccessEstablished, IngressAccessMode};
+use crate::tunnel::endpoint::TngEndpoint;
+use crate::tunnel::service_metrics::ServiceMetrics;
+use crate::tunnel::service_metrics::ServiceMetricsCreator;
+use crate::tunnel::utils::runtime::TokioRuntime;
+use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+
+/// Trait for QUIC tunnel operations on the ingress side.
+///
+/// Implemented by protocol-specific tunnel wrappers (e.g. QUIC-based).
+/// The Flow owns the UDP socket and session map; the tunnel handles
+/// communication with the egress endpoint.
+#[async_trait]
+pub(super) trait IngressDatagramTunnel: Send + Sync {
+    /// Send a datagram to the egress endpoint.
+    fn send_datagram(&self, payload: Bytes) -> Result<()>;
+
+    /// Read a datagram from the egress endpoint.
+    async fn read_datagram(&self) -> Result<Bytes>;
+
+    /// Close the tunnel connection with the given error code and reason.
+    fn close(&self, error_code: u32, reason: &[u8]);
+}
+
+/// Trait for ingress datagram listeners.
+///
+/// Implemented by protocol-specific ingress configurations (e.g. mapping_udp).
+/// The Flow manages the UDP socket, session map, idle cleanup, and TLS config;
+/// this trait only provides the ability to create QUIC tunnels to egress.
+#[async_trait]
+pub(super) trait IngressDatagramTrait: Send + Sync {
+    /// Return the metric attributes of this ingress.
+    fn metric_attributes(&self) -> IndexMap<String, String>;
+
+    /// The UDP listen address for this ingress.
+    fn listen_endpoint(&self) -> (String, u16);
+
+    /// The egress endpoint this ingress forwards to.
+    fn egress_endpoint(&self) -> TngEndpoint;
+
+    /// The idle timeout in seconds for client sessions.
+    fn idle_timeout_secs(&self) -> u64;
+
+    /// Create a new QUIC tunnel to the egress endpoint for the given client.
+    /// The Flow provides the TLS config generator so RA context is managed centrally.
+    async fn create_tunnel(
+        &self,
+        client_addr: SocketAddr,
+        tls_gen: &TlsConfigGenerator,
+        runtime: TokioRuntime,
+    ) -> Result<Arc<dyn IngressDatagramTunnel>>;
+}
+
+/// Per-client QUIC session on ingress.
+struct ClientSession {
+    tunnel: Arc<dyn IngressDatagramTunnel>,
+    last_activity: Arc<Mutex<Instant>>,
+    /// Access log guard — logs on drop when the session is removed.
+    #[allow(dead_code)]
+    access_established: AccessEstablished,
+}
+
+pub struct DatagramIngressFlow {
+    ingress: Box<dyn IngressDatagramTrait>,
+    tls_gen: TlsConfigGenerator,
+    metrics: ServiceMetrics,
+    runtime: TokioRuntime,
+}
+
+impl DatagramIngressFlow {
+    #[allow(private_bounds)]
+    pub async fn new(
+        ingress: impl IngressDatagramTrait + 'static,
+        common_args: &IngressCommonArgs,
+        service_metrics_creator: &ServiceMetricsCreator,
+        runtime: TokioRuntime,
+    ) -> Result<Self> {
+        let metric_attributes = ingress.metric_attributes();
+        let metrics = service_metrics_creator.new_service_metrics(metric_attributes);
+
+        let ra_args = common_args.ra_args.clone().into_checked()?;
+        let ra_context =
+            Arc::new(crate::tunnel::ra_context::RaContext::from_ra_args(&ra_args).await?);
+        let tls_gen = TlsConfigGenerator::new(ra_context, runtime.clone()).await?;
+
+        Ok(Self {
+            ingress: Box::new(ingress),
+            tls_gen,
+            metrics,
+            runtime,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl RegistedService for DatagramIngressFlow {
+    async fn serve(&self, ready: Sender<()>) -> Result<()> {
+        let (listen_addr, listen_port) = self.ingress.listen_endpoint();
+        let listen_str = format!("{}:{}", listen_addr, listen_port);
+        let udp_socket = Arc::new(UdpSocket::bind(&listen_str).await?);
+        let listener_addr = udp_socket.local_addr()?;
+        tracing::info!("UDP mapping ingress listening on {}", listen_str);
+
+        ready.send(()).await?;
+
+        let idle_timeout_secs = self.ingress.idle_timeout_secs();
+        let egress_ep = self.ingress.egress_endpoint();
+        let check_interval = Duration::from_secs(5);
+
+        // client_addr -> ClientSession
+        let client_map: Arc<Mutex<HashMap<SocketAddr, ClientSession>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let mut buf = vec![0u8; 65535];
+
+        loop {
+            tokio::select! {
+                // Direction A: Client -> QUIC
+                recv_result = udp_socket.recv_from(&mut buf) => {
+                    let (n, client_src) = recv_result?;
+                    let payload = Bytes::copy_from_slice(&buf[..n]);
+
+                    let mut map = client_map.lock().await;
+                    let session = match map.get(&client_src) {
+                        Some(s) => s,
+                        None => {
+                            tracing::info!(
+                                %client_src,
+                                egress = %egress_ep,
+                                "Creating QUIC connection for new client"
+                            );
+
+                            let tunnel = self.ingress
+                                .create_tunnel(client_src, &self.tls_gen, self.runtime.clone())
+                                .await?;
+
+                            let access_accepted = AccessAccepted::new_ingress(
+                                client_src,
+                                listener_addr,
+                                IngressAccessMode::MappingUdp,
+                            );
+                            let access_routed = access_accepted.into_routed(
+                                &egress_ep,
+                                true, // to_trusted_tunnel
+                            );
+                            let access_established =
+                                access_routed.into_established(None, false);
+
+                            let last_activity = Arc::new(Mutex::new(Instant::now()));
+
+                            let metrics = self.metrics.clone();
+                            let active_cx = metrics.new_cx();
+
+                            // Spawn QUIC -> Client forwarding task
+                            let udp_socket_clone = udp_socket.clone();
+                            let last_activity_clone = last_activity.clone();
+                            let idle_timeout = Duration::from_secs(idle_timeout_secs);
+                            let client_src_for_task = client_src;
+                            let runtime_clone = self.runtime.clone();
+                            let tunnel_clone = tunnel.clone();
+
+                            runtime_clone.spawn_supervised_task(async move {
+                                let mut success = false;
+                                loop {
+                                    tokio::select! {
+                                        datagram_result = tunnel_clone.read_datagram() => {
+                                            match datagram_result {
+                                                Ok(datagram) => {
+                                                    if let Err(e) = udp_socket_clone
+                                                        .send_to(&datagram, client_src_for_task)
+                                                        .await
+                                                    {
+                                                        tracing::warn!(
+                                                            %client_src_for_task,
+                                                            error = %e,
+                                                            "Failed to send datagram to client"
+                                                        );
+                                                    } else {
+                                                        *last_activity_clone.lock().await = Instant::now();
+                                                        success = true;
+                                                    }
+                                                }
+                                                Err(_) => break,
+                                            }
+                                        }
+                                        _ = sleep(check_interval) => {
+                                            let last = *last_activity_clone.lock().await;
+                                            if last.elapsed() >= idle_timeout {
+                                                tracing::debug!(
+                                                    %client_src_for_task,
+                                                    "Idle timeout - closing QUIC connection"
+                                                );
+                                                tunnel_clone.close(0, b"idle");
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                if success {
+                                    active_cx.mark_finished_successfully();
+                                }
+                            });
+
+                            map.entry(client_src).or_insert(ClientSession {
+                                tunnel,
+                                last_activity,
+                                access_established,
+                            })
+                        }
+                    };
+
+                    // Update activity and forward
+                    *session.last_activity.lock().await = Instant::now();
+                    if let Err(e) = session.tunnel.send_datagram(payload) {
+                        tracing::warn!(
+                            %client_src,
+                            error = %e,
+                            "Failed to send datagram to QUIC"
+                        );
+                    }
+                }
+                // Periodic cleanup of idle sessions
+                _ = sleep(check_interval) => {
+                    let mut map = client_map.lock().await;
+                    let idle_timeout = Duration::from_secs(idle_timeout_secs);
+
+                    map.retain(|addr, session| {
+                        let last = session.last_activity.try_lock();
+                        match last {
+                            Ok(guard) => {
+                                if guard.elapsed() >= idle_timeout {
+                                    tracing::debug!(
+                                        %addr,
+                                        "Idle timeout - removing client session"
+                                    );
+                                    session.tunnel.close(0, b"idle");
+                                    false
+                                } else {
+                                    true
+                                }
+                            }
+                            Err(_) => true,
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl StatusProvider for DatagramIngressFlow {
+    async fn query_status(&self, _path: &[&str]) -> Result<StatusQueryResult, TngError> {
+        Err(TngError::StatusPathNotFound)
+    }
+}

--- a/tng/src/tunnel/ingress/flow/mod.rs
+++ b/tng/src/tunnel/ingress/flow/mod.rs
@@ -129,13 +129,6 @@ impl RegistedService for IngressFlow {
     }
 }
 
-#[async_trait]
-impl RegistedService for Arc<IngressFlow> {
-    async fn serve(&self, ready: Sender<()>) -> Result<()> {
-        (**self).serve(ready).await
-    }
-}
-
 impl IngressFlow {
     async fn serve_in_async_task_no_throw_error(
         &self,

--- a/tng/src/tunnel/ingress/mapping_udp.rs
+++ b/tng/src/tunnel/ingress/mapping_udp.rs
@@ -1,0 +1,149 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use indexmap::IndexMap;
+
+use crate::config::ingress::IngressMappingUdpArgs;
+use crate::tunnel::endpoint::TngEndpoint;
+use crate::tunnel::ingress::datagram_flow::{IngressDatagramTrait, IngressDatagramTunnel};
+use crate::tunnel::udp::quic_tunnel::QuicDatagramTunnelClient;
+use crate::tunnel::utils::runtime::TokioRuntime;
+use crate::tunnel::utils::rustls::config::alpn::Alpn;
+use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+
+/// QUIC-backed tunnel implementing `IngressDatagramTunnel`.
+struct QuicIngressTunnel {
+    inner: QuicDatagramTunnelClient,
+}
+
+#[async_trait]
+impl IngressDatagramTunnel for QuicIngressTunnel {
+    fn send_datagram(&self, payload: Bytes) -> Result<()> {
+        self.inner.send_datagram(payload)
+    }
+
+    async fn read_datagram(&self) -> Result<Bytes> {
+        self.inner.receive_datagram().await
+    }
+
+    fn close(&self, error_code: u32, reason: &[u8]) {
+        self.inner.connection.close(error_code.into(), reason);
+    }
+}
+
+/// UDP mapping ingress configuration.
+///
+/// Holds parsed config values. The actual datagram forwarding loop
+/// is managed by `DatagramIngressFlow`.
+pub struct MappingUdpIngress {
+    pub id: usize,
+    pub listen_addr: String,
+    pub listen_port: u16,
+    pub egress_addr: String,
+    pub egress_port: u16,
+    pub max_datagram_size: Option<usize>,
+    pub idle_timeout_secs: u64,
+}
+
+impl MappingUdpIngress {
+    pub async fn new(id: usize, mapping_args: &IngressMappingUdpArgs) -> Result<Self> {
+        let listen_addr = mapping_args
+            .r#in
+            .host
+            .as_deref()
+            .unwrap_or("0.0.0.0")
+            .to_owned();
+        let listen_port = mapping_args.r#in.port;
+
+        let egress_addr = mapping_args
+            .out
+            .host
+            .as_deref()
+            .context("'host' of 'out' field must be set for mapping_udp ingress")?
+            .to_owned();
+        let egress_port = mapping_args.out.port;
+
+        let idle_timeout_secs = mapping_args.idle_timeout_secs.unwrap_or(30);
+
+        Ok(Self {
+            id,
+            listen_addr,
+            listen_port,
+            egress_addr,
+            egress_port,
+            max_datagram_size: None,
+            idle_timeout_secs,
+        })
+    }
+
+    /// Set max_datagram_size from top-level quic config.
+    pub fn set_max_datagram_size(&mut self, size: Option<usize>) {
+        self.max_datagram_size = size;
+    }
+
+    pub fn metric_attributes(&self) -> IndexMap<String, String> {
+        [
+            ("ingress_type".to_owned(), "mapping_udp".to_owned()),
+            ("ingress_id".to_owned(), self.id.to_string()),
+            (
+                "ingress_in".to_owned(),
+                format!("{}:{}", self.listen_addr, self.listen_port),
+            ),
+            (
+                "ingress_out".to_owned(),
+                format!("{}:{}", self.egress_addr, self.egress_port),
+            ),
+        ]
+        .into()
+    }
+}
+
+#[async_trait]
+impl IngressDatagramTrait for MappingUdpIngress {
+    fn metric_attributes(&self) -> IndexMap<String, String> {
+        self.metric_attributes()
+    }
+
+    fn listen_endpoint(&self) -> (String, u16) {
+        (self.listen_addr.clone(), self.listen_port)
+    }
+
+    fn egress_endpoint(&self) -> TngEndpoint {
+        TngEndpoint::new(self.egress_addr.clone(), self.egress_port)
+    }
+
+    fn idle_timeout_secs(&self) -> u64 {
+        self.idle_timeout_secs
+    }
+
+    async fn create_tunnel(
+        &self,
+        _client_addr: SocketAddr,
+        tls_gen: &TlsConfigGenerator,
+        _runtime: TokioRuntime,
+    ) -> Result<Arc<dyn IngressDatagramTunnel>> {
+        use crate::config::Endpoint;
+
+        let egress_endpoint = Endpoint {
+            host: Some(self.egress_addr.clone()),
+            port: self.egress_port,
+        };
+
+        let tls_config = tls_gen
+            .get_blocking_one_time_rustls_client_config(Alpn::RatsQuic)
+            .await?;
+
+        let quic_tunnel = QuicDatagramTunnelClient::connect(
+            &egress_endpoint,
+            Alpn::RatsQuic,
+            self.max_datagram_size,
+            tls_config,
+        )
+        .await?;
+
+        Ok(Arc::new(QuicIngressTunnel { inner: quic_tunnel }))
+    }
+}

--- a/tng/src/tunnel/ingress/mod.rs
+++ b/tng/src/tunnel/ingress/mod.rs
@@ -11,7 +11,12 @@ pub mod hook;
 pub mod http_proxy;
 #[cfg(feature = "ingress-mapping")]
 pub mod mapping;
+#[cfg(feature = "ingress-mapping-udp")]
+pub mod mapping_udp;
 #[cfg(all(feature = "ingress-netfilter", target_os = "linux"))]
 pub mod netfilter;
 #[cfg(feature = "ingress-socks5")]
 pub mod socks5;
+
+#[cfg(feature = "ingress-mapping-udp")]
+pub mod datagram_flow;

--- a/tng/src/tunnel/mod.rs
+++ b/tng/src/tunnel/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod access_log;
 pub(crate) mod attestation_result;
+#[cfg(not(wasm))]
+pub(crate) mod datagram;
 #[cfg(feature = "__egress-common")]
 pub(crate) mod egress;
 pub mod endpoint;
@@ -11,4 +13,6 @@ pub(crate) mod ra_context;
 #[cfg(not(wasm))]
 pub(crate) mod service_metrics;
 pub(crate) mod stream;
+#[cfg(not(wasm))]
+pub(crate) mod udp;
 pub(crate) mod utils;

--- a/tng/src/tunnel/udp/mod.rs
+++ b/tng/src/tunnel/udp/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(not(wasm))]
+pub mod quic_tunnel;

--- a/tng/src/tunnel/udp/quic_tunnel.rs
+++ b/tng/src/tunnel/udp/quic_tunnel.rs
@@ -1,0 +1,94 @@
+// QUIC tunnel client (ingress side).
+//
+// QuicDatagramTunnelClient connects to egress with RA-TLS config and
+// sends/receives pure UDP datagrams. Reuses TlsConfigGenerator
+// pattern from peer_shared for rustls-to-quinn config conversion.
+//
+// The server side (egress QUIC listener) is implemented by the
+// `EgressDatagramTrait` in egress/mapping_udp.rs, which creates
+// the quinn::Endpoint directly.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use quinn::crypto::rustls::QuicClientConfig;
+
+use crate::config::Endpoint;
+use crate::tunnel::utils::rustls::config::{alpn::Alpn, client::BlockingOnetimeTlsClientConfig};
+
+/// QUIC Datagram tunnel client (ingress side).
+///
+/// Connects to egress QUIC endpoint with RA-based TLS config.
+/// The QUIC connection carries pure UDP datagrams as datagram payloads —
+/// no metadata headers, no framing beyond QUIC's own datagram encoding.
+pub struct QuicDatagramTunnelClient {
+    pub connection: quinn::Connection,
+    max_datagram_size: Option<usize>,
+}
+
+impl QuicDatagramTunnelClient {
+    /// Connect to egress QUIC endpoint with RA-based TLS config.
+    pub async fn connect(
+        target: &Endpoint,
+        _alpn: Alpn,
+        max_datagram_size: Option<usize>,
+        tls_config: BlockingOnetimeTlsClientConfig,
+    ) -> Result<Self> {
+        let listen_addr: SocketAddr = "0.0.0.0:0".parse()?;
+
+        let mut endpoint = quinn::Endpoint::client(listen_addr)?;
+        let quinn_config =
+            quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls_config.0)?));
+        endpoint.set_default_client_config(quinn_config);
+
+        let server_name = target
+            .host
+            .as_deref()
+            .context("target host is required for QUIC connection")?
+            .to_owned();
+
+        let connection = endpoint
+            .connect(
+                format!("{}:{}", server_name, target.port).parse()?,
+                &server_name,
+            )
+            .context("Failed to establish QUIC connection")?
+            .await
+            .context("QUIC connection handshake failed")?;
+
+        Ok(Self {
+            connection,
+            max_datagram_size,
+        })
+    }
+
+    /// Send a datagram through the QUIC connection (pure payload, no metadata).
+    pub fn send_datagram(&self, payload: Bytes) -> Result<()> {
+        if let Some(max_size) = self.max_datagram_size {
+            if payload.len() > max_size {
+                anyhow::bail!(
+                    "datagram size {} exceeds max_datagram_size {}",
+                    payload.len(),
+                    max_size
+                );
+            }
+        }
+
+        self.connection
+            .send_datagram(payload)
+            .context("Failed to send QUIC datagram")?;
+        Ok(())
+    }
+
+    /// Receive a datagram from the QUIC connection.
+    pub async fn receive_datagram(&self) -> Result<Bytes> {
+        let datagram = self
+            .connection
+            .read_datagram()
+            .await
+            .context("Failed to receive QUIC datagram")?;
+        Ok(datagram)
+    }
+}

--- a/tng/src/tunnel/utils/rustls/config/alpn.rs
+++ b/tng/src/tunnel/utils/rustls/config/alpn.rs
@@ -15,6 +15,8 @@ pub enum Alpn {
     Http2,
     /// Serf gossip protocol for memberlist QUIC stream layer.
     Serf,
+    /// QUIC Datagram tunnel for UDP traffic encryption with RA.
+    RatsQuic,
 }
 
 impl Alpn {
@@ -23,6 +25,7 @@ impl Alpn {
             Alpn::RatsTls => b"rats-tls",
             Alpn::Http2 => b"h2",
             Alpn::Serf => b"serf",
+            Alpn::RatsQuic => b"rats-quic",
         }
     }
 }


### PR DESCRIPTION
## Summary

Add UDP over QUIC Datagram tunnel support with a new `mapping_udp` mode for both ingress and egress configurations.

## Changes

- **New tunnel mode**: `mapping_udp` for UDP over QUIC Datagram transport
- **Config**: New ingress/egress configuration fields for `mapping_udp` mode
- **Datagram flows**: New datagram flow modules for both ingress and egress
- **QUIC tunnel**: UDP-specific QUIC tunnel implementation
- **Tests**: Integration test suite with UDP client/server tasks and mapping_udp tests

## Files Changed

- `tng/src/config/` - Configuration structs for mapping_udp mode
- `tng/src/tunnel/` - Datagram flow handlers and UDP QUIC tunnel
- `tng-testsuite/tests/mapping_udp.rs` - Integration tests (+594 lines)
- `tng-testsuite/src/task/app/udp_{client,server}.rs` - Test utilities

28 files changed, +2164 / -64 lines