### PR TITLE
refactor(tng): replace CIDR host filtering with IP address + interface name in egress hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,6 +1938,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2736,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4053,6 +4095,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
+dependencies = [
+ "libc",
+ "neli",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,6 +4496,35 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neli"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "derive_builder",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot 0.12.3",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7673,6 +7755,7 @@ dependencies = [
  "hyper-util 0.1.7",
  "indexmap 2.13.0",
  "itertools 0.14.0",
+ "local-ip-address",
  "nix 0.30.1",
  "notify",
  "ohttp",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -809,7 +809,8 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
 | `hook` | object | Yes | Hook egress configuration object |
 | `hook.capture_listen` | array | Yes | List of ports to intercept |
 | `hook.capture_listen[].port` | number | Yes | Port to intercept |
-| `hook.capture_listen[].host` | string | No | IPv4 address to match (default: any) |
+| `hook.capture_listen[].host` | string | No | IPv4 address to match (default: `0.0.0.0` — any IP) |
+| `hook.capture_listen[].ifname` | string | No | Network interface name (e.g. `docker0`). When set, connections must arrive on this interface. `host` and `ifname` are AND conditions. |
 | `hook.capture_listen[].port_end` | number | No | End port for range matching |
 | `hook.capture_listen[].redirect_to_port` | number | No | Real port to redirect to (auto-allocated if not set) |
 | `hook.capture_listen[].redirect_to_port_end` | number | No | End port for redirect range |
@@ -829,7 +830,7 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
                 "capture_listen": [
                     { "port": 8080 },
                     { "port": 8080, "port_end": 8090, "redirect_to_port": 48080, "redirect_to_port_end": 48090 },
-                    { "host": "192.168.1.1", "port": 30002, "redirect_to_port": 45002 }
+                    { "host": "192.168.1.1", "ifname": "docker0", "port": 30002, "redirect_to_port": 45002 }
                 ]
             },
             "attest": {

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -809,7 +809,8 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
 | `hook` | object | 是 | Hook egress 配置对象 |
 | `hook.capture_listen` | array | 是 | 要拦截的端口列表 |
 | `hook.capture_listen[].port` | number | 是 | 要拦截的端口 |
-| `hook.capture_listen[].host` | string | 否 | 要匹配的 IPv4 地址（默认：任意） |
+| `hook.capture_listen[].host` | string | 否 | 要匹配的 IPv4 地址（默认：`0.0.0.0` — 任意 IP） |
+| `hook.capture_listen[].ifname` | string | 否 | 网卡名称（如 `docker0`）。设置后，连接必须来自该网卡。`host` 和 `ifname` 是 AND 关系。 |
 | `hook.capture_listen[].port_end` | number | 否 | 范围匹配的结束端口 |
 | `hook.capture_listen[].redirect_to_port` | number | 否 | 重定向到的真实端口（未设置时自动分配） |
 | `hook.capture_listen[].redirect_to_port_end` | number | 否 | 重定向范围的结束端口 |
@@ -829,7 +830,7 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
                 "capture_listen": [
                     { "port": 8080 },
                     { "port": 8080, "port_end": 8090, "redirect_to_port": 48080, "redirect_to_port_end": 48090 },
-                    { "host": "192.168.1.1", "port": 30002, "redirect_to_port": 45002 }
+                    { "host": "192.168.1.1", "ifname": "docker0", "port": 30002, "redirect_to_port": 45002 }
                 ]
             },
             "attest": {

--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -267,8 +267,8 @@ pub extern "C" fn bind(sockfd: c_int, addr: *const sockaddr, addrlen: socklen_t)
         }
     } else if !addr.is_null() {
         let sa = unsafe { &*addr };
-        tracing::warn!(
-            "bind: non-IPv4 socket, family={:#x}, fd={}",
+        tracing::debug!(
+            "bind: non-IPv4 socket, family={:#x}, fd={}, passthrough",
             sa.sa_family,
             sockfd
         );
@@ -354,8 +354,8 @@ pub extern "C" fn connect(sockfd: c_int, addr: *const sockaddr, addrlen: socklen
     let Some(dst_addr) = (unsafe { sockaddr_to_v4(addr) }) else {
         if !addr.is_null() {
             let sa = unsafe { &*addr };
-            tracing::warn!(
-                "connect: non-IPv4 destination, family={:#x}, fd={}",
+            tracing::debug!(
+                "connect: non-IPv4 destination, family={:#x}, fd={}, passthrough",
                 sa.sa_family,
                 sockfd
             );

--- a/tng-testsuite/src/task/tng/exec.rs
+++ b/tng-testsuite/src/task/tng/exec.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use scopeguard::defer;
 use tokio::process::Command;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -89,13 +90,15 @@ impl Task for TngExecTask {
                 // On cancellation, kill the child process before returning.
                 tokio::select! {
                     status = child.wait() => {
+                        defer! {
+                            if stop_after_exit {
+                                token.cancel();
+                            }
+                        }
                         let status = status.context("Failed to wait for tng exec child")?;
                         tracing::info!(?status, "tng exec child exited");
                         if !status.success() {
                             anyhow::bail!("tng exec exited with status: {:?}", status);
-                        }
-                        if stop_after_exit {
-                            token.cancel();
                         }
                         Ok::<_, anyhow::Error>(())
                     }

--- a/tng-testsuite/tests/hook/ingress_hook_basic.rs
+++ b/tng-testsuite/tests/hook/ingress_hook_basic.rs
@@ -13,7 +13,7 @@ use tng_testsuite::{
 /// Architecture:
 /// - Server side: Echo server on port 30001 + TNG with egress mapping
 ///   (0.0.0.0:20001 → 127.0.0.1:30001).
-/// - Client side: `tng exec` with ingress hook (captures connect to 20001)
+/// - Client side: `tng exec` with ingress hook (captures connect to 192.168.1.1:20001)
 ///   running a Python TCP client.
 ///
 /// Flow:
@@ -86,7 +86,7 @@ sleep 120
 python3 -c '
 import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.connect(("127.0.0.1", 20001))
+s.connect(("192.168.1.1", 20001))
 s.sendall(b"Hello World TCP!")
 s.shutdown(socket.SHUT_WR)
 d = s.recv(4096)

--- a/tng-testsuite/tests/hook/sendto_tfo_intercept.rs
+++ b/tng-testsuite/tests/hook/sendto_tfo_intercept.rs
@@ -19,12 +19,13 @@ use tng_testsuite::{
 /// - Server side: Python echo server on port 30001 + TNG with egress mapping
 ///   (0.0.0.0:20001 → 127.0.0.1:30001).
 /// - Client side: `tng exec` with ingress hook (captures connections to port
-///   20001) running a Python script that uses sendto() with MSG_FASTOPEN.
+///   20001) running a Python script that uses sendto() with MSG_FASTOPEN
+///   targeting the server address 192.168.1.1:20001.
 ///
 /// Flow:
 /// 1. Echo server (on server node) listens on port 30001.
 /// 2. Python client (inside `tng exec`) calls sendto(data, MSG_FASTOPEN,
-///    (127.0.0.1, 20001)) without calling connect() first.
+///    (192.168.1.1, 20001)) without calling connect() first.
 /// 3. sendto hook detects MSG_FASTOPEN, calls connect() hook to trigger
 ///    proxy hijacking → connection tunneled to server's egress mapping.
 /// 4. Server egress mapping forwards locally to echo server on 127.0.0.1:30001.
@@ -103,7 +104,7 @@ s.setsockopt(socket.IPPROTO_TCP, TCP_FASTOPEN, 1)
 # Send data using sendto with MSG_FASTOPEN — this bypasses connect().
 # The sendto hook must intercept this and route through the proxy tunnel.
 data = b"Hello TFO via sendto!"
-n = s.sendto(data, MSG_FASTOPEN, ("127.0.0.1", 20001))
+n = s.sendto(data, MSG_FASTOPEN, ("192.168.1.1", 20001))
 assert n == len(data), f"Expected sendto to send {len(data)} bytes, got {n}"
 
 # Read the echo response through the tunnel.

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -21,6 +21,7 @@ bytes = {workspace = true}
 chrono = {workspace = true}
 cidr = {workspace = true}
 clap = {workspace = true}
+local-ip-address = "0.6"
 console-subscriber = {workspace = true, optional = true}
 const_format = {workspace = true}
 derivative = {workspace = true}

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -21,7 +21,6 @@ bytes = {workspace = true}
 chrono = {workspace = true}
 cidr = {workspace = true}
 clap = {workspace = true}
-local-ip-address = "0.6"
 console-subscriber = {workspace = true, optional = true}
 const_format = {workspace = true}
 derivative = {workspace = true}
@@ -41,6 +40,7 @@ hyper = {workspace = true}
 hyper-util = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
+local-ip-address = "0.6"
 nix = {workspace = true, features = ["process", "signal", "socket", "net"]}
 ohttp = {git = "https://github.com/inclavare-containers/ohttp.git", rev = "7d45814b747eb3944b234956edc1e56e2bf9cb2f"}
 opentelemetry = {workspace = true, optional = true}

--- a/tng/src/config/egress_hook.rs
+++ b/tng/src/config/egress_hook.rs
@@ -1,14 +1,12 @@
+use std::net::Ipv4Addr;
+
 use anyhow::bail;
-use cidr::Ipv4Cidr;
 use serde::{Deserialize, Serialize};
 use serde_with::{formats::PreferMany, serde_as, OneOrMany};
-use std::net::Ipv4Addr;
-use std::ops::RangeInclusive;
 
-/// Wildcard CIDR (0.0.0.0/0 — match all).
-#[allow(clippy::expect_used)]
-fn wildcard_cidr() -> Ipv4Cidr {
-    Ipv4Cidr::new(Ipv4Addr::UNSPECIFIED, 0).expect("0.0.0.0/0 is always valid")
+/// Wildcard IP address (0.0.0.0 — match all).
+fn wildcard_ip() -> Ipv4Addr {
+    Ipv4Addr::UNSPECIFIED
 }
 
 /// Configuration for the hook-based egress mode.
@@ -43,7 +41,11 @@ pub struct EgressHookArgs {
 pub struct EgressHookInterceptEntry {
     /// IPv4 address to match (e.g., "0.0.0.0", "192.168.1.1").
     /// When omitted, matches any bind address.
-    pub host: Option<Ipv4Cidr>,
+    pub host: Option<Ipv4Addr>,
+
+    /// Optional network interface name to match (e.g., "eth0", "docker0").
+    /// When specified, the bind address must belong to this interface.
+    pub ifname: Option<String>,
 
     /// Port to intercept. Required.
     pub port: Option<u16>,
@@ -69,42 +71,18 @@ pub struct EgressHookInterceptEntry {
 /// Internal mapping entry used by TNG exec/runtime.
 ///
 /// Unlike EgressHookMappingEntry (passed to the .so), this includes the host
-/// CIDR for runtime accept-time filtering.
+/// IP for runtime accept-time filtering.
 #[derive(Debug, Clone)]
 pub struct TngEgressHookMappingEntry {
-    /// Host CIDR to match at accept time (e.g. 172.17.80.0/20)
-    pub host_cidr: Ipv4Cidr,
+    /// Host IP to match at accept time (e.g. 172.17.80.1).
+    /// Ipv4Addr::UNSPECIFIED (0.0.0.0) means match any host.
+    pub host: Ipv4Addr,
+    /// Optional network interface name to match at accept time.
+    pub ifname: Option<String>,
     /// The port the app thinks it's binding to
     pub origin_port: u16,
     /// The actual port the app binds to (redirected by hook)
     pub real_port: u16,
-}
-
-impl TngEgressHookMappingEntry {
-    /// Build a host filter rule from this mapping entry.
-    ///
-    /// Returns `None` when the host CIDR is 0.0.0.0/0 (match all),
-    /// meaning no host-level filtering is needed.
-    pub fn host_filter_rule(&self) -> Option<EgressHookHostFilterRule> {
-        let cidr = &self.host_cidr;
-        if cidr.first_address() == Ipv4Addr::UNSPECIFIED && cidr.network_length() == 0 {
-            return None;
-        }
-        Some(EgressHookHostFilterRule {
-            host_cidr: self.host_cidr,
-            port_range: self.origin_port..=self.origin_port,
-        })
-    }
-}
-
-/// Host filter rule used at accept time.
-///
-/// A connection's local_addr.ip() is checked against this CIDR,
-/// and the local port is checked against the port range.
-#[derive(Debug, Clone)]
-pub struct EgressHookHostFilterRule {
-    pub host_cidr: Ipv4Cidr,
-    pub port_range: RangeInclusive<u16>,
 }
 
 impl EgressHookInterceptEntry {
@@ -125,15 +103,17 @@ impl EgressHookInterceptEntry {
             bail!("'port_end' ({}) must be >= 'port' ({})", port_end, port);
         }
 
-        // Default host CIDR: 0.0.0.0/0 (match all) when not specified
-        let host_cidr = self.host.unwrap_or(wildcard_cidr());
+        // Default host IP: 0.0.0.0 (match all) when not specified
+        let host = self.host.unwrap_or(wildcard_ip());
+        let ifname = self.ifname.clone();
 
         let redirect_to_port = self.redirect_to_port;
         let redirect_to_port_end = self.redirect_to_port_end;
 
         // Helper to create a mapping entry
         let make_entry = |origin_port: u16, real_port: u16| TngEgressHookMappingEntry {
-            host_cidr,
+            host,
+            ifname: ifname.clone(),
             origin_port,
             real_port,
         };
@@ -253,6 +233,7 @@ mod tests {
             "redirect_to_port": 45002
         }))?;
         assert!(entry.host.is_some());
+        assert_eq!(entry.host.unwrap(), Ipv4Addr::new(192, 168, 1, 1));
         Ok(())
     }
 
@@ -266,8 +247,8 @@ mod tests {
         assert_eq!(entries[0].origin_port, 8080);
         assert_eq!(entries[0].real_port, 40000);
         assert_eq!(next_port, 40001);
-        // host_cidr should be 0.0.0.0/0 when not specified
-        assert!(entries[0].host_cidr.contains(&Ipv4Addr::UNSPECIFIED));
+        // host should be 0.0.0.0 (wildcard) when not specified
+        assert_eq!(entries[0].host, Ipv4Addr::UNSPECIFIED);
         Ok(())
     }
 
@@ -386,35 +367,31 @@ mod tests {
     }
 
     #[test]
-    fn test_host_filter_rule_wildcard_returns_none() {
-        // When host CIDR is 0.0.0.0/0, host_filter_rule should return None
+    fn test_ifname_propagation() {
         let entry: EgressHookInterceptEntry = serde_json::from_value(json!({
+            "host": "10.0.0.1",
+            "ifname": "eth0",
             "port": 8080,
             "redirect_to_port": 48080
         }))
         .unwrap();
         let (entries, _) = entry.expand_mappings(40000).unwrap();
-        assert!(entries[0].host_filter_rule().is_none());
+        assert_eq!(entries[0].host, Ipv4Addr::new(10, 0, 0, 1));
+        assert_eq!(entries[0].ifname.as_deref(), Some("eth0"));
     }
 
     #[test]
-    fn test_host_filter_rule_specific_host_returns_some() {
-        // When host CIDR is a specific network, host_filter_rule should return Some
+    fn test_wildcard_ip_default() {
+        assert_eq!(wildcard_ip(), Ipv4Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn test_ifname_none_by_default() {
         let entry: EgressHookInterceptEntry = serde_json::from_value(json!({
-            "host": "172.17.80.0/20",
-            "port": 8080,
-            "redirect_to_port": 48080
+            "port": 8080
         }))
         .unwrap();
         let (entries, _) = entry.expand_mappings(40000).unwrap();
-        let rule = entries[0].host_filter_rule().expect("expected Some");
-        assert_eq!(rule.port_range, (8080..=8080));
-        // Verify the CIDR matches
-        assert!(rule
-            .host_cidr
-            .contains(&"172.17.80.0".parse::<Ipv4Addr>().unwrap()));
-        assert!(!rule
-            .host_cidr
-            .contains(&"192.168.1.1".parse::<Ipv4Addr>().unwrap()));
+        assert!(entries[0].ifname.is_none());
     }
 }

--- a/tng/src/config/mod.rs
+++ b/tng/src/config/mod.rs
@@ -19,7 +19,7 @@ pub use tng_hook_types::{
 };
 
 // Internal TNG types (not serialized to .so)
-pub use egress_hook::{EgressHookHostFilterRule, TngEgressHookMappingEntry};
+pub use egress_hook::TngEgressHookMappingEntry;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -315,7 +315,8 @@ impl TngExec {
                         .pick()
                         .context("Failed to pick unused port for hook mapping")?;
                     entries.push(TngEgressHookMappingEntry {
-                        host_cidr: e.host_cidr,
+                        host: e.host,
+                        ifname: e.ifname,
                         origin_port: e.origin_port,
                         real_port,
                     });
@@ -623,12 +624,14 @@ mod tests {
     fn test_check_conflicts_no_conflict() {
         let entries = vec![
             TngEgressHookMappingEntry {
-                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+                host: std::net::Ipv4Addr::UNSPECIFIED,
+                ifname: None,
                 origin_port: 8080,
                 real_port: 48080,
             },
             TngEgressHookMappingEntry {
-                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+                host: std::net::Ipv4Addr::UNSPECIFIED,
+                ifname: None,
                 origin_port: 8081,
                 real_port: 48081,
             },
@@ -640,12 +643,14 @@ mod tests {
     fn test_check_conflicts_duplicate_origin() {
         let entries = vec![
             TngEgressHookMappingEntry {
-                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+                host: std::net::Ipv4Addr::UNSPECIFIED,
+                ifname: None,
                 origin_port: 8080,
                 real_port: 48080,
             },
             TngEgressHookMappingEntry {
-                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+                host: std::net::Ipv4Addr::UNSPECIFIED,
+                ifname: None,
                 origin_port: 8080,
                 real_port: 48080, // same origin, same real → no conflict
             },
@@ -657,12 +662,14 @@ mod tests {
     fn test_check_conflicts_real_port_collision() {
         let entries = vec![
             TngEgressHookMappingEntry {
-                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+                host: std::net::Ipv4Addr::UNSPECIFIED,
+                ifname: None,
                 origin_port: 8080,
                 real_port: 48080,
             },
             TngEgressHookMappingEntry {
-                host_cidr: cidr::Ipv4Cidr::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+                host: std::net::Ipv4Addr::UNSPECIFIED,
+                ifname: None,
                 origin_port: 8081,
                 real_port: 48080, // different origin, same real → conflict
             },

--- a/tng/src/tunnel/egress/flow.rs
+++ b/tng/src/tunnel/egress/flow.rs
@@ -157,8 +157,8 @@ impl EgressFlow {
 
             if !encrypted {
                 // Transport-level direct forward: determined at accept time by the
-                // egress mode's host CIDR filter (HookEgress::encrypted checks whether
-                // the connection's local_addr.ip() matches a configured CIDR).
+                // egress mode's host/ifname filter (HookEgress::encrypted checks whether
+                // the connection's local_addr.ip() matches a configured host and ifname).
                 // When the IP doesn't match any rule, the entire connection bypasses
                 // the trusted stream manager — no OHTTP/RATS-TLS processing happens.
                 // This is a per-connection decision, made once when the TCP accept occurs.
@@ -211,7 +211,7 @@ impl EgressFlow {
                         // decryption entirely and is forwarded as plain HTTP to upstream.
                         //
                         // This is a per-request decision, distinct from the transport-level
-                        // decision above. A connection can pass the transport-level CIDR
+                        // decision above. A connection can pass the transport-level IP/ifname
                         // check (encrypted=true, entering the trusted stream path) yet
                         // still yield DirectlyForward NextStreams when individual request
                         // paths match the direct_forward rules.

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -67,6 +67,29 @@ impl HookEgress {
             });
         }
 
+        // Diagnose missing ifname interfaces at startup so users know why
+        // all connections are being blocked.
+        for entry in &entries {
+            if let Some(ips) = &entry.resolved_ifname_ips {
+                if ips.is_empty() {
+                    let ifname = hook_args
+                        .resolved_entries
+                        .iter()
+                        .find(|r| {
+                            r.origin_port == entry.origin_port && r.real_port == entry.real_port
+                        })
+                        .and_then(|r| r.ifname.as_deref())
+                        .unwrap_or("?");
+                    tracing::warn!(
+                        %ifname,
+                        origin_port = entry.origin_port,
+                        real_port = entry.real_port,
+                        "ifname configured but interface not found or has no IPv4 addresses — connections will bypass tunnel"
+                    );
+                }
+            }
+        }
+
         Self { id, entries }
     }
 
@@ -345,7 +368,7 @@ mod tests {
             5600
         )));
 
-        // IP matches ifname but not host -> false
+        // IP matches neither host nor ifname -> false
         assert!(!egress.encrypted(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(172, 17, 80, 2)),
             5600

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -57,10 +57,7 @@ impl HookEgress {
         let mut entries: Vec<ResolvedEgressEntry> = Vec::new();
 
         for entry in &hook_args.resolved_entries {
-            let resolved_ifname_ips = match &entry.ifname {
-                None => None,
-                Some(name) => Some(resolve_ifname_ips(name)),
-            };
+            let resolved_ifname_ips = entry.ifname.as_ref().map(|name| resolve_ifname_ips(name));
 
             entries.push(ResolvedEgressEntry {
                 origin_port: entry.origin_port,

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -96,14 +96,10 @@ impl HookEgress {
     /// Check whether a connection arriving at local_addr should go through
     /// the encryption/decryption path.
     ///
-    /// Returns true if:
-    /// - local_addr.ip() matches the configured host (0.0.0.0 = wildcard), AND
-    /// - if ifname was configured (Some), local_addr.ip() is in the resolved ifname IP set
-    /// - if ifname was not configured (None), skip the ifname check
-    /// - IPv6 connections always return false
-    /// - No entries -> default to encrypted (backward compatible)
+    /// Returns true if local_addr matches any entry's host AND ifname filter.
+    /// When no entries are configured, defaults to encrypted (backward compatible).
+    /// IPv6 connections always return false.
     pub fn encrypted(&self, local_addr: SocketAddr) -> bool {
-        // No entries configured -> default to encrypted (backward compatible)
         if self.entries.is_empty() {
             return true;
         }
@@ -114,25 +110,17 @@ impl HookEgress {
         };
 
         for entry in &self.entries {
-            // Host check: 0.0.0.0 matches all, otherwise exact match
-            if !entry.host.is_unspecified() && entry.host != ip {
-                continue;
-            }
+            let host_match = entry.host.is_unspecified() || entry.host == ip;
+            let ifname_match = match &entry.resolved_ifname_ips {
+                None => true,                   // no ifname configured
+                Some(set) => set.contains(&ip), // empty set → false (no IPs)
+            };
 
-            // Ifname check: None = no filter (pass-through),
-            // Some(empty) = nothing matches, Some(set) = must contain IP
-            match &entry.resolved_ifname_ips {
-                None => {} // no ifname configured -> pass-through
-                Some(set) if set.is_empty() => continue,
-                Some(set) if !set.contains(&ip) => continue,
-                Some(_) => {}
+            if host_match && ifname_match {
+                return true;
             }
-
-            // Found a matching entry
-            return true;
         }
 
-        // Entries exist but none matched
         false
     }
 }

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -1,4 +1,5 @@
-use std::net::{IpAddr, SocketAddr};
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -8,9 +9,6 @@ use futures::stream::select_all;
 use indexmap::IndexMap;
 use tokio::net::TcpListener;
 
-use crate::config::egress_hook::EgressHookArgs;
-use crate::config::egress_hook::EgressHookHostFilterRule;
-use crate::config::EgressHookMappingEntry;
 use crate::tunnel::access_log::{AccessAccepted, EgressAccessMode};
 use crate::tunnel::egress::flow::AcceptedStream;
 use crate::tunnel::endpoint::TngEndpoint;
@@ -19,61 +17,74 @@ use crate::tunnel::utils::socket::SetListenerSockOpts;
 
 use super::flow::{EgressTrait, Incomming};
 
+/// Pre-resolved entry: port mapping + resolved ifname IPs.
+///
+/// Built from config entries during HookEgress::new(),
+/// with ifname resolved to actual IPs via list_afinet_netifas().
+pub struct ResolvedEgressEntry {
+    /// The port the app thinks it's binding to
+    pub origin_port: u16,
+    /// The actual port the app binds to (redirected by hook)
+    pub real_port: u16,
+    /// Host IP to match (0.0.0.0 = wildcard, match all)
+    pub host: Ipv4Addr,
+    /// Resolved IPs of the configured ifname.
+    /// None = no ifname was configured (pass-through).
+    /// Some(empty) = ifname configured but interface has no IPs (nothing matches).
+    /// Some(set) = ifname configured with IPs (check membership).
+    pub resolved_ifname_ips: Option<HashSet<Ipv4Addr>>,
+}
+
 /// Hook-based egress that listens on origin ports and forwards
 /// to real ports on localhost.
 ///
 /// Each HookEgress instance handles a list of origin->real port mappings
 /// (expanded from capture_listen entries by `tng exec`).
 ///
-/// Host CIDR filtering happens at accept time: connections whose local_addr
-/// matches a configured CIDR go through encryption; others are forwarded directly.
+/// Host/ifname filtering happens at accept time: connections are checked
+/// against the resolved host IP and ifname IP set.
 pub struct HookEgress {
     id: usize,
-    /// Port-only mapping entries (origin_port -> real_port) for metric attributes
-    /// and getsockname lookup reference.
-    entries: Vec<EgressHookMappingEntry>,
-    /// Host filter rules for accept-time CIDR matching.
-    /// A connection is encrypted only if its local_addr.ip() matches
-    /// one of these CIDRs AND the port is in range.
-    /// When empty, all traffic is encrypted (default behavior).
-    host_filters: Vec<EgressHookHostFilterRule>,
+    entries: Vec<ResolvedEgressEntry>,
 }
 
 impl HookEgress {
     /// Create a new HookEgress from hook args.
     ///
-    /// Expands `resolved_entries` into port-only mapping entries for
-    /// metric attributes and getsockname lookup, and builds host filter
-    /// rules for accept-time CIDR matching.
-    pub fn new(id: usize, hook_args: &EgressHookArgs) -> Self {
-        let mut entries: Vec<EgressHookMappingEntry> = Vec::new();
-        let mut host_filters: Vec<EgressHookHostFilterRule> = Vec::new();
+    /// Expands `resolved_entries` into resolved entries, resolving
+    /// ifname -> IPs via list_afinet_netifas() once at startup.
+    pub fn new(id: usize, hook_args: &crate::config::egress_hook::EgressHookArgs) -> Self {
+        let mut entries: Vec<ResolvedEgressEntry> = Vec::new();
 
         for entry in &hook_args.resolved_entries {
-            entries.push(EgressHookMappingEntry {
+            let resolved_ifname_ips = match &entry.ifname {
+                None => None,
+                Some(name) => Some(resolve_ifname_ips(name)),
+            };
+
+            entries.push(ResolvedEgressEntry {
                 origin_port: entry.origin_port,
                 real_port: entry.real_port,
+                host: entry.host,
+                resolved_ifname_ips,
             });
-            if let Some(rule) = entry.host_filter_rule() {
-                host_filters.push(rule);
-            }
         }
 
-        Self {
-            id,
-            entries,
-            host_filters,
-        }
+        Self { id, entries }
     }
 
     /// Check whether a connection arriving at local_addr should go through
     /// the encryption/decryption path.
     ///
-    /// Returns true if local_addr.ip() matches any configured host CIDR
-    /// and the port is within the configured range. When no filters are
-    /// configured, all traffic is encrypted (backward compatible default).
+    /// Returns true if:
+    /// - local_addr.ip() matches the configured host (0.0.0.0 = wildcard), AND
+    /// - if ifname was configured (Some), local_addr.ip() is in the resolved ifname IP set
+    /// - if ifname was not configured (None), skip the ifname check
+    /// - IPv6 connections always return false
+    /// - No entries -> default to encrypted (backward compatible)
     pub fn encrypted(&self, local_addr: SocketAddr) -> bool {
-        if self.host_filters.is_empty() {
+        // No entries configured -> default to encrypted (backward compatible)
+        if self.entries.is_empty() {
             return true;
         }
 
@@ -82,11 +93,54 @@ impl HookEgress {
             IpAddr::V6(_) => return false,
         };
 
-        let port = local_addr.port();
+        for entry in &self.entries {
+            // Host check: 0.0.0.0 matches all, otherwise exact match
+            if !entry.host.is_unspecified() && entry.host != ip {
+                continue;
+            }
 
-        self.host_filters
-            .iter()
-            .any(|rule| rule.host_cidr.contains(&ip) && rule.port_range.contains(&port))
+            // Ifname check: None = no filter (pass-through),
+            // Some(empty) = nothing matches, Some(set) = must contain IP
+            match &entry.resolved_ifname_ips {
+                None => {} // no ifname configured -> pass-through
+                Some(set) if set.is_empty() => continue,
+                Some(set) if !set.contains(&ip) => continue,
+                Some(_) => {}
+            }
+
+            // Found a matching entry
+            return true;
+        }
+
+        // Entries exist but none matched
+        false
+    }
+}
+
+/// Resolve a network interface name to its IPv4 addresses.
+///
+/// Called once at HookEgress startup. Uses netlink on Linux
+/// (via local-ip-address crate). Returns empty set if the
+/// interface doesn't exist or has no IPv4 addresses.
+fn resolve_ifname_ips(ifname: &str) -> HashSet<Ipv4Addr> {
+    match local_ip_address::list_afinet_netifas() {
+        Ok(interfaces) => interfaces
+            .into_iter()
+            .filter_map(|(name, ip)| {
+                if name == ifname {
+                    match ip {
+                        IpAddr::V4(addr) => Some(addr),
+                        IpAddr::V6(_) => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect(),
+        Err(error) => {
+            tracing::warn!(?error, %ifname, "Failed to resolve interface IPs");
+            HashSet::new()
+        }
     }
 }
 
@@ -191,99 +245,142 @@ impl EgressTrait for HookEgress {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::egress_hook::TngEgressHookMappingEntry;
-    use cidr::Ipv4Cidr;
-    use std::net::Ipv4Addr;
 
-    fn make_args(entries: Vec<TngEgressHookMappingEntry>) -> EgressHookArgs {
-        EgressHookArgs {
-            capture_listen: vec![],
-            resolved_entries: entries,
+    fn make_egress(entries: Vec<ResolvedEgressEntry>) -> HookEgress {
+        HookEgress { id: 0, entries }
+    }
+
+    fn make_entry(
+        host: Ipv4Addr,
+        ifname_ips: Option<HashSet<Ipv4Addr>>,
+        origin_port: u16,
+        real_port: u16,
+    ) -> ResolvedEgressEntry {
+        ResolvedEgressEntry {
+            origin_port,
+            real_port,
+            host,
+            resolved_ifname_ips: ifname_ips,
         }
     }
 
     #[test]
-    fn test_should_encrypt_empty_filters_returns_true() {
-        let egress = HookEgress::new(0, &make_args(vec![]));
+    fn test_encrypted_empty_entries_returns_true() {
+        let egress = make_egress(vec![]);
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 5600);
         assert!(egress.encrypted(addr));
     }
 
     #[test]
-    fn test_should_encrypt_matches_cidr_and_port() {
-        let entry = TngEgressHookMappingEntry {
-            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(172, 17, 80, 0), 20).unwrap(),
-            origin_port: 5600,
-            real_port: 9600,
-        };
-        let egress = HookEgress::new(0, &make_args(vec![entry]));
+    fn test_encrypted_wildcard_host_matches_all() {
+        // host = 0.0.0.0, no ifname -> always true
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+        let egress = make_egress(vec![entry]);
 
-        // In range
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 17, 80, 5)), 5600);
-        assert!(egress.encrypted(addr));
-
-        // Out of CIDR
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 5600);
-        assert!(!egress.encrypted(addr));
-
-        // Out of port range
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(172, 17, 80, 5)), 5601);
-        assert!(!egress.encrypted(addr));
+        // Any IP should match
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            5600
+        )));
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            5600
+        )));
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            5600
+        )));
     }
 
     #[test]
-    fn test_should_encrypt_ipv6_returns_false() {
-        let entry = TngEgressHookMappingEntry {
-            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(172, 17, 80, 0), 20).unwrap(),
-            origin_port: 5600,
-            real_port: 9600,
-        };
-        let egress = HookEgress::new(0, &make_args(vec![entry]));
+    fn test_encrypted_specific_host_matches() {
+        let entry = make_entry(Ipv4Addr::new(172, 17, 80, 1), None, 5600, 9600);
+        let egress = make_egress(vec![entry]);
+
+        // Exact match
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
+            5600
+        )));
+
+        // Different IP -> fail
+        assert!(!egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            5600
+        )));
+    }
+
+    #[test]
+    fn test_encrypted_ifname_filter() {
+        // host = 0.0.0.0, ifname resolved to specific IPs
+        let mut ips = HashSet::new();
+        ips.insert(Ipv4Addr::new(172, 17, 80, 1));
+        ips.insert(Ipv4Addr::new(172, 17, 80, 2));
+
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, Some(ips), 5600, 9600);
+        let egress = make_egress(vec![entry]);
+
+        // IP in the resolved set -> match
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
+            5600
+        )));
+
+        // IP not in the set -> no match
+        assert!(!egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            5600
+        )));
+    }
+
+    #[test]
+    fn test_encrypted_host_and_ifname_and() {
+        // host = 172.17.80.1 AND ifname_ips contains 172.17.80.1
+        let mut ips = HashSet::new();
+        ips.insert(Ipv4Addr::new(172, 17, 80, 1));
+
+        let entry = make_entry(Ipv4Addr::new(172, 17, 80, 1), Some(ips.clone()), 5600, 9600);
+        let egress = make_egress(vec![entry]);
+
+        // Both match -> true
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
+            5600
+        )));
+
+        // IP matches ifname but not host -> false
+        assert!(!egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 2)),
+            5600
+        )));
+
+        // IP matches ifname but not host (different entry) -> false
+        let entry2 = make_entry(Ipv4Addr::new(10, 0, 0, 1), Some(ips), 5601, 9601);
+        let egress2 = make_egress(vec![entry2]);
+        assert!(!egress2.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
+            5601
+        )));
+    }
+
+    #[test]
+    fn test_encrypted_ipv6_returns_false() {
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+        let egress = make_egress(vec![entry]);
 
         let addr = SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST), 5600);
         assert!(!egress.encrypted(addr));
     }
 
     #[test]
-    fn test_should_encrypt_port_range() {
-        // Each TngEgressHookMappingEntry creates a single-port host filter rule.
-        // Include entries only for 8000, 8005, 8010 — 8011 should return false.
-        let entry = TngEgressHookMappingEntry {
-            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
-            origin_port: 8000,
-            real_port: 9000,
-        };
-        let entry2 = TngEgressHookMappingEntry {
-            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
-            origin_port: 8005,
-            real_port: 9005,
-        };
-        let entry3 = TngEgressHookMappingEntry {
-            host_cidr: Ipv4Cidr::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap(),
-            origin_port: 8010,
-            real_port: 9010,
-        };
-        let egress = HookEgress::new(0, &make_args(vec![entry, entry2, entry3]));
-
-        // Port at start of range
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            8000
-        )));
-        // Port in middle
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            8005
-        )));
-        // Port at end of range
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            8010
-        )));
-        // Port just outside range
+    fn test_encrypted_ifname_no_ips_blocks_all() {
+        // ifname configured but interface has no IPs -> empty Some -> nothing matches
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, Some(HashSet::new()), 5600, 9600);
+        let egress = make_egress(vec![entry]);
+        // No IPs to match -> nothing is encrypted
         assert!(!egress.encrypted(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            8011
+            5600
         )));
     }
 }


