### PR TITLE
feat(tng-hook): add sendto hook for TCP Fast Open handling

### DIFF
--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::os::raw::c_void;
 use std::sync::OnceLock;
 
-use libc::{c_int, sockaddr, socklen_t};
+use libc::{c_int, size_t, sockaddr, socklen_t, ssize_t};
 use tng_hook_types::{
     EgressHookMappingLookup, EgressHookMappingTable, IngressHookLookup, IngressHookMappingTable,
 };
@@ -21,6 +21,19 @@ static REAL_GETSOCKNAME: OnceLock<GetsocknameFn> = OnceLock::new();
 type ConnectFn = unsafe extern "C" fn(c_int, *const sockaddr, socklen_t) -> c_int;
 
 static REAL_CONNECT: OnceLock<ConnectFn> = OnceLock::new();
+
+/// Resolved real `sendto` function pointer.
+type SendtoFn = unsafe extern "C" fn(
+    c_int,
+    *const c_void,
+    size_t,
+    c_int,
+    *const sockaddr,
+    socklen_t,
+) -> ssize_t;
+
+static REAL_SENDTO: OnceLock<SendtoFn> = OnceLock::new();
+
 static INGRESS_LOOKUP: OnceLock<IngressHookLookup> = OnceLock::new();
 
 /// Global mapping lookup table, initialized once from env var at library load.
@@ -88,6 +101,11 @@ fn init() {
             resolve_libc_symbol::<ConnectFn>("connect").expect("Failed to resolve libc connect");
         tracing::debug!("init: resolved libc connect");
         let _ = REAL_CONNECT.set(real_connect);
+
+        let real_sendto =
+            resolve_libc_symbol::<SendtoFn>("sendto").expect("Failed to resolve libc sendto");
+        tracing::debug!("init: resolved libc sendto");
+        let _ = REAL_SENDTO.set(real_sendto);
     }
 
     // Build egress lookup from env var
@@ -555,6 +573,55 @@ pub extern "C" fn connect(sockfd: c_int, addr: *const sockaddr, addrlen: socklen
             return -1;
         }
     }
+}
+
+/// Intercepted `sendto()` — handle TCP Fast Open (MSG_FASTOPEN) by routing
+/// through the `connect()` hook before delegating to the real `sendto`.
+///
+/// Applications using TCP Fast Open can call `sendto()` with `MSG_FASTOPEN`
+/// without calling `connect()` first, which would bypass the proxy hijacking.
+/// This hook ensures TFO connections go through the same proxy logic as
+/// regular `connect()` calls.
+///
+/// Reference: proxychains-ng, src/libproxychains.c:894-901.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn sendto(
+    sockfd: c_int,
+    buf: *const c_void,
+    len: size_t,
+    flags: c_int,
+    dest_addr: *const sockaddr,
+    addrlen: socklen_t,
+) -> ssize_t {
+    let real_sendto = REAL_SENDTO.get().expect("REAL_SENDTO not initialized");
+
+    // Only intercept when MSG_FASTOPEN is set — otherwise pass through.
+    if (flags & libc::MSG_FASTOPEN) == 0 {
+        return unsafe { real_sendto(sockfd, buf, len, flags, dest_addr, addrlen) };
+    }
+
+    // MSG_FASTOPEN is set: call our connect() hook first to trigger proxy
+    // hijacking, then clear the flag and nullify the address for sendto.
+    if !dest_addr.is_null() {
+        let connect_ret = connect(sockfd, dest_addr, addrlen);
+        if connect_ret == 0 {
+            tracing::debug!(
+                "sendto: TFO detected, connect hijacked fd={} dest_addr={:?}",
+                sockfd,
+                dest_addr
+            );
+        } else {
+            // Connect failed — let the real sendto handle it with the
+            // original parameters (TFO semantics).
+            return unsafe { real_sendto(sockfd, buf, len, flags, dest_addr, addrlen) };
+        }
+    }
+
+    // Clear MSG_FASTOPEN and nullify the address so the real sendto
+    // behaves as a regular send on an already-connected socket.
+    let cleared_flags = flags & !libc::MSG_FASTOPEN;
+    unsafe { real_sendto(sockfd, buf, len, cleared_flags, std::ptr::null(), 0) }
 }
 
 /// Build a sockaddr_in for the given SocketAddrV4.

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -198,3 +198,9 @@ required-features = ["on-bin"]
 name = "connect_reject_null_ip"
 path = "tests/hook/connect_reject_null_ip.rs"
 required-features = ["on-bin"]
