### PR TITLE
feat(tng): egress hook host filtering at accept time + exec port allocation fix

### DIFF
--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -199,7 +199,7 @@ pub extern "C" fn bind(sockfd: c_int, addr: *const sockaddr, addrlen: socklen_t)
     // Only intercept AF_INET (IPv4)
     if let Some(origin_addr) = unsafe { sockaddr_to_v4(addr) } {
         if let Some(lookup) = LOOKUP.get() {
-            if let Some(real_port) = lookup.lookup_forward(origin_addr) {
+            if let Some(real_port) = lookup.lookup_forward(origin_addr.port()) {
                 // Rewrite the port in-place
                 let mut new_addr = unsafe { std::ptr::read(addr as *const libc::sockaddr_in) };
                 new_addr.sin_port = real_port.to_be();
@@ -259,7 +259,7 @@ pub extern "C" fn getsockname(
     // Check if the returned address is one we remapped
     if let Some(real_addr) = unsafe { sockaddr_to_v4(addr) } {
         if let Some(lookup) = LOOKUP.get() {
-            if let Some(origin_port) = lookup.lookup_reverse(real_addr) {
+            if let Some(origin_port) = lookup.lookup_reverse(real_addr.port()) {
                 // Rewrite the port back to origin
                 let mut new_addr = unsafe { std::ptr::read(addr as *const libc::sockaddr_in) };
                 new_addr.sin_port = origin_port.to_be();

--- a/tng-hook/types/src/egress.rs
+++ b/tng-hook/types/src/egress.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, SocketAddrV4};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,15 +10,15 @@ pub struct EgressHookMappingTable {
     pub entries: Vec<EgressHookMappingEntry>,
 }
 
-/// A single port mapping entry: when the server binds to (host, origin_port),
-/// redirect it to real_port instead.
+/// A single port mapping entry: when the server binds to origin_port,
+/// redirect it to real_port instead. Host IP is NOT checked at bind time —
+/// all binds to the origin port are intercepted. Host filtering happens
+/// at accept time in the TNG runtime.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EgressHookMappingEntry {
-    /// Bind address (e.g. "0.0.0.0", "192.168.1.1")
-    pub host: Ipv4Addr,
     /// The port the server thinks it's binding to
     pub origin_port: u16,
-    /// The actual ports the server binds to
+    /// The actual port the server binds to (redirected by the hook)
     pub real_port: u16,
 }
 
@@ -28,47 +27,37 @@ pub struct EgressHookMappingEntry {
 /// Built once at library init time, read-only thereafter.
 /// No Mutex needed — HashMap reads are thread-safe after construction.
 pub struct EgressHookMappingLookup {
-    /// origin SocketAddrV4 -> real_port (for bind intercept)
-    forward: HashMap<SocketAddrV4, u16>,
-    /// real SocketAddrV4 -> origin_port (for getsockname rewrite)
-    reverse: HashMap<SocketAddrV4, u16>,
+    /// origin_port -> real_port (for bind intercept)
+    forward: HashMap<u16, u16>,
+    /// real_port -> origin_port (for getsockname rewrite)
+    reverse: HashMap<u16, u16>,
 }
 
 impl EgressHookMappingLookup {
     /// Build the forward and reverse lookup tables from a deserialized
     /// `EgressHookMappingTable`. Each entry produces one forward mapping
-    /// (origin address -> real port) and one reverse mapping
-    /// (real address -> origin port).
+    /// (origin_port -> real_port) and one reverse mapping
+    /// (real_port -> origin_port).
     pub fn from_table(table: &EgressHookMappingTable) -> Self {
         let mut forward = HashMap::new();
         let mut reverse = HashMap::new();
 
         for entry in &table.entries {
-            let origin_addr = SocketAddrV4::new(entry.host, entry.origin_port);
-            let real_addr = SocketAddrV4::new(entry.host, entry.real_port);
-            forward.insert(origin_addr, entry.real_port);
-            reverse.insert(real_addr, entry.origin_port);
+            forward.insert(entry.origin_port, entry.real_port);
+            reverse.insert(entry.real_port, entry.origin_port);
         }
 
         Self { forward, reverse }
     }
 
-    /// Look up the real port for a given origin address.
-    /// First tries exact match, then falls back to wildcard (0.0.0.0).
-    pub fn lookup_forward(&self, addr: SocketAddrV4) -> Option<u16> {
-        self.forward.get(&addr).copied().or_else(|| {
-            let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, addr.port());
-            self.forward.get(&wildcard).copied()
-        })
+    /// Look up the real port for a given origin port.
+    pub fn lookup_forward(&self, port: u16) -> Option<u16> {
+        self.forward.get(&port).copied()
     }
 
-    /// Look up the origin port for a given real address.
-    /// First tries exact match, then falls back to wildcard (0.0.0.0).
-    pub fn lookup_reverse(&self, addr: SocketAddrV4) -> Option<u16> {
-        self.reverse.get(&addr).copied().or_else(|| {
-            let wildcard = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, addr.port());
-            self.reverse.get(&wildcard).copied()
-        })
+    /// Look up the origin port for a given real port.
+    pub fn lookup_reverse(&self, port: u16) -> Option<u16> {
+        self.reverse.get(&port).copied()
     }
 }
 
@@ -80,84 +69,36 @@ mod tests {
     fn test_lookup_forward_exact() {
         let table = EgressHookMappingTable {
             entries: vec![EgressHookMappingEntry {
-                host: Ipv4Addr::new(192, 168, 1, 1),
                 origin_port: 8080,
                 real_port: 48080,
             }],
         };
         let lookup = EgressHookMappingLookup::from_table(&table);
-        assert_eq!(
-            lookup.lookup_forward(SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 1), 8080)),
-            Some(48080)
-        );
-    }
-
-    #[test]
-    fn test_lookup_forward_wildcard_fallback() {
-        let table = EgressHookMappingTable {
-            entries: vec![EgressHookMappingEntry {
-                host: Ipv4Addr::UNSPECIFIED,
-                origin_port: 8080,
-                real_port: 48080,
-            }],
-        };
-        let lookup = EgressHookMappingLookup::from_table(&table);
-        // Any IP should match the wildcard
-        assert_eq!(
-            lookup.lookup_forward(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 8080)),
-            Some(48080)
-        );
+        assert_eq!(lookup.lookup_forward(8080), Some(48080));
     }
 
     #[test]
     fn test_lookup_forward_no_match() {
         let table = EgressHookMappingTable {
             entries: vec![EgressHookMappingEntry {
-                host: Ipv4Addr::new(192, 168, 1, 1),
                 origin_port: 8080,
                 real_port: 48080,
             }],
         };
         let lookup = EgressHookMappingLookup::from_table(&table);
-        assert!(lookup
-            .lookup_forward(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 8080))
-            .is_none());
+        assert!(lookup.lookup_forward(9090).is_none());
     }
 
     #[test]
     fn test_lookup_reverse() {
         let table = EgressHookMappingTable {
             entries: vec![EgressHookMappingEntry {
-                host: Ipv4Addr::UNSPECIFIED,
                 origin_port: 8080,
                 real_port: 48080,
             }],
         };
         let lookup = EgressHookMappingLookup::from_table(&table);
-        assert_eq!(
-            lookup.lookup_reverse(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 48080)),
-            Some(8080)
-        );
-    }
-
-    #[test]
-    fn test_lookup_reverse_specific_ip() {
-        let table = EgressHookMappingTable {
-            entries: vec![EgressHookMappingEntry {
-                host: Ipv4Addr::new(192, 168, 1, 1),
-                origin_port: 8080,
-                real_port: 48080,
-            }],
-        };
-        let lookup = EgressHookMappingLookup::from_table(&table);
-        assert_eq!(
-            lookup.lookup_reverse(SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 1), 48080)),
-            Some(8080)
-        );
-        // Should not match a different IP (no wildcard fallback for this entry)
-        assert!(lookup
-            .lookup_reverse(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 48080))
-            .is_none());
+        assert_eq!(lookup.lookup_reverse(48080), Some(8080));
     }
 
     #[test]
@@ -165,12 +106,10 @@ mod tests {
         let table = EgressHookMappingTable {
             entries: vec![
                 EgressHookMappingEntry {
-                    host: Ipv4Addr::UNSPECIFIED,
                     origin_port: 30001,
                     real_port: 40001,
                 },
                 EgressHookMappingEntry {
-                    host: Ipv4Addr::new(192, 168, 1, 1),
                     origin_port: 30002,
                     real_port: 40002,
                 },

--- a/tng/src/config/egress_hook.rs
+++ b/tng/src/config/egress_hook.rs
@@ -3,8 +3,13 @@ use cidr::Ipv4Cidr;
 use serde::{Deserialize, Serialize};
 use serde_with::{formats::PreferMany, serde_as, OneOrMany};
 use std::net::Ipv4Addr;
+use std::ops::RangeInclusive;
 
-use super::EgressHookMappingEntry;
+/// Wildcard CIDR (0.0.0.0/0 — match all).
+#[allow(clippy::expect_used)]
+fn wildcard_cidr() -> Ipv4Cidr {
+    Ipv4Cidr::new(Ipv4Addr::UNSPECIFIED, 0).expect("0.0.0.0/0 is always valid")
+}
 
 /// Configuration for the hook-based egress mode.
 ///
@@ -20,11 +25,13 @@ pub struct EgressHookArgs {
     pub capture_listen: Vec<EgressHookInterceptEntry>,
 
     /// Resolved port mappings, built by `tng exec` at runtime.
-    /// Each capture_listen entry is expanded into one or more EgressHookMappingEntry
+    /// Each capture_listen entry is expanded into one or more TngEgressHookMappingEntry
     /// (ranges → individual ports, auto-allocated real ports resolved).
+    /// This field is not serializable to the .so — a separate port-only
+    /// EgressHookMappingTable is built for that.
     /// This field is not serialized — it's a runtime-only data channel from exec to runtime.
     #[serde(skip, default)]
-    pub resolved_entries: Vec<EgressHookMappingEntry>,
+    pub resolved_entries: Vec<TngEgressHookMappingEntry>,
 }
 
 /// A single intercept rule for the hook egress mode.
@@ -59,16 +66,56 @@ pub struct EgressHookInterceptEntry {
     pub redirect_to_port_end: Option<u16>,
 }
 
-impl EgressHookInterceptEntry {
-    /// Validate this entry and expand it into mapping entries.
+/// Internal mapping entry used by TNG exec/runtime.
+///
+/// Unlike EgressHookMappingEntry (passed to the .so), this includes the host
+/// CIDR for runtime accept-time filtering.
+#[derive(Debug, Clone)]
+pub struct TngEgressHookMappingEntry {
+    /// Host CIDR to match at accept time (e.g. 172.17.80.0/20)
+    pub host_cidr: Ipv4Cidr,
+    /// The port the app thinks it's binding to
+    pub origin_port: u16,
+    /// The actual port the app binds to (redirected by hook)
+    pub real_port: u16,
+}
+
+impl TngEgressHookMappingEntry {
+    /// Build a host filter rule from this mapping entry.
     ///
-    /// Returns a list of (host, origin_port, real_port) tuples.
-    /// If `next_auto_port` is provided, auto-allocates real ports starting from it,
-    /// returning the next unused port number.
+    /// Returns `None` when the host CIDR is 0.0.0.0/0 (match all),
+    /// meaning no host-level filtering is needed.
+    pub fn host_filter_rule(&self) -> Option<EgressHookHostFilterRule> {
+        let cidr = &self.host_cidr;
+        if cidr.first_address() == Ipv4Addr::UNSPECIFIED && cidr.network_length() == 0 {
+            return None;
+        }
+        Some(EgressHookHostFilterRule {
+            host_cidr: self.host_cidr,
+            port_range: self.origin_port..=self.origin_port,
+        })
+    }
+}
+
+/// Host filter rule used at accept time.
+///
+/// A connection's local_addr.ip() is checked against this CIDR,
+/// and the local port is checked against the port range.
+#[derive(Debug, Clone)]
+pub struct EgressHookHostFilterRule {
+    pub host_cidr: Ipv4Cidr,
+    pub port_range: RangeInclusive<u16>,
+}
+
+impl EgressHookInterceptEntry {
+    /// Validate this entry and expand it into TNG-internal mapping entries.
+    ///
+    /// Returns a list of TngEgressHookMappingEntry tuples and the next
+    /// unused auto-allocated port number.
     pub fn expand_mappings(
         &self,
         next_auto_port: u16,
-    ) -> anyhow::Result<(Vec<EgressHookMappingEntry>, u16)> {
+    ) -> anyhow::Result<(Vec<TngEgressHookMappingEntry>, u16)> {
         let port = self
             .port
             .ok_or_else(|| anyhow::anyhow!("'port' is required"))?;
@@ -78,10 +125,19 @@ impl EgressHookInterceptEntry {
             bail!("'port_end' ({}) must be >= 'port' ({})", port_end, port);
         }
 
+        // Default host CIDR: 0.0.0.0/0 (match all) when not specified
+        let host_cidr = self.host.unwrap_or(wildcard_cidr());
+
         let redirect_to_port = self.redirect_to_port;
         let redirect_to_port_end = self.redirect_to_port_end;
 
-        // Validate redirect consistency
+        // Helper to create a mapping entry
+        let make_entry = |origin_port: u16, real_port: u16| TngEgressHookMappingEntry {
+            host_cidr,
+            origin_port,
+            real_port,
+        };
+
         match (redirect_to_port, redirect_to_port_end) {
             (None, None) => {
                 // Auto-allocate all ports in range
@@ -90,14 +146,7 @@ impl EgressHookInterceptEntry {
                 let mut current_real = next_auto_port;
 
                 for i in 0..range_len {
-                    entries.push(EgressHookMappingEntry {
-                        host: self
-                            .host
-                            .map(|c| c.first_address())
-                            .unwrap_or(Ipv4Addr::UNSPECIFIED),
-                        origin_port: port + i as u16,
-                        real_port: current_real,
-                    });
+                    entries.push(make_entry(port + i as u16, current_real));
                     current_real = current_real.checked_add(1).unwrap_or(49152);
                     // wrap to ephemeral
                 }
@@ -126,14 +175,7 @@ impl EgressHookInterceptEntry {
                 let mut entries = Vec::with_capacity(count as usize);
 
                 for i in 0..count {
-                    entries.push(EgressHookMappingEntry {
-                        host: self
-                            .host
-                            .map(|c| c.first_address())
-                            .unwrap_or(Ipv4Addr::UNSPECIFIED),
-                        origin_port: port + i,
-                        real_port: rt + i,
-                    });
+                    entries.push(make_entry(port + i, rt + i));
                 }
 
                 Ok((entries, next_auto_port))
@@ -143,14 +185,7 @@ impl EgressHookInterceptEntry {
                 if self.port_end.is_some() {
                     bail!("'redirect_to_port_end' must be set when 'redirect_to_port' is set with a port range (port_end is present)");
                 }
-                let entries = vec![EgressHookMappingEntry {
-                    host: self
-                        .host
-                        .map(|c| c.first_address())
-                        .unwrap_or(Ipv4Addr::UNSPECIFIED),
-                    origin_port: port,
-                    real_port: rt,
-                }];
+                let entries = vec![make_entry(port, rt)];
                 Ok((entries, next_auto_port))
             }
             (None, Some(_)) => {
@@ -160,7 +195,7 @@ impl EgressHookInterceptEntry {
     }
 }
 
-impl TryFrom<EgressHookInterceptEntry> for Vec<EgressHookMappingEntry> {
+impl TryFrom<EgressHookInterceptEntry> for Vec<TngEgressHookMappingEntry> {
     type Error = anyhow::Error;
 
     fn try_from(value: EgressHookInterceptEntry) -> Result<Self, Self::Error> {
@@ -231,6 +266,8 @@ mod tests {
         assert_eq!(entries[0].origin_port, 8080);
         assert_eq!(entries[0].real_port, 40000);
         assert_eq!(next_port, 40001);
+        // host_cidr should be 0.0.0.0/0 when not specified
+        assert!(entries[0].host_cidr.contains(&Ipv4Addr::UNSPECIFIED));
         Ok(())
     }
 
@@ -346,5 +383,38 @@ mod tests {
         }))
         .unwrap();
         assert!(entry.expand_mappings(40000).is_err());
+    }
+
+    #[test]
+    fn test_host_filter_rule_wildcard_returns_none() {
+        // When host CIDR is 0.0.0.0/0, host_filter_rule should return None
+        let entry: EgressHookInterceptEntry = serde_json::from_value(json!({
+            "port": 8080,
+            "redirect_to_port": 48080
+        }))
+        .unwrap();
+        let (entries, _) = entry.expand_mappings(40000).unwrap();
+        assert!(entries[0].host_filter_rule().is_none());
+    }
+
+    #[test]
+    fn test_host_filter_rule_specific_host_returns_some() {
+        // When host CIDR is a specific network, host_filter_rule should return Some
+        let entry: EgressHookInterceptEntry = serde_json::from_value(json!({
+            "host": "172.17.80.0/20",
+            "port": 8080,
+            "redirect_to_port": 48080
+        }))
+        .unwrap();
+        let (entries, _) = entry.expand_mappings(40000).unwrap();
+        let rule = entries[0].host_filter_rule().expect("expected Some");
+        assert_eq!(rule.port_range, (8080..=8080));
+        // Verify the CIDR matches
+        assert!(rule
+            .host_cidr
+            .contains(&"172.17.80.0".parse::<Ipv4Addr>().unwrap()));
+        assert!(!rule
+            .host_cidr
+            .contains(&"192.168.1.1".parse::<Ipv4Addr>().unwrap()));
     }
 }

--- a/tng/src/config/mod.rs
+++ b/tng/src/config/mod.rs
@@ -18,6 +18,9 @@ pub use tng_hook_types::{
     IngressHookMappingTable, IngressHookProxy,
 };
 
+// Internal TNG types (not serialized to .so)
+pub use egress_hook::{EgressHookHostFilterRule, TngEgressHookMappingEntry};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TngConfig {

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -9,7 +9,7 @@ use crate::config::ingress::IngressHookArgs;
 use crate::config::ingress::IngressMode as IngressHookMode;
 use crate::config::{
     EgressHookMappingEntry, EgressHookMappingTable, IngressHookCaptureRule,
-    IngressHookMappingTable, IngressHookProxy, TngConfig,
+    IngressHookMappingTable, IngressHookProxy, TngConfig, TngEgressHookMappingEntry,
 };
 use crate::tunnel::access_log::EgressAccessMode;
 use crate::tunnel::access_log::IngressAccessMode;
@@ -95,10 +95,8 @@ impl TngExec {
         // 1. Validate all hook-mode entries
         Self::validate_config(&config)?;
 
-        // 2. Build egress resolved entries, tracking used real ports to avoid
-        // portpicker TOCTOU collisions (pick_unused_port binds then drops, so
-        // another entry can pick the same port before conflict check runs).
-        let mut all_egress_entries: Vec<EgressHookMappingEntry> = Vec::new();
+        // 2. Build egress resolved entries
+        let mut all_egress_entries: Vec<TngEgressHookMappingEntry> = Vec::new();
         let mut next_auto_port: u16 = 49152;
         let mut port_alloc = PortAllocator::new();
 
@@ -277,7 +275,7 @@ impl TngExec {
         args: &EgressHookArgs,
         start_auto_port: u16,
         port_alloc: &mut PortAllocator,
-    ) -> Result<(Vec<EgressHookMappingEntry>, u16)> {
+    ) -> Result<(Vec<TngEgressHookMappingEntry>, u16)> {
         let mut entries = Vec::new();
         let mut next_auto_port = start_auto_port;
 
@@ -299,8 +297,8 @@ impl TngExec {
                     let real_port = port_alloc
                         .pick()
                         .context("Failed to pick unused port for hook mapping")?;
-                    entries.push(EgressHookMappingEntry {
-                        host: e.host,
+                    entries.push(TngEgressHookMappingEntry {
+                        host_cidr: e.host_cidr,
                         origin_port: e.origin_port,
                         real_port,
                     });
@@ -314,45 +312,40 @@ impl TngExec {
     }
 
     /// Check for conflicts across all resolved entries from all egress entries.
-    /// Two entries conflict if they map the same (host, origin_port) to different real_ports,
+    /// Two entries conflict if they map the same origin_port to different real_ports,
     /// or if two entries claim the same real_port.
-    fn check_conflicts(all_entries: &[EgressHookMappingEntry]) -> Result<()> {
-        let mut origin_map: HashMap<(std::net::Ipv4Addr, u16), u16> = HashMap::new();
-        let mut real_port_map: HashMap<u16, (std::net::Ipv4Addr, u16)> = HashMap::new();
+    fn check_conflicts(all_entries: &[TngEgressHookMappingEntry]) -> Result<()> {
+        let mut origin_map: HashMap<u16, u16> = HashMap::new(); // origin_port -> real_port
+        let mut real_port_map: HashMap<u16, u16> = HashMap::new(); // real_port -> origin_port
 
         for entry in all_entries {
-            let key = (entry.host, entry.origin_port);
-
-            // Check duplicate (host, origin_port)
-            if let Some(existing_real) = origin_map.get(&key) {
+            // Check duplicate origin_port
+            if let Some(existing_real) = origin_map.get(&entry.origin_port) {
                 if *existing_real != entry.real_port {
                     bail!(
-                        "Conflict: ({}, {}) is mapped to both real_port {} and {}",
-                        key.0,
-                        key.1,
+                        "Conflict: origin_port {} is mapped to both real_port {} and {}",
+                        entry.origin_port,
                         existing_real,
                         entry.real_port
                     );
                 }
                 // Same mapping is fine (deduplicated at .so level)
             } else {
-                origin_map.insert(key, entry.real_port);
+                origin_map.insert(entry.origin_port, entry.real_port);
             }
 
             // Check duplicate real_port
-            if let Some(existing_key) = real_port_map.get(&entry.real_port) {
-                if *existing_key != key {
+            if let Some(existing_origin) = real_port_map.get(&entry.real_port) {
+                if *existing_origin != entry.origin_port {
                     bail!(
-                        "Conflict: real_port {} is claimed by both ({}, {}) and ({}, {})",
+                        "Conflict: real_port {} is claimed by both origin_port {} and {}",
                         entry.real_port,
-                        existing_key.0,
-                        existing_key.1,
-                        key.0,
-                        key.1
+                        existing_origin,
+                        entry.origin_port
                     );
                 }
             } else {
-                real_port_map.insert(entry.real_port, key);
+                real_port_map.insert(entry.real_port, entry.origin_port);
             }
         }
 
@@ -361,15 +354,17 @@ impl TngExec {
 
     /// Build combined EgressHookMappingTable for .so env var.
     fn build_mapping_table_for_so(
-        all_entries: &[EgressHookMappingEntry],
+        all_entries: &[TngEgressHookMappingEntry],
     ) -> EgressHookMappingTable {
-        // Deduplicate: if multiple entries map the same (host, origin_port), first wins
+        // Deduplicate: if multiple entries map the same origin_port, first wins
         let mut seen = std::collections::HashSet::new();
         let mut deduped = Vec::new();
         for e in all_entries {
-            let key = (e.host, e.origin_port);
-            if seen.insert(key) {
-                deduped.push(e.clone());
+            if seen.insert(e.origin_port) {
+                deduped.push(EgressHookMappingEntry {
+                    origin_port: e.origin_port,
+                    real_port: e.real_port,
+                });
             }
         }
 
@@ -610,13 +605,13 @@ mod tests {
     #[test]
     fn test_check_conflicts_no_conflict() {
         let entries = vec![
-            EgressHookMappingEntry {
-                host: std::net::Ipv4Addr::UNSPECIFIED,
+            TngEgressHookMappingEntry {
+                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
                 origin_port: 8080,
                 real_port: 48080,
             },
-            EgressHookMappingEntry {
-                host: std::net::Ipv4Addr::UNSPECIFIED,
+            TngEgressHookMappingEntry {
+                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
                 origin_port: 8081,
                 real_port: 48081,
             },
@@ -627,13 +622,13 @@ mod tests {
     #[test]
     fn test_check_conflicts_duplicate_origin() {
         let entries = vec![
-            EgressHookMappingEntry {
-                host: std::net::Ipv4Addr::UNSPECIFIED,
+            TngEgressHookMappingEntry {
+                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
                 origin_port: 8080,
                 real_port: 48080,
             },
-            EgressHookMappingEntry {
-                host: std::net::Ipv4Addr::UNSPECIFIED,
+            TngEgressHookMappingEntry {
+                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
                 origin_port: 8080,
                 real_port: 48080, // same origin, same real → no conflict
             },
@@ -644,13 +639,13 @@ mod tests {
     #[test]
     fn test_check_conflicts_real_port_collision() {
         let entries = vec![
-            EgressHookMappingEntry {
-                host: std::net::Ipv4Addr::UNSPECIFIED,
+            TngEgressHookMappingEntry {
+                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
                 origin_port: 8080,
                 real_port: 48080,
             },
-            EgressHookMappingEntry {
-                host: std::net::Ipv4Addr::UNSPECIFIED,
+            TngEgressHookMappingEntry {
+                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
                 origin_port: 8081,
                 real_port: 48080, // different origin, same real → conflict
             },

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::{bail, Context as _, Result};
@@ -14,7 +14,73 @@ use crate::config::{
 use crate::tunnel::access_log::EgressAccessMode;
 use crate::tunnel::access_log::IngressAccessMode;
 
-/// Execute a command with LD_PRELOAD-based port interception.
+/// A centralized port allocator that ensures no two auto-allocated ports collide
+/// across all egress and ingress hook entries in exec mode.
+///
+/// portpicker::pick_unused_port() binds then drops the socket, so another call
+/// immediately after can get the same port (TOCTOU). By tracking all allocated
+/// ports in a single HashSet and checking before accept, we prevent collisions.
+struct PortAllocator {
+    used: HashSet<u16>,
+}
+
+impl PortAllocator {
+    fn new() -> Self {
+        Self {
+            used: HashSet::new(),
+        }
+    }
+
+    /// Pick a unique port that hasn't been allocated yet.
+    /// Tries portpicker first (up to 50 attempts), then asks the OS,
+    /// then falls back to sequential scan from 49152.
+    fn pick(&mut self) -> Option<u16> {
+        let mut attempts = 0;
+        while attempts < 50 {
+            if let Some(port) = portpicker::pick_unused_port() {
+                if self.used.insert(port) {
+                    return Some(port);
+                }
+                // Port already claimed, try again.
+            } else {
+                // portpicker exhausted, fall back to asking OS.
+                if let Some(port) = Self::ask_os_port() {
+                    if self.used.insert(port) {
+                        return Some(port);
+                    }
+                }
+            }
+            attempts += 1;
+        }
+        // Final fallback: sequential search from 49152.
+        (49152..=65535).find(|p| !self.used.contains(p))
+    }
+
+    /// Record a port as used (for explicit redirect_to_port / proxy_port).
+    /// Returns Err if the port was already claimed.
+    fn reserve(&mut self, port: u16) -> Result<()> {
+        if self.used.insert(port) {
+            Ok(())
+        } else {
+            bail!(
+                "Conflict: port {} is already claimed by another entry",
+                port
+            )
+        }
+    }
+
+    /// Ask the OS for an available TCP port (binds then drops).
+    fn ask_os_port() -> Option<u16> {
+        for _ in 0..10 {
+            let listener =
+                std::net::TcpListener::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+            if let Ok(addr) = listener.local_addr() {
+                return Some(addr.port());
+            }
+        }
+        None
+    }
+}
 pub struct TngExec;
 
 impl TngExec {
@@ -29,13 +95,17 @@ impl TngExec {
         // 1. Validate all hook-mode entries
         Self::validate_config(&config)?;
 
-        // 2. Build egress resolved entries
+        // 2. Build egress resolved entries, tracking used real ports to avoid
+        // portpicker TOCTOU collisions (pick_unused_port binds then drops, so
+        // another entry can pick the same port before conflict check runs).
         let mut all_egress_entries: Vec<EgressHookMappingEntry> = Vec::new();
         let mut next_auto_port: u16 = 49152;
+        let mut port_alloc = PortAllocator::new();
 
         for egress in &mut config.add_egress {
             if let EgressMode::Hook(args) = &mut egress.egress_mode {
-                let (entries, next_port) = Self::build_resolved_entries(args, next_auto_port)?;
+                let (entries, next_port) =
+                    Self::build_resolved_entries(args, next_auto_port, &mut port_alloc)?;
                 args.resolved_entries = entries;
                 next_auto_port = next_port;
                 all_egress_entries.extend(args.resolved_entries.clone());
@@ -54,7 +124,7 @@ impl TngExec {
         };
 
         // 3. Build ingress mapping table and serialize
-        let ingress_table = Self::build_ingress_mapping_table(&mut config)?;
+        let ingress_table = Self::build_ingress_mapping_table(&mut config, &mut port_alloc)?;
         let has_ingress_hooks = !ingress_table.proxies.is_empty();
         let ingress_json = serde_json::to_string(&ingress_table)
             .context("Failed to serialize ingress mapping table")?;
@@ -199,31 +269,41 @@ impl TngExec {
     /// Build resolved entries for a single EgressHookArgs.
     /// Expands port ranges, auto-allocates real ports for entries without redirect_to_port,
     /// and fills host defaults (unspecified → 0.0.0.0).
-    /// Returns (resolved_entries, next_auto_port).
+    ///
+    /// `port_alloc` tracks all real ports already claimed across all egress and ingress
+    /// entries. Each newly allocated port is registered immediately to prevent portpicker
+    /// TOCTOU races. Returns (resolved_entries, next_auto_port).
     fn build_resolved_entries(
         args: &EgressHookArgs,
         start_auto_port: u16,
+        port_alloc: &mut PortAllocator,
     ) -> Result<(Vec<EgressHookMappingEntry>, u16)> {
         let mut entries = Vec::new();
         let mut next_auto_port = start_auto_port;
 
         for entry in &args.capture_listen {
-            let (new_entries, next_port) = entry
+            let (mut new_entries, next_port) = entry
                 .expand_mappings(next_auto_port)
                 .context("Failed to expand intercept entry")?;
 
-            // For entries with explicit redirect_to_port, keep the ports as-is.
-            // For entries without redirect (auto-allocated), re-pick via portpicker.
+            // For entries with explicit redirect_to_port, verify no collision and reserve.
+            // For entries without redirect (auto-allocated), pick via the shared allocator
+            // until we find an unclaimed port.
             if entry.redirect_to_port.is_some() {
-                entries.extend(new_entries);
+                for e in &new_entries {
+                    port_alloc.reserve(e.real_port)?;
+                }
+                entries.append(&mut new_entries);
             } else {
-                for mut e in new_entries {
-                    if let Some(picked) = portpicker::pick_unused_port() {
-                        e.real_port = picked;
-                    } else {
-                        bail!("Failed to pick unused port for hook mapping");
-                    }
-                    entries.push(e);
+                for e in new_entries {
+                    let real_port = port_alloc
+                        .pick()
+                        .context("Failed to pick unused port for hook mapping")?;
+                    entries.push(EgressHookMappingEntry {
+                        host: e.host,
+                        origin_port: e.origin_port,
+                        real_port,
+                    });
                 }
             }
 
@@ -297,12 +377,18 @@ impl TngExec {
     }
 
     /// Build the ingress hook mapping table from all hook-mode ingress entries.
-    fn build_ingress_mapping_table(config: &mut TngConfig) -> Result<IngressHookMappingTable> {
+    ///
+    /// Uses the shared `port_alloc` to allocate proxy ports, preventing collisions
+    /// with egress real ports and other ingress proxy ports.
+    fn build_ingress_mapping_table(
+        config: &mut TngConfig,
+        port_alloc: &mut PortAllocator,
+    ) -> Result<IngressHookMappingTable> {
         let mut mapping_table = IngressHookMappingTable::default();
 
         for (i, ingress) in config.add_ingress.iter_mut().enumerate() {
             if let IngressHookMode::Hook(args) = &mut ingress.ingress_mode {
-                let proxy = Self::build_ingress_proxy(i, args)?;
+                let proxy = Self::build_ingress_proxy(i, args, port_alloc)?;
                 mapping_table.proxies.push(proxy);
             }
         }
@@ -319,16 +405,24 @@ impl TngExec {
 
     /// Build a single IngressHookProxy from an IngressHookArgs.
     ///
-    /// If `args.proxy_port` is not set, a port is auto-allocated and written
-    /// back to `args.proxy_port` so the runtime uses the same port.
+    /// If `args.proxy_port` is not set, a port is auto-allocated via the shared
+    /// allocator and written back to `args.proxy_port` so the runtime uses the
+    /// same port.
     fn build_ingress_proxy(
         _entry_index: usize,
         args: &mut IngressHookArgs,
+        port_alloc: &mut PortAllocator,
     ) -> Result<IngressHookProxy> {
         let proxy_port = match args.proxy_port {
-            Some(port) => port,
+            Some(port) => {
+                port_alloc
+                    .reserve(port)
+                    .with_context(|| format!("Failed to use ingress proxy port {port}"))?;
+                port
+            }
             None => {
-                let port = portpicker::pick_unused_port()
+                let port = port_alloc
+                    .pick()
                     .context("Failed to pick unused port for ingress hook proxy")?;
                 args.proxy_port = Some(port);
                 port
@@ -458,7 +552,9 @@ mod tests {
         } else {
             panic!("expected hook mode")
         };
-        let (entries, next_port) = TngExec::build_resolved_entries(&args, 49152).unwrap();
+        let mut alloc = PortAllocator::new();
+        let (entries, next_port) =
+            TngExec::build_resolved_entries(&args, 49152, &mut alloc).unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].origin_port, 8080);
         assert_eq!(entries[1].origin_port, 8081);
@@ -467,6 +563,8 @@ mod tests {
         assert!(entries[1].real_port > 0);
         assert_ne!(entries[0].real_port, entries[1].real_port);
         assert_eq!(next_port, 49154); // next_auto_port incremented by expand_mappings
+                                      // Both ports tracked in allocator
+        assert_eq!(alloc.used.len(), 2);
     }
 
     #[test]
@@ -480,10 +578,13 @@ mod tests {
         } else {
             panic!("expected hook mode")
         };
-        let (entries, next_port) = TngExec::build_resolved_entries(&args, 49152).unwrap();
+        let mut alloc = PortAllocator::new();
+        let (entries, next_port) =
+            TngExec::build_resolved_entries(&args, 49152, &mut alloc).unwrap();
         assert_eq!(entries[0].real_port, 48080);
         assert_eq!(entries[1].real_port, 48081);
         assert_eq!(next_port, 49152); // auto port unchanged
+        assert_eq!(alloc.used.len(), 2);
     }
 
     #[test]
@@ -498,7 +599,8 @@ mod tests {
         } else {
             panic!("expected hook mode")
         };
-        let (entries, _) = TngExec::build_resolved_entries(&args, 49152).unwrap();
+        let mut alloc = PortAllocator::new();
+        let (entries, _) = TngExec::build_resolved_entries(&args, 49152, &mut alloc).unwrap();
         let table = TngExec::build_mapping_table_for_so(&entries);
         // First entry wins
         assert_eq!(table.entries.len(), 1);
@@ -559,6 +661,53 @@ mod tests {
     }
 
     #[test]
+    fn test_build_resolved_entries_explicit_redirect_collision() {
+        // Two entries with the same explicit redirect_to_port should error
+        // during build_resolved_entries (no longer waits for check_conflicts)
+        let config = make_hook_config(json!([
+            { "port": 8080, "redirect_to_port": 48080 },
+            { "port": 8081, "redirect_to_port": 48080 }
+        ]));
+        let args = if let EgressMode::Hook(args) = &config.add_egress[0].egress_mode {
+            args.clone()
+        } else {
+            panic!("expected hook mode")
+        };
+        let mut alloc = PortAllocator::new();
+        let result = TngExec::build_resolved_entries(&args, 49152, &mut alloc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already claimed"));
+    }
+
+    #[test]
+    fn test_build_resolved_entries_reuses_used_set() {
+        // Simulate multiple egress entries sharing a PortAllocator.
+        // Second entry's auto-allocated ports should not collide with first's.
+        let config1 = make_hook_config(json!([{ "port": 8080 }]));
+        let args1 = if let EgressMode::Hook(args) = &config1.add_egress[0].egress_mode {
+            args.clone()
+        } else {
+            panic!("expected hook mode")
+        };
+        let mut alloc = PortAllocator::new();
+        let (entries1, _) = TngExec::build_resolved_entries(&args1, 49152, &mut alloc).unwrap();
+        assert_eq!(entries1.len(), 1);
+
+        let config2 = make_hook_config(json!([{ "port": 9090 }]));
+        let args2 = if let EgressMode::Hook(args) = &config2.add_egress[0].egress_mode {
+            args.clone()
+        } else {
+            panic!("expected hook mode")
+        };
+        let (entries2, _) = TngExec::build_resolved_entries(&args2, 49152, &mut alloc).unwrap();
+        assert_eq!(entries2.len(), 1);
+
+        // The second entry's real port must differ from the first's
+        assert_ne!(entries1[0].real_port, entries2[0].real_port);
+        assert_eq!(alloc.used.len(), 2);
+    }
+
+    #[test]
     fn test_validate_ingress_hook_only() {
         // Config with only ingress hook mode (no egress) should pass validation
         let config: TngConfig = serde_json::from_value(json!({
@@ -606,7 +755,8 @@ mod tests {
             ]
         }))
         .unwrap();
-        let proxy = TngExec::build_ingress_proxy(0, &mut args).unwrap();
+        let mut alloc = PortAllocator::new();
+        let proxy = TngExec::build_ingress_proxy(0, &mut args, &mut alloc).unwrap();
         assert!(proxy.proxy_port > 0);
         assert_eq!(proxy.capture_rules.len(), 2);
         assert_eq!(proxy.capture_rules[0].host_cidr, "10.0.0.0/24");
@@ -614,6 +764,7 @@ mod tests {
         assert_eq!(proxy.capture_rules[1].port, 443);
         // Verify the port was written back to args
         assert_eq!(args.proxy_port, Some(proxy.proxy_port));
+        assert_eq!(alloc.used.len(), 1);
     }
 
     #[test]
@@ -623,8 +774,58 @@ mod tests {
             "proxy_port": 49001
         }))
         .unwrap();
-        let proxy = TngExec::build_ingress_proxy(0, &mut args).unwrap();
+        let mut alloc = PortAllocator::new();
+        let proxy = TngExec::build_ingress_proxy(0, &mut args, &mut alloc).unwrap();
         assert_eq!(proxy.proxy_port, 49001);
         assert_eq!(proxy.capture_rules.len(), 1);
+    }
+
+    #[test]
+    fn test_egress_ingress_no_collision_shared_allocator() {
+        // Egress auto-allocates a port, then ingress auto-allocates.
+        // They must not collide because they share the same PortAllocator.
+        let config = make_hook_config(json!([{ "port": 8080 }]));
+        let args = if let EgressMode::Hook(args) = &config.add_egress[0].egress_mode {
+            args.clone()
+        } else {
+            panic!("expected hook mode")
+        };
+        let mut alloc = PortAllocator::new();
+        let (entries, _) = TngExec::build_resolved_entries(&args, 49152, &mut alloc).unwrap();
+        let egress_port = entries[0].real_port;
+
+        let mut ingress_args: IngressHookArgs = serde_json::from_value(json!({
+            "capture_dst": [{ "port": 5600 }]
+        }))
+        .unwrap();
+        let proxy = TngExec::build_ingress_proxy(0, &mut ingress_args, &mut alloc).unwrap();
+
+        assert_ne!(proxy.proxy_port, egress_port);
+        assert_eq!(alloc.used.len(), 2);
+    }
+
+    #[test]
+    fn test_explicit_ingress_proxy_port_collision() {
+        // If the user explicitly sets proxy_port to a value already claimed
+        // by egress, the collision should be detected at build time.
+        let config = make_hook_config(json!([{ "port": 8080 }]));
+        let args = if let EgressMode::Hook(args) = &config.add_egress[0].egress_mode {
+            args.clone()
+        } else {
+            panic!("expected hook mode")
+        };
+        let mut alloc = PortAllocator::new();
+        let (entries, _) = TngExec::build_resolved_entries(&args, 49152, &mut alloc).unwrap();
+        let claimed_port = entries[0].real_port;
+
+        let mut ingress_args: IngressHookArgs = serde_json::from_value(json!({
+            "capture_dst": [{ "port": 5600 }],
+            "proxy_port": claimed_port
+        }))
+        .unwrap();
+        let result = TngExec::build_ingress_proxy(0, &mut ingress_args, &mut alloc);
+        assert!(result.is_err(), "expected error, got: {:?}", result.ok());
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(err.contains("already claimed"));
     }
 }

--- a/tng/src/runtime.rs
+++ b/tng/src/runtime.rs
@@ -219,8 +219,9 @@ impl TngRuntime {
                     }
                     EgressMode::Hook(hook_args) => {
                         use crate::tunnel::egress::hook::HookEgress;
+
                         vec![EgressFlow::new(
-                            HookEgress::new(id, &hook_args.resolved_entries),
+                            HookEgress::new(id, hook_args),
                             &add_egress.common,
                             &service_metrics_creator,
                             runtime.clone(),

--- a/tng/src/tunnel/access_log.rs
+++ b/tng/src/tunnel/access_log.rs
@@ -100,14 +100,14 @@ impl AccessAccepted {
     }
 
     /// Transition to AccessRouted. Consumes self.
-    pub fn into_routed(mut self, upstream_remote: impl Display, tunnel: bool) -> AccessRouted {
+    pub fn into_routed(mut self, upstream_remote: impl Display, encrypted: bool) -> AccessRouted {
         self.need_print = false;
         AccessRouted {
             downstream_remote: self.downstream_remote,
             downstream_local: self.downstream_local,
             mode: self.mode,
             upstream_remote: upstream_remote.to_string(),
-            tunnel,
+            encrypted,
             need_print: true,
         }
     }
@@ -151,7 +151,7 @@ pub struct AccessRouted {
     downstream_local: SocketAddr,
     mode: AccessMode,
     upstream_remote: String,
-    tunnel: bool,
+    encrypted: bool,
     need_print: bool,
 }
 
@@ -170,7 +170,7 @@ impl AccessRouted {
             mode: self.mode,
             upstream_remote: self.upstream_remote.clone(),
             upstream_local,
-            tunnel: self.tunnel,
+            encrypted: self.encrypted,
             attested,
             need_print: true,
         }
@@ -181,8 +181,8 @@ impl Display for AccessRouted {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "downstream_remote={} -> downstream_local={}({}) -> (..) -> upstream_remote={} — not connected tunnel={}",
-            self.downstream_remote, self.downstream_local, self.mode, self.upstream_remote, self.tunnel
+            "downstream_remote={} -> downstream_local={}({}) -> (..) -> upstream_remote={} — not connected encrypted={}",
+            self.downstream_remote, self.downstream_local, self.mode, self.upstream_remote, self.encrypted
         )
     }
 }
@@ -205,7 +205,7 @@ pub struct AccessEstablished {
     mode: AccessMode,
     upstream_remote: String,
     upstream_local: Option<SocketAddr>,
-    tunnel: bool,
+    encrypted: bool,
     attested: bool,
     need_print: bool,
 }
@@ -223,8 +223,8 @@ impl Display for AccessEstablished {
             write!(f, " -> upstream_local={}", local)?;
         }
         write!(f, " -> upstream_remote={}", self.upstream_remote)?;
-        write!(f, " — tunnel={}", self.tunnel)?;
-        // Only print attested if tunnel is true (meaningful only with tunnel)
+        write!(f, " — encrypted={}", self.encrypted)?;
+        // Only print attested if encrypted is true (meaningful only with tunnel)
         // Actually per spec, always print attested in established state
         write!(f, " attested={}", self.attested)?;
         Ok(())
@@ -267,7 +267,7 @@ mod tests {
         let routed = accepted.into_routed("10.0.0.2:443", false);
         assert_eq!(
             format!("{routed}"),
-            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> (..) -> upstream_remote=10.0.0.2:443 — not connected tunnel=false"
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> (..) -> upstream_remote=10.0.0.2:443 — not connected encrypted=false"
         );
         std::mem::forget(routed);
     }
@@ -283,7 +283,7 @@ mod tests {
         let established = routed.into_established(None, false);
         assert_eq!(
             format!("{established}"),
-            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> upstream_remote=10.0.0.2:443 — tunnel=false attested=false"
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(hook) -> upstream_remote=10.0.0.2:443 — encrypted=false attested=false"
         );
         std::mem::forget(established);
     }
@@ -299,7 +299,7 @@ mod tests {
         let established = routed.into_established(Some("10.0.0.1:54322".parse().unwrap()), true);
         assert_eq!(
             format!("{established}"),
-            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(mapping) -> upstream_local=10.0.0.1:54322 -> upstream_remote=10.0.0.2:443 — tunnel=true attested=true"
+            "downstream_remote=10.0.0.1:54321 -> downstream_local=0.0.0.0:8080(mapping) -> upstream_local=10.0.0.1:54322 -> upstream_remote=10.0.0.2:443 — encrypted=true attested=true"
         );
         std::mem::forget(established);
     }

--- a/tng/src/tunnel/egress/flow.rs
+++ b/tng/src/tunnel/egress/flow.rs
@@ -54,6 +54,9 @@ pub(super) struct AcceptedStream {
     pub listener_addr: SocketAddr,
     pub egress_mode: EgressAccessMode,
     pub access_accepted: AccessAccepted,
+    /// Whether this connection should go through the encryption/decryption path.
+    /// When false, the stream is forwarded directly to the upstream.
+    pub encrypted: bool,
 }
 
 impl EgressFlow {
@@ -139,6 +142,7 @@ impl EgressFlow {
             // Egress processes multiple upstream connections per accepted downstream.
             // Extract access_accepted fields here so they can be cloned per inner-loop iteration.
             mut access_accepted,
+            encrypted,
         } = accepted_stream;
 
         let trusted_stream_manager = self.trusted_stream_manager.clone();
@@ -151,7 +155,31 @@ impl EgressFlow {
         runtime.spawn_supervised_task_with_span(span, async move {
             tracing::debug!("Start serving new connection from client");
 
-            // Consume streams come from downstream
+            if !encrypted {
+                // Transport-level direct forward: determined at accept time by the
+                // egress mode's host CIDR filter (HookEgress::encrypted checks whether
+                // the connection's local_addr.ip() matches a configured CIDR).
+                // When the IP doesn't match any rule, the entire connection bypasses
+                // the trusted stream manager — no OHTTP/RATS-TLS processing happens.
+                // This is a per-connection decision, made once when the TCP accept occurs.
+                if let Err(error) = forward_to_upstream(
+                    &metrics,
+                    access_accepted,
+                    &dst,
+                    stream,
+                    false,
+                    false,
+                    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+                    transport_so_mark,
+                )
+                .await
+                {
+                    tracing::error!(?error, "Failed to forward stream");
+                }
+                return;
+            }
+
+            // Existing trusted stream path
             let mut pending = match trusted_stream_manager.consume_stream(stream).await {
                 Ok(pending) => pending,
                 Err(error) => {
@@ -169,52 +197,49 @@ impl EgressFlow {
                     }
                 };
 
-                let metrics = metrics.clone();
-
                 // Spawn a task to handle the connection
                 runtime_cloned.spawn_supervised_task_current_span({
                     let dst = dst.clone();
                     let access_accepted = access_accepted.clone_for_multiplexing();
+                    let metrics = metrics.clone();
 
                     async move {
-                        let fut = async {
-                            let active_cx = metrics.new_cx();
+                        // Protocol-level direct forward: determined by TransportLayer
+                        // inside consume_stream. The first bytes of the stream are inspected
+                        // as HTTP; if the path matches a configured direct_forward regex
+                        // (common_args.direct_forward_rules), the request bypasses OHTTP
+                        // decryption entirely and is forwarded as plain HTTP to upstream.
+                        //
+                        // This is a per-request decision, distinct from the transport-level
+                        // decision above. A connection can pass the transport-level CIDR
+                        // check (encrypted=true, entering the trusted stream path) yet
+                        // still yield DirectlyForward NextStreams when individual request
+                        // paths match the direct_forward rules.
+                        //
+                        // Three sub-stream outcomes:
+                        // - Secured(stream, Some(attestation)): OHTTP decrypted + attested
+                        // - Secured(stream, None): OHTTP/RATS-TLS decrypted, no attestation
+                        // - DirectlyForward(stream): plain HTTP matched by direct_forward rule
+                        let encrypted = next_stream.is_secured();
+                        let attested = next_stream.attestation_result().is_some();
+                        let downstream = next_stream.into_stream();
 
-                            let from_trusted_tunnel = next_stream.is_secured();
-                            let attested = next_stream.attestation_result().is_some();
-                            let downstream = next_stream.into_stream();
-
-                            // Transition to AccessRouted: dst and from_trusted_tunnel are known
-                            let access_routed =
-                                access_accepted.into_routed(&dst, from_trusted_tunnel);
-
-                            let upstream = tcp_connect(
-                                (dst.host(), dst.port()),
-                                #[cfg(any(
-                                    target_os = "android",
-                                    target_os = "fuchsia",
-                                    target_os = "linux"
-                                ))]
-                                transport_so_mark,
-                            )
-                            .await
-                            .context("Failed to connect to upstream")?;
-                            let egress_local =
-                                upstream.local_addr().context("Failed to get local addr")?;
-                            let upstream = ContextualStream::new(upstream, "egress-tcp-connect");
-
-                            // Print access log — Transition to AccessEstablished: upstream connected, then drop immediately to log
-                            access_routed.into_established(Some(egress_local), attested);
-
-                            let downstream = metrics.new_wrapped_stream(downstream);
-
-                            utils::forward::forward_stream(upstream, downstream).await?;
-
-                            active_cx.mark_finished_successfully();
-                            Ok::<_, anyhow::Error>(())
-                        };
-
-                        if let Err(error) = fut.await {
+                        if let Err(error) = forward_to_upstream(
+                            &metrics,
+                            access_accepted,
+                            &dst,
+                            downstream,
+                            encrypted,
+                            attested,
+                            #[cfg(any(
+                                target_os = "android",
+                                target_os = "fuchsia",
+                                target_os = "linux"
+                            ))]
+                            transport_so_mark,
+                        )
+                        .await
+                        {
                             tracing::error!(?error, "Failed to forward stream");
                         }
                     }
@@ -222,6 +247,45 @@ impl EgressFlow {
             }
         });
     }
+}
+
+/// Common upstream-connect-and-forward logic used by both direct and encrypted paths.
+///
+/// Handles the full lifecycle: create metrics context, connect to upstream,
+/// transition access log states, forward streams, and mark success.
+async fn forward_to_upstream(
+    metrics: &ServiceMetrics,
+    access_accepted: AccessAccepted,
+    dst: &TngEndpoint,
+    downstream: Box<dyn CommonStreamTrait>,
+    encrypted: bool,
+    attested: bool,
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    transport_so_mark: Option<u32>,
+) -> Result<()> {
+    let active_cx = metrics.new_cx();
+
+    let access_routed = access_accepted.into_routed(dst, encrypted);
+
+    let upstream = tcp_connect(
+        (dst.host(), dst.port()),
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        transport_so_mark,
+    )
+    .await
+    .context("Failed to connect to upstream")?;
+    let egress_local = upstream.local_addr().context("Failed to get local addr")?;
+    let upstream = ContextualStream::new(upstream, "egress-tcp-connect");
+
+    // Print access log — Transition to AccessEstablished: upstream connected, then drop immediately to log
+    access_routed.into_established(Some(egress_local), attested);
+
+    let downstream = metrics.new_wrapped_stream(downstream);
+
+    utils::forward::forward_stream(upstream, downstream).await?;
+
+    active_cx.mark_finished_successfully();
+    Ok(())
 }
 
 #[async_trait]

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -105,6 +105,11 @@ impl EgressTrait for HookEgress {
                                 // local address (the actual IP the connection arrived on).
                                 // The hook only changes the port, not the IP, so we must
                                 // connect back to the same host on the real port.
+                                //
+                                // This is necessary: using local_addr() as the forwarding
+                                // target ensures we only reach the interface the listener
+                                // was bound to, avoiding accidentally exposing a
+                                // localhost-bound listener to the external network.
                                 let local = stream.local_addr().unwrap_or(info.local_addr);
                                 let upstream_host = if local.ip().is_unspecified() {
                                     "127.0.0.1".to_owned()

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -1,4 +1,5 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use async_stream::stream;
@@ -7,6 +8,8 @@ use futures::stream::select_all;
 use indexmap::IndexMap;
 use tokio::net::TcpListener;
 
+use crate::config::egress_hook::EgressHookArgs;
+use crate::config::egress_hook::EgressHookHostFilterRule;
 use crate::config::EgressHookMappingEntry;
 use crate::tunnel::access_log::{AccessAccepted, EgressAccessMode};
 use crate::tunnel::egress::flow::AcceptedStream;
@@ -21,34 +24,78 @@ use super::flow::{EgressTrait, Incomming};
 ///
 /// Each HookEgress instance handles a list of origin->real port mappings
 /// (expanded from capture_listen entries by `tng exec`).
+///
+/// Host CIDR filtering happens at accept time: connections whose local_addr
+/// matches a configured CIDR go through encryption; others are forwarded directly.
 pub struct HookEgress {
     id: usize,
+    /// Port-only mapping entries (origin_port -> real_port) for metric attributes
+    /// and getsockname lookup reference.
     entries: Vec<EgressHookMappingEntry>,
+    /// Host filter rules for accept-time CIDR matching.
+    /// A connection is encrypted only if its local_addr.ip() matches
+    /// one of these CIDRs AND the port is in range.
+    /// When empty, all traffic is encrypted (default behavior).
+    host_filters: Vec<EgressHookHostFilterRule>,
 }
 
 impl HookEgress {
-    /// Create a new HookEgress from resolved mapping entries.
-    pub fn new(id: usize, entries: &[EgressHookMappingEntry]) -> Self {
+    /// Create a new HookEgress from hook args.
+    ///
+    /// Expands `resolved_entries` into port-only mapping entries for
+    /// metric attributes and getsockname lookup, and builds host filter
+    /// rules for accept-time CIDR matching.
+    pub fn new(id: usize, hook_args: &EgressHookArgs) -> Self {
+        let mut entries: Vec<EgressHookMappingEntry> = Vec::new();
+        let mut host_filters: Vec<EgressHookHostFilterRule> = Vec::new();
+
+        for entry in &hook_args.resolved_entries {
+            entries.push(EgressHookMappingEntry {
+                origin_port: entry.origin_port,
+                real_port: entry.real_port,
+            });
+            if let Some(rule) = entry.host_filter_rule() {
+                host_filters.push(rule);
+            }
+        }
+
         Self {
             id,
-            entries: entries.to_vec(),
+            entries,
+            host_filters,
         }
+    }
+
+    /// Check whether a connection arriving at local_addr should go through
+    /// the encryption/decryption path.
+    ///
+    /// Returns true if local_addr.ip() matches any configured host CIDR
+    /// and the port is within the configured range. When no filters are
+    /// configured, all traffic is encrypted (backward compatible default).
+    pub fn encrypted(&self, local_addr: SocketAddr) -> bool {
+        if self.host_filters.is_empty() {
+            return true;
+        }
+
+        let ip = match local_addr.ip() {
+            IpAddr::V4(ip) => ip,
+            IpAddr::V6(_) => return false,
+        };
+
+        let port = local_addr.port();
+
+        self.host_filters
+            .iter()
+            .any(|rule| rule.host_cidr.contains(&ip) && rule.port_range.contains(&port))
     }
 }
 
 #[async_trait]
 impl EgressTrait for HookEgress {
-    /// egress_type=hook,egress_id={id},egress_in={listen_addr}:{origin_port},egress_out=127.0.0.1:{real_port}
+    /// egress_type=hook,egress_id={id},egress_in=0.0.0.0:{origin_port},egress_out=127.0.0.1:{real_port}
     fn metric_attributes(&self) -> IndexMap<String, String> {
         let first = self.entries.first();
-        let in_desc = first.map_or("".to_owned(), |e| {
-            let host = if e.host.is_unspecified() {
-                "0.0.0.0"
-            } else {
-                ""
-            };
-            format!("{}:{}", host, e.origin_port)
-        });
+        let in_desc = first.map_or("".to_owned(), |e| format!("0.0.0.0:{}", e.origin_port));
         let out_desc = first.map_or("".to_owned(), |e| format!("127.0.0.1:{}", e.real_port));
 
         [
@@ -75,12 +122,7 @@ impl EgressTrait for HookEgress {
         let mut listeners: Vec<ListenerInfo> = Vec::new();
 
         for entry in &self.entries {
-            let host = if entry.host.is_unspecified() {
-                "0.0.0.0".to_owned()
-            } else {
-                entry.host.to_string()
-            };
-            let addr = format!("{}:{}", host, entry.origin_port);
+            let addr = format!("0.0.0.0:{}", entry.origin_port);
             tracing::debug!(%addr, real_port = entry.real_port, "Hook egress: Add TCP listener on origin port");
 
             let listener = TcpListener::bind(&addr).await?;
@@ -123,6 +165,8 @@ impl EgressTrait for HookEgress {
                                     info.local_addr,
                                     EgressAccessMode::Hook,
                                 );
+                                let encrypted = self.encrypted(local);
+
                                 yield Ok(AcceptedStream {
                                     stream: Box::new(crate::ContextualStream::new(stream, "egress-hook")),
                                     src: peer_addr,
@@ -130,6 +174,7 @@ impl EgressTrait for HookEgress {
                                     listener_addr: info.local_addr,
                                     egress_mode: EgressAccessMode::Hook,
                                     access_accepted,
+                                    encrypted,
                                 })
                             }
                             Err(e) => yield Err(anyhow!(e)),
@@ -140,5 +185,105 @@ impl EgressTrait for HookEgress {
             .collect();
 
         Ok(Box::new(select_all(streams)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::egress_hook::TngEgressHookMappingEntry;
+    use cidr::Ipv4Cidr;
+    use std::net::Ipv4Addr;
+
+    fn make_args(entries: Vec<TngEgressHookMappingEntry>) -> EgressHookArgs {
+        EgressHookArgs {
+            capture_listen: vec![],
+            resolved_entries: entries,
+        }
+    }
+
+    #[test]
+    fn test_should_encrypt_empty_filters_returns_true() {
+        let egress = HookEgress::new(0, &make_args(vec![]));
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 5600);
+        assert!(egress.encrypted(addr));
+    }
+
+    #[test]
+    fn test_should_encrypt_matches_cidr_and_port() {
+        let entry = TngEgressHookMappingEntry {
+            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(172, 17, 80, 0), 20).unwrap(),
+            origin_port: 5600,
+            real_port: 9600,
+        };
+        let egress = HookEgress::new(0, &make_args(vec![entry]));
+
+        // In range
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 17, 80, 5)), 5600);
+        assert!(egress.encrypted(addr));
+
+        // Out of CIDR
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 5600);
+        assert!(!egress.encrypted(addr));
+
+        // Out of port range
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 17, 80, 5)), 5601);
+        assert!(!egress.encrypted(addr));
+    }
+
+    #[test]
+    fn test_should_encrypt_ipv6_returns_false() {
+        let entry = TngEgressHookMappingEntry {
+            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(172, 17, 80, 0), 20).unwrap(),
+            origin_port: 5600,
+            real_port: 9600,
+        };
+        let egress = HookEgress::new(0, &make_args(vec![entry]));
+
+        let addr = SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST), 5600);
+        assert!(!egress.encrypted(addr));
+    }
+
+    #[test]
+    fn test_should_encrypt_port_range() {
+        // Each TngEgressHookMappingEntry creates a single-port host filter rule.
+        // Include entries only for 8000, 8005, 8010 — 8011 should return false.
+        let entry = TngEgressHookMappingEntry {
+            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
+            origin_port: 8000,
+            real_port: 9000,
+        };
+        let entry2 = TngEgressHookMappingEntry {
+            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
+            origin_port: 8005,
+            real_port: 9005,
+        };
+        let entry3 = TngEgressHookMappingEntry {
+            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
+            origin_port: 8010,
+            real_port: 9010,
+        };
+        let egress = HookEgress::new(0, &make_args(vec![entry, entry2, entry3]));
+
+        // Port at start of range
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            8000
+        )));
+        // Port in middle
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            8005
+        )));
+        // Port at end of range
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            8010
+        )));
+        // Port just outside range
+        assert!(!egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            8011
+        )));
     }
 }

--- a/tng/src/tunnel/egress/mapping.rs
+++ b/tng/src/tunnel/egress/mapping.rs
@@ -138,6 +138,7 @@ impl EgressTrait for MappingEgress {
                                     listener_addr: target.local_addr,
                                     egress_mode: EgressAccessMode::Mapping,
                                     access_accepted,
+                                    encrypted: true,
                                 })
                             }
                             Err(e) => yield Err(anyhow!(e)),

--- a/tng/src/tunnel/egress/netfilter/mod.rs
+++ b/tng/src/tunnel/egress/netfilter/mod.rs
@@ -142,6 +142,7 @@ impl EgressTrait for NetfilterEgress {
                     listener_addr: listen_addr,
                     egress_mode: EgressAccessMode::Netfilter,
                     access_accepted,
+                    encrypted: true,
                 })
             }),
         ))

--- a/tng/src/tunnel/ingress/flow/mod.rs
+++ b/tng/src/tunnel/ingress/flow/mod.rs
@@ -58,7 +58,7 @@ pub(super) struct AcceptedStream {
     pub stream: Box<dyn CommonStreamTrait + Send>,
     pub src: SocketAddr,
     pub dst: Arc<TngEndpoint>,
-    pub via_tunnel: bool,
+    pub encrypted: bool,
     pub listener_addr: SocketAddr,
     pub ingress_mode: IngressAccessMode,
     pub access_accepted: AccessAccepted,
@@ -146,7 +146,7 @@ impl IngressFlow {
             stream,
             src,
             dst,
-            via_tunnel,
+            encrypted,
             listener_addr: _,
             ingress_mode: _,
             access_accepted,
@@ -162,18 +162,18 @@ impl IngressFlow {
             tracing::info_span!("serve", client=?src),
             async move {
                 let fut = async move {
-                    tracing::debug!(%src, %dst, via_tunnel, "Acquire connection to upstream");
+                    tracing::debug!(%src, %dst, encrypted, "Acquire connection to upstream");
 
                     // TODO: merge .new_cx() and .new_wrapped_stream()
                     let active_cx = metrics.new_cx();
                     let stream = metrics.new_wrapped_stream(stream);
 
-                    // Transition to AccessRouted: dst and via_tunnel are known here
-                    let access_routed = access_accepted.into_routed(&dst, via_tunnel);
+                    // Transition to AccessRouted: dst and encrypted are known here
+                    let access_routed = access_accepted.into_routed(&dst, encrypted);
 
                     let attestation_result;
                     let upstream_local;
-                    let forward_stream_task = if !via_tunnel {
+                    let forward_stream_task = if !encrypted {
                         // Forward via unprotected tcp
                         let (forward_stream_task, att, up_local) = unprotected_stream_manager
                             .forward_stream(&dst, Box::new(stream))

--- a/tng/src/tunnel/ingress/flow/stream_router.rs
+++ b/tng/src/tunnel/ingress/flow/stream_router.rs
@@ -10,12 +10,12 @@ impl StreamRouter {
     }
 
     pub fn should_forward_via_tunnel(&self, endpoint: &TngEndpoint) -> bool {
-        let via_tunnel = self.endpoint_matcher.matches(endpoint);
+        let encrypted = self.endpoint_matcher.matches(endpoint);
         tracing::debug!(
             endpoint=?endpoint,
-            via_tunnel,
+            encrypted,
             "Determine whether to forward the stream via secure tunnel"
         );
-        via_tunnel
+        encrypted
     }
 }

--- a/tng/src/tunnel/ingress/http_proxy.rs
+++ b/tng/src/tunnel/ingress/http_proxy.rs
@@ -147,7 +147,7 @@ impl RequestHelper {
                         .await
                         .context("Failed during http connect upgrade")?;
 
-                    let via_tunnel = stream_router.should_forward_via_tunnel(&dst);
+                    let encrypted = stream_router.should_forward_via_tunnel(&dst);
                     let access_accepted =
                         AccessAccepted::new_ingress(peer_addr, listener_addr, mode);
                     sender
@@ -158,7 +158,7 @@ impl RequestHelper {
                             )),
                             src: peer_addr,
                             dst: Arc::new(dst),
-                            via_tunnel,
+                            encrypted,
                             listener_addr,
                             ingress_mode: mode,
                             access_accepted,
@@ -191,13 +191,13 @@ impl RequestHelper {
                 let (s1, s2) = tokio::io::duplex(4096);
 
                 let send_accepted_stream = async {
-                    let via_tunnel = stream_router.should_forward_via_tunnel(&dst);
+                    let encrypted = stream_router.should_forward_via_tunnel(&dst);
                     let access_accepted = AccessAccepted::new_ingress(
                         peer_addr,
                         listener_addr,
                         mode,
                     );
-                    sender.send(AcceptedStream { stream: Box::new(crate::ContextualStream::new(s2, "ingress-http-reverse-proxy")), src: peer_addr, dst: Arc::new(dst), via_tunnel, listener_addr, ingress_mode: mode, access_accepted })
+                    sender.send(AcceptedStream { stream: Box::new(crate::ContextualStream::new(s2, "ingress-http-reverse-proxy")), src: peer_addr, dst: Arc::new(dst), encrypted, listener_addr, ingress_mode: mode, access_accepted })
                 };
 
                 let send_task = async {

--- a/tng/src/tunnel/ingress/mapping.rs
+++ b/tng/src/tunnel/ingress/mapping.rs
@@ -139,7 +139,7 @@ impl IngressTrait for MappingIngress {
                                     stream: Box::new(crate::ContextualStream::new(stream, "ingress-mapping")),
                                     src: peer_addr,
                                     dst: Arc::clone(&target.out_ep),
-                                    via_tunnel: true,
+                                    encrypted: true,
                                     listener_addr: target.local_addr,
                                     ingress_mode: IngressAccessMode::Mapping,
                                     access_accepted,

--- a/tng/src/tunnel/ingress/netfilter/mod.rs
+++ b/tng/src/tunnel/ingress/netfilter/mod.rs
@@ -136,7 +136,7 @@ impl IngressTrait for NetfilterIngress {
                     stream: Box::new(crate::ContextualStream::new(stream, "ingress-netfilter")),
                     src: peer_addr,
                     dst: Arc::new(orig_dst),
-                    via_tunnel: true,
+                    encrypted: true,
                     listener_addr: listen_addr,
                     ingress_mode: IngressAccessMode::Netfilter,
                     access_accepted,

--- a/tng/src/tunnel/ingress/socks5.rs
+++ b/tng/src/tunnel/ingress/socks5.rs
@@ -163,7 +163,7 @@ impl IngressTrait for Socks5Ingress {
 
                     tracing::debug!(src = ?peer_addr, %dst, "Accepted socks5 connection");
 
-                    let via_tunnel = self.stream_router.should_forward_via_tunnel(&dst);
+                    let encrypted = self.stream_router.should_forward_via_tunnel(&dst);
 
                     let access_accepted = AccessAccepted::new_ingress(
                         peer_addr,
@@ -174,7 +174,7 @@ impl IngressTrait for Socks5Ingress {
                         stream: Box::new(crate::ContextualStream::new(stream, "ingress-socks5")),
                         src: peer_addr,
                         dst: Arc::new(dst),
-                        via_tunnel,
+                        encrypted,
                         listener_addr,
                         ingress_mode: IngressAccessMode::Socks5,
                         access_accepted,

--- a/tng/src/tunnel/utils/rustls/ra/server_cert_verifier.rs
+++ b/tng/src/tunnel/utils/rustls/ra/server_cert_verifier.rs
@@ -101,7 +101,6 @@ impl rustls::client::danger::ServerCertVerifier for BlockingServerCertVerifier {
         _now: rustls::pki_types::UnixTime,
     ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
         let _: AttestationResult = self.1.verify_cert_blocking(end_entity).map_err(|error| {
-            tracing::error!(?error, "Failed to verify server certificate");
             rustls::Error::InvalidCertificate(rustls::CertificateError::Other(rustls::OtherError(
                 Arc::from(error.into_boxed_dyn_error()),
             )))


### PR DESCRIPTION
## Summary

Decouple bind-time port mapping from runtime host filtering in the egress hook, and fix a TOCTOU port allocation race in exec mode.

## Changes

### Egress Hook Host Filtering at Accept Time
- **config**: Add internal `TngEgressHookMappingEntry` with host CIDR for runtime accept-time filtering; `EgressHookMappingEntry` (from `tng-hook-types`) remains port-only for the `.so` env payload
- **hook**: Simplify egress mapping to port-only lookup, move entry building into `HookEgress::new`, rename `tunnel` to `encrypted` across access_log and all ingress/egress modes for clarity
- **exec**: Build port-only mapping tables; `HookEgress` provides `should_encrypt(local_addr)` for accept-time CIDR matching
- **flow**: `AcceptedStream` carries `should_encrypt` flag; `EgressFlow` skips the trusted stream manager and forwards directly when `should_encrypt` is false
- **egress**: Extract `forward_to_upstream` helper to eliminate 30+ lines of duplicated connect-forward-metrics code
- **docs**: Clarify two levels of direct-forward decisions in flow (transport-level CIDR match vs protocol-level HTTP path regex)

### Port Allocation TOCTOU Fix
- `portpicker::pick_unused_port()` binds then drops the socket, so independent calls can return the same port (TOCTOU race) causing intermittent "Conflict: real_port X is claimed by both" errors
- Introduce `PortAllocator` that tracks all allocated ports in a single `HashSet` — both egress `real_port` and ingress `proxy_port` funnel through it
- Add 5 new tests covering cross-entry, cross-category, and explicit-port collision scenarios

### Other Fixes
- Add comment explaining `local_addr()` forwarding in hook egress
- Remove redundant error log in server cert verifier (error already in rustls chain)

## Tests

- `cargo fmt`, `make clippy`, `cargo build` all pass
- Unit tests for `PortAllocator` cover cross-entry, cross-category, and explicit-port collisions