### PR DESCRIPTION
## Summary

Replace CIDR-based host filtering in `tng exec` hook egress mode with **exact IPv4 address match + optional network interface name (ifname) match**. Both conditions are ANDed together.

## Problem

The previous design used CIDR matching (`Ipv4Cidr`) at accept time to determine whether a connection should be encrypted. This overcomplicated the design:
- CIDR containment is heavier than needed — users only care about specific IPs
- `EgressHookHostFilterRule`, `host_filter_rule()`, and related code added complexity
- No support for interface-level filtering (e.g., "only encrypt traffic from docker0")

## Solution

### Filtering Logic
```
encrypted = host_match AND ifname_match

host_match:
  host == 0.0.0.0  → true  (wildcard, matches any IP)
  host == other    → local_addr.ip() == host  (exact equality)

ifname_match:
  ifname not configured   → true  (no interface restriction)
  ifname configured:
    interface has no IPs  → false (nothing matches)
    otherwise             → local_addr.ip() in resolved interface IPs
```

### Ifname Resolution
Resolved at **startup** via `list_afinet_netifas()` from the `local-ip-address` crate (netlink-based). Results stored as `Option<HashSet<Ipv4Addr>>`:
- `None` = no ifname configured → pass-through
- `Some(empty)` = ifname configured but interface has no IPs → nothing matches
- `Some(set)` = check membership at accept time

