### PR TITLE
feat(cli): add --log-file option for file-based logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7302,6 +7302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7721,6 +7727,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -8277,6 +8284,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ tracing-futures = {version = "0.2.5"}
 tracing-log = "0.2.0"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}
+tracing-appender = "0.2"
 tracing-wasm = "0.2.1"
 ttrpc = "0.8.4"
 ttrpc-codegen = "0.5.0"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@
 - [Deprecated Configuration](#deprecated-configuration)
 - [Observability](#observability)
   - [Log](#log)
+    - [`--log-file`](#---log-file-file-)
   - [Metric](#metric)
   - [Trace](#trace)
 - [Appendix: Regular Expression Syntax](#appendix-regular-expression-syntax)
@@ -1776,6 +1777,32 @@ Includes Log, Metric, and Trace aspects.
 TNG outputs logs to standard output by default. Control the log level via the `RUST_LOG` environment variable: `error`, `warn`, `info`, `debug`, `trace`, `off`. Default is `info`, with all third-party library logs disabled.
 
 > Supports complex configurations; see [tracing-subscriber EnvFilter](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives).
+
+#### `--log-file <FILE>`
+
+Redirect all log output to the specified file instead of stdout/stderr.
+This is a global CLI option and applies to both `tng launch` and `tng exec`.
+
+When used with `tng exec`, the hook library (`.so`) loaded by the child
+process also writes to the same log file.
+
+Log level is controlled by the `RUST_LOG` environment variable (same as
+without `--log-file`).
+
+```bash
+# Write logs to file
+tng --log-file /var/log/tng.log launch --config-file config.json
+
+# Exec mode — tng and hook .so both write to the same file
+tng --log-file /tmp/tng.log exec --config-file config.json -- /usr/bin/app
+
+# Control log level via RUST_LOG
+RUST_LOG=debug tng --log-file tng-debug.log launch --config-file config.json
+```
+
+If the specified directory does not exist, the command fails with an error.
+The file is created automatically if it doesn't exist but the directory does.
+Logs are appended to existing files.
 
 ### Metric
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -42,6 +42,7 @@
 - [废弃配置](#废弃配置)
 - [可观测性](#可观测性)
   - [Log](#log)
+    - [`--log-file`](#---log-file-file-)
   - [Metric](#metric)
   - [Trace](#trace)
 - [附录：正则表达式语法](#附录正则表达式语法)
@@ -1780,6 +1781,30 @@ MC4CAQAwBQYDK2VuBCIEILi5PepL11X3ptJneUQu40m2kiuNeLD9MRK4CYh94t1d
 TNG 默认将日志输出到标准输出，通过 `RUST_LOG` 环境变量控制日志级别：`error`、`warn`、`info`、`debug`、`trace`、`off`。默认 `info`，禁用所有第三方库日志。
 
 > 支持复杂配置，参考 [tracing-subscriber EnvFilter](https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives)。
+
+#### `--log-file <FILE>`
+
+将所有日志输出重定向到指定文件，而非 stdout/stderr。
+这是一个全局 CLI 选项，对 `tng launch` 和 `tng exec` 均生效。
+
+在 `tng exec` 模式下，子进程加载的 hook 库（`.so`）也会写入同一个日志文件。
+
+日志级别由 `RUST_LOG` 环境变量控制（与不使用 `--log-file` 时相同）。
+
+```bash
+# 将日志写入文件
+tng --log-file /var/log/tng.log launch --config-file config.json
+
+# Exec 模式 — tng 和 hook .so 都写入同一个文件
+tng --log-file /tmp/tng.log exec --config-file config.json -- /usr/bin/app
+
+# 通过 RUST_LOG 控制日志级别
+RUST_LOG=debug tng --log-file tng-debug.log launch --config-file config.json
+```
+
+如果指定的目录不存在，命令会报错并退出。
+如果目录存在但文件不存在，文件会自动创建。
+已存在的文件会以追加模式写入。
 
 ### Metric
 

--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -70,21 +70,44 @@ unsafe fn resolve_libc_symbol<T>(name: &str) -> Option<T> {
 /// the mapping lookup table from the `TNG_HOOK_EGRESS_MAPPINGS` env var.
 #[ctor::ctor]
 fn init() {
-    // Initialize tracing subscriber writing to stderr.
-    // This allows `tracing::info!` etc. to produce output even in a
-    // preloaded library where the host process has no tracing configured.
-    // The log level can be controlled via `RUST_LOG` env var (default: info).
+    // Initialize tracing subscriber based on TNG_HOOK_LOG_FILE env var.
+    // When set, write to the specified file; otherwise fall back to stderr.
     // Uses `set_default` so it won't panic if the host already has a subscriber.
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_ansi(atty::is(atty::Stream::Stderr))
-                .with_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-                ),
-        )
-        .init();
+    let log_file_path = std::env::var("TNG_HOOK_LOG_FILE").ok();
+
+    if let Some(ref path) = log_file_path {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap_or_else(|e| {
+                panic!("tng-hook: failed to open log file {}: {}", path, e);
+            });
+
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::sync::Mutex::new(file))
+                    .with_ansi(false)
+                    .with_filter(
+                        tracing_subscriber::EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+                    ),
+            )
+            .init();
+    } else {
+        // Default: write to stderr (existing behavior)
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(atty::is(atty::Stream::Stderr))
+                    .with_filter(
+                        tracing_subscriber::EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+                    ),
+            )
+            .init();
+    }
 
     // Resolve real functions directly from libc
     unsafe {

--- a/tng-testsuite/tests/hook/connect_reject_null_ip.rs
+++ b/tng-testsuite/tests/hook/connect_reject_null_ip.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use tng_testsuite::{
     run_test,
-    task::{tng::TngExecTask, Task as _},
+    task::{tng::TngExecTask, NodeType, Task as _},
 };
 
 /// Test that the connect hook rejects connections to 0.0.0.0 (NULL IP).
@@ -41,6 +41,7 @@ async fn test() -> Result<()> {
             .to_string(),
         ],
         true, // stop_after_exit: test is complete once this exits
+        NodeType::Client,
     )
     .boxed(),])
     .await?;

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -103,7 +103,6 @@ tracing = {workspace = true}
 tracing-futures = {workspace = true, features = ["futures-03"]}
 tracing-opentelemetry = {workspace = true, optional = true}
 tracing-subscriber = {workspace = true}
-tracing-appender = {workspace = true}
 url = {workspace = true}
 uuid = {workspace = true, features = ["v4"], optional = true}
 which = {workspace = true, optional = true}
@@ -118,6 +117,7 @@ quinn = {workspace = true}
 rats-cert = {path = "../rats-cert", default-features = false, features = ["crypto-rustcrypto", "attester-coco", "verifier-coco", "attester-ita", "verifier-ita"]}
 socket2 = {workspace = true}
 tokio = {workspace = true, default-features = true, features = ["rt-multi-thread", "time", "process"]}
+tracing-appender = {workspace = true}
 # Enable aws-lc-rs for native targets (AVX512/VAES optimization)
 rustls = {workspace = true, default-features = false, features = ["logging", "std", "tls12", "aws-lc-rs", "brotli"]}
 tokio-rustls = {workspace = true, default-features = false, features = ["logging", "tls12", "aws-lc-rs"]}

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -103,6 +103,7 @@ tracing = {workspace = true}
 tracing-futures = {workspace = true, features = ["futures-03"]}
 tracing-opentelemetry = {workspace = true, optional = true}
 tracing-subscriber = {workspace = true}
+tracing-appender = {workspace = true}
 url = {workspace = true}
 uuid = {workspace = true, features = ["v4"], optional = true}
 which = {workspace = true, optional = true}

--- a/tng/src/bin/tng/cli.rs
+++ b/tng/src/bin/tng/cli.rs
@@ -14,6 +14,10 @@ pub struct Cli {
     #[clap(long, global = true)]
     /// Enable tokio console
     pub tokio_console: bool,
+
+    #[clap(long, global = true, value_name = "FILE")]
+    /// Path to log file (writes to stdout/stderr if not set)
+    pub log_file: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/tng/src/bin/tng/main.rs
+++ b/tng/src/bin/tng/main.rs
@@ -1,7 +1,10 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 
-use std::{fs::File, io::BufReader};
+use std::{
+    fs::{File, OpenOptions},
+    io::BufReader,
+};
 
 use anyhow::{bail, Context};
 use clap::Parser as _;
@@ -39,7 +42,7 @@ fn reject_hook_modes(config: &TngConfig) -> anyhow::Result<()> {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Initialize rustls crypto provider
@@ -52,24 +55,51 @@ async fn main() {
     let pending_tracing_layers = vec![];
     let (pending_tracing_layers, reload_handle) =
         tracing_subscriber::reload::Layer::new(pending_tracing_layers);
+
+    // Open log file if --log-file is specified.
+    // We always create a NonBlocking writer (either file-backed or stdout-backed)
+    // so that both branches produce the same concrete Layer type.
+    let (log_writer, is_file) = match &cli.log_file {
+        Some(path) => {
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .context("Failed to open log file")?;
+            let (non_blocking, guard) = tracing_appender::non_blocking(file);
+            // Leak the guard to keep the worker thread alive for the process
+            // lifetime. This is safe because the guard is never dropped until
+            // process exit, at which point the OS cleans up anyway.
+            std::mem::forget(guard);
+            (non_blocking, true)
+        }
+        None => {
+            let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stdout());
+            std::mem::forget(guard);
+            (non_blocking, false)
+        }
+    };
+
     let subscriber_init = tracing_subscriber::registry()
-        // Here we add two layer each has it's own filter (per-layer filter), and the first layer is
-        // a vector which can be updated dynamically later(e.g. to append a layer like otlp exporter).
         .with(
             pending_tracing_layers.with_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env()
                     .unwrap_or_else(|_| "info,tokio_graceful=off,rats_cert=trace,tng=trace".into()),
             ),
         )
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_ansi(atty::is(atty::Stream::Stdout))
-                .with_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                        "info,tokio_graceful=off,rats_cert=info,tng=info".into()
-                    }),
-                ),
-        );
+        .with({
+            let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,tokio_graceful=off,rats_cert=info,tng=info".into());
+
+            let base_layer = tracing_subscriber::fmt::layer().with_writer(log_writer.clone());
+            if is_file {
+                base_layer.with_ansi(false).with_filter(filter)
+            } else {
+                base_layer
+                    .with_ansi(atty::is(atty::Stream::Stdout))
+                    .with_filter(filter)
+            }
+        });
 
     #[cfg(unix)]
     if cli.tokio_console {
@@ -148,7 +178,13 @@ async fn main() {
                     }
                 };
 
-                TngExec::run(config, options.command, &reload_handle).await?;
+                TngExec::run(
+                    config,
+                    options.command,
+                    &reload_handle,
+                    cli.log_file.as_ref(),
+                )
+                .await?;
 
                 tracing::info!("Exec session ended");
             }
@@ -161,4 +197,6 @@ async fn main() {
         tracing::error!(?error);
         std::process::exit(1);
     }
+
+    Ok(())
 }

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
-use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 
 use anyhow::{bail, Context as _, Result};
 
@@ -204,7 +206,16 @@ impl TngExec {
         // 10. Exit with child's exit code
         let exit_code = exit_status
             .code()
-            .or_else(|| exit_status.signal().map(|sig| 128 + sig))
+            .or_else(|| {
+                #[cfg(unix)]
+                {
+                    exit_status.signal().map(|sig| 128 + sig)
+                }
+                #[cfg(not(unix))]
+                {
+                    None
+                }
+            })
             .unwrap_or(1);
         std::process::exit(exit_code);
     }

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -92,6 +92,7 @@ impl TngExec {
         mut config: TngConfig,
         command: Vec<String>,
         reload_handle: &crate::runtime::TracingReloadHandle,
+        log_file: Option<&PathBuf>,
     ) -> Result<()> {
         // 1. Validate all hook-mode entries
         Self::validate_config(&config)?;
@@ -181,6 +182,10 @@ impl TngExec {
         }
         // Always set ingress mapping (even if empty proxies, for consistency)
         child_cmd.env("TNG_HOOK_INGRESS_MAPPINGS", &ingress_json);
+
+        if let Some(ref log_file) = log_file {
+            child_cmd.env("TNG_HOOK_LOG_FILE", log_file);
+        }
 
         let mut child = child_cmd.spawn().context("Failed to spawn child command")?;
 


### PR DESCRIPTION
## Summary

Add a `--log-file` global CLI option to redirect all TNG logs (tng binary + tng-hook .so) to a specified file.

## Changes

- **CLI** (`tng/src/bin/tng/cli.rs`): New global `--log-file <FILE>` option
- **Main** (`tng/src/bin/tng/main.rs`): When `--log-file` is set, uses `tracing_appender::non_blocking` for async file writes instead of stdout
- **Exec** (`tng/src/exec.rs`): Passes `TNG_HOOK_LOG_FILE` env var to child process
- **Hook** (`tng-hook/cdylib/src/lib.rs`): Reads `TNG_HOOK_LOG_FILE` in `\#[ctor::ctor]` and initializes file-based tracing subscriber
- **Docs** (`docs/configuration.md` + `configuration_zh.md`): Updated with `--log-file` documentation

## Behavior

- File open mode: create + append
- Directory not found → error exit; file not found → auto-create
- .so file open failure → panic
- Log level remains controlled by `RUST_LOG` env var
- Fully backward compatible (optional, default behavior unchanged)

## Commits

1. `build: add tracing-appender dependency`
2. `feat(cli): add --log-file global option`
3. `feat(tng): wire --log-file to tracing subscriber`
4. `feat(exec): pass TNG_HOOK_LOG_FILE env to child process`
5. `feat(hook): support TNG_HOOK_LOG_FILE for file logging`
6. `docs: add --log-file option documentation`