### PR TITLE
feat(tng-hook): reject connections to 0.0.0.0 in connect hook

### DIFF
--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -329,6 +329,18 @@ pub extern "C" fn connect(sockfd: c_int, addr: *const sockaddr, addrlen: socklen
         dst_addr.port()
     );
 
+    // Reject connections to 0.0.0.0 (NULL IP) early. Connecting to the
+    // unspecified address is often an application bug and should not be
+    // routed through the proxy. Mirrors proxychains-ng's behavior
+    // (src/libproxychains.c:702-705).
+    if *dst_addr.ip() == Ipv4Addr::UNSPECIFIED {
+        tracing::debug!("connect: rejecting 0.0.0.0 (null IP)");
+        unsafe {
+            *libc::__errno_location() = libc::ECONNREFUSED;
+        }
+        return -1;
+    }
+
     // Check if this destination matches any ingress capture rule
     let Some(lookup) = INGRESS_LOOKUP.get() else {
         tracing::debug!(

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -193,3 +193,8 @@ required-features = ["on-bin"]
 name = "ingress_hook_basic"
 path = "tests/hook/ingress_hook_basic.rs"
 required-features = ["on-bin"]
+
+[[test]]
+name = "connect_reject_null_ip"
+path = "tests/hook/connect_reject_null_ip.rs"
+required-features = ["on-bin"]

--- a/tng-testsuite/tests/hook/connect_reject_null_ip.rs
+++ b/tng-testsuite/tests/hook/connect_reject_null_ip.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use tng_testsuite::{
+    run_test,
+    task::{tng::TngExecTask, Task as _},
+};
+
+/// Test that the connect hook rejects connections to 0.0.0.0 (NULL IP).
+///
+/// Connecting to the unspecified address 0.0.0.0 is often an application bug
+/// and should not be routed through the proxy. This mirrors proxychains-ng's
+/// behavior (src/libproxychains.c:702-705).
+///
+/// The test runs a Python script inside `tng exec` (which loads libtng_hook.so
+/// via LD_PRELOAD) that attempts to connect to 0.0.0.0:9999 and verifies that
+/// the connect fails with errno ECONNREFUSED (111).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test() -> Result<()> {
+    run_test!(vec![TngExecTask::new(
+        // Minimal config: a dummy ingress hook capture rule — just enough to load the hook.
+        r#"{"add_ingress": [{"hook": {"capture_dst": [{"port": 9999}]}, "no_ra": true}]}"#
+            .to_string(),
+        vec![
+            "python3".to_string(),
+            "-c".to_string(),
+            concat!(
+                "import socket, errno, sys\n",
+                "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
+                "try:\n",
+                "    s.connect(('0.0.0.0', 9999))\n",
+                "    print('FAIL: connect to 0.0.0.0 should have failed')\n",
+                "    sys.exit(1)\n",
+                "except OSError as e:\n",
+                "    if e.errno == errno.ECONNREFUSED:\n",
+                "        print('OK: connect to 0.0.0.0 correctly rejected with ECONNREFUSED')\n",
+                "    else:\n",
+                "        print(f'FAIL: expected ECONNREFUSED (111), got errno={e.errno}')\n",
+                "        sys.exit(1)\n",
+                "finally:\n",
+                "    s.close()\n",
+            )
+            .to_string(),
+        ],
+        true, // stop_after_exit: test is complete once this exits
+    )
+    .boxed(),])
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
Reject connections to the unspecified address (0.0.0.0) in the connect hook, avoiding routing invalid addresses to the proxy. Mirrors proxychains-ng behavior (`src/libproxychains.c:702-705`).

## Changes

### `tng-hook/cdylib/src/lib.rs`
- After IPv4 address resolution, check if destination IP is `Ipv4Addr::UNSPECIFIED` (0.0.0.0)
- If matched, set `errno = ECONNREFUSED`, return `-1`, log a debug message
- Placed before any ingress/egress hijacking logic

### `tng-testsuite/tests/hook/connect_reject_null_ip.rs` (new)
- Integration test running a Python script inside `tng exec` (LD_PRELOAD)
- Attempts `connect(("0.0.0.0", 9999))` and asserts `ECONNREFUSED`

## Reference
proxychains-ng `src/libproxychains.c:702-705`:
```c
if(!v6 && !memcmp(p_addr_in, "\0\0\0\0", 4)) {
    errno = ECONNREFUSED;
    return -1;
}
```