### What Does NOT Change
- TNG listener binding: still `0.0.0.0:origin_port` (应绑尽绑)
- Hook bind interception: still port-only (no IP check at bind time)
- `EgressHookMappingEntry` (passed to .so): still `(origin_port, real_port)` only
- `cidr` crate: retained (used by ingress and egress mapping modes)

## Changes

| File | Change |
|------|--------|
| `tng/Cargo.toml` | Add `local-ip-address = "0.6"` dependency |
| `tng/src/config/egress_hook.rs` | `host: Ipv4Cidr` → `Ipv4Addr`, add `ifname: Option<String>`, delete `EgressHookHostFilterRule` |
| `tng/src/config/mod.rs` | Remove `EgressHookHostFilterRule` export |
| `tng/src/exec.rs` | Update `TngEgressHookMappingEntry` field constructions |
| `tng/src/tunnel/egress/hook.rs` | Rewrite `HookEgress` with `ResolvedEgressEntry`, startup ifname resolution |
| `tng/src/tunnel/egress/flow.rs` | Update CIDR → IP/ifname comments |
| `docs/configuration.md` | Update `host` field docs, add `ifname` field |
| `docs/configuration_zh.md` | Update `host` field docs, add `ifname` field |

## Breaking Change

`host` field changes from CIDR notation (`"172.17.80.0/20"`) to exact IPv4 address (`"172.17.80.1"`). Existing configs using CIDR will fail to parse.