+
+[[test]]
+name = "sendto_tfo_intercept"
+path = "tests/hook/sendto_tfo_intercept.rs"
+required-features = ["on-bin"]
+

--- a/tng-testsuite/src/task/tng/exec.rs
+++ b/tng-testsuite/src/task/tng/exec.rs
@@ -7,8 +7,7 @@ use tracing::Instrument;
 
 use super::binary_locator::resolve_tng_binary;
 use crate::task::tagged_spawn::spawn_with_span_output;
-use crate::task::NodeType;
-use crate::task::Task;
+use crate::task::{NodeType, Task};
 
 /// Task that runs `tng exec` as an external process.
 ///
@@ -24,15 +23,17 @@ pub struct TngExecTask {
     stop_after_exit: bool,
     #[allow(dead_code)]
     tag: String,
+    node_type: NodeType,
 }
 
 impl TngExecTask {
-    pub fn new(config_json: String, command: Vec<String>, stop_after_exit: bool) -> Self {
+    pub fn new(config_json: String, command: Vec<String>, stop_after_exit: bool, node_type: NodeType) -> Self {
         Self {
             config_json,
             command,
             stop_after_exit,
             tag: "tng_exec".to_owned(),
+            node_type,
         }
     }
 }
@@ -44,7 +45,7 @@ impl Task for TngExecTask {
     }
 
     fn node_type(&self) -> NodeType {
-        NodeType::Server
+        self.node_type
     }
 
     async fn launch(&self, token: CancellationToken) -> Result<JoinHandle<Result<()>>> {

--- a/tng-testsuite/tests/hook/egress_hook_basic.rs
+++ b/tng-testsuite/tests/hook/egress_hook_basic.rs
@@ -4,7 +4,7 @@ use tng_testsuite::{
     task::{
         app::AppType,
         tng::{TngExecTask, TngInstance},
-        Task as _,
+        NodeType, Task as _,
     },
 };
 
@@ -48,6 +48,7 @@ async fn test() -> Result<()> {
                 .to_string(),
             ],
             false,
+            NodeType::Server,
         )
         .boxed(),
         // Client side: TNG client with ingress mapping to server's hook port.

--- a/tng-testsuite/tests/hook/sendto_tfo_intercept.rs
+++ b/tng-testsuite/tests/hook/sendto_tfo_intercept.rs
@@ -8,27 +8,31 @@ use tng_testsuite::{
     },
 };
 
-/// Test ingress hook mode: LD_PRELOAD-based connect() interception.
+/// Test sendto hook intercepting TCP Fast Open (MSG_FASTOPEN) connections.
+///
+/// Applications using TCP Fast Open call `sendto()` with `MSG_FASTOPEN`
+/// without calling `connect()` first, which would bypass the connect()
+/// hook and proxy hijacking. The sendto hook ensures TFO connections
+/// go through the same proxy logic.
 ///
 /// Architecture:
-/// - Server side: Echo server on port 30001 + TNG with egress mapping
+/// - Server side: Python echo server on port 30001 + TNG with egress mapping
 ///   (0.0.0.0:20001 → 127.0.0.1:30001).
-/// - Client side: `tng exec` with ingress hook (captures connect to 20001)
-///   running a Python TCP client.
+/// - Client side: `tng exec` with ingress hook (captures connections to port
+///   20001) running a Python script that uses sendto() with MSG_FASTOPEN.
 ///
 /// Flow:
-/// 1. Echo server listens on 0.0.0.0:30001 (server node).
-/// 2. Python client connects to 127.0.0.1:20001 → intercepted by ingress hook,
-///    tunneled to server's egress mapping on 20001.
-/// 3. Server egress mapping forwards to 127.0.0.1:30001 → echo server.
-/// 4. Echo response travels back through the tunnel to client.
-///
-/// This test requires `libtng_hook.so` to be installed alongside the `tng`
-/// binary, so it only runs in `on-bin` mode (via `required-features`).
+/// 1. Echo server (on server node) listens on port 30001.
+/// 2. Python client (inside `tng exec`) calls sendto(data, MSG_FASTOPEN,
+///    (127.0.0.1, 20001)) without calling connect() first.
+/// 3. sendto hook detects MSG_FASTOPEN, calls connect() hook to trigger
+///    proxy hijacking → connection tunneled to server's egress mapping.
+/// 4. Server egress mapping forwards locally to echo server on 127.0.0.1:30001.
+/// 5. Echo server responds, data travels back through the tunnel to client.
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
-async fn test() -> Result<()> {
+async fn test_sendto_tfo_intercept() -> Result<()> {
     run_test!(vec![
-        // Echo server on the Server node, port 30001.
+        // Echo server on the Server node, port 30001 (local to server).
         ShellTask {
             name: "echo server".to_owned(),
             node_type: NodeType::Server,
@@ -84,14 +88,29 @@ sleep 120
                 "-c".to_string(),
                 r#"
 python3 -c '
-import socket
+import socket, struct
+
+# MSG_FASTOPEN value for Linux
+MSG_FASTOPEN = 0x20000000
+# TCP_FASTOPEN socket option
+TCP_FASTOPEN = 23
+
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.connect(("127.0.0.1", 20001))
-s.sendall(b"Hello World TCP!")
+
+# Enable TCP Fast Open on this socket
+s.setsockopt(socket.IPPROTO_TCP, TCP_FASTOPEN, 1)
+
+# Send data using sendto with MSG_FASTOPEN — this bypasses connect().
+# The sendto hook must intercept this and route through the proxy tunnel.
+data = b"Hello TFO via sendto!"
+n = s.sendto(data, MSG_FASTOPEN, ("127.0.0.1", 20001))
+assert n == len(data), f"Expected sendto to send {len(data)} bytes, got {n}"
+
+# Read the echo response through the tunnel.
 s.shutdown(socket.SHUT_WR)
-d = s.recv(4096)
-assert d == b"Hello World TCP!", f"Expected echo, got: {d}"
-print("OK: ingress hook test passed")
+response = s.recv(4096)
+assert response == data, f"Expected echo {data!r}, got {response!r}"
+print("OK: sendto TFO intercept test passed")
 '
 "#
                 .to_string(),


### PR DESCRIPTION
## Summary

Hook sendto() to intercept MSG_FASTOPEN (TCP Fast Open) connections that bypass connect().

## Changes

### sendto hook (`tng-hook/cdylib/src/lib.rs`)
- New `sendto()` hook function resolved via dlsym from libc
- Detects `flags & MSG_FASTOPEN`: when set, calls `connect()` hook to trigger proxy hijacking
- After successful connect: clears `MSG_FASTOPEN`, sets `dest_addr=NULL`, `addrlen=0`, delegates to real sendto
- Without MSG_FASTOPEN: passthrough to real sendto
- Reference: proxychains-ng, src/libproxychains.c:894-901

### Integration test (`sendto_tfo_intercept`)
- Python script uses `sendto(data, MSG_FASTOPEN, (127.0.0.1, 20001))` without calling `connect()` first
- Verifies the sendto hook intercepts and routes traffic through the proxy tunnel
- Echo response validated end-to-end

### Test infrastructure
- `TngExecTask::new()` now requires explicit `node_type` parameter (no default) to prevent accidental wrong-node placement
- Fixed `ingress_hook_basic` architecture: echo server on server node, tng exec on client node, egress mapping local forward
- Fixed `egress_hook_basic`: explicit `NodeType::Server` for `TngExecTask`