### PR TITLE
fix(hook): require local peer to skip encryption with capture_local_traffic=false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7843,6 +7843,7 @@ name = "tng-hook-types"
 version = "2.6.0"
 dependencies = [
  "cidr",
+ "local-ip-address",
  "serde",
  "serde_json",
 ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -485,6 +485,7 @@ Intercepts outgoing TCP connections from the child process via LD_PRELOAD and ro
 | `capture_dst[].port_end` | integer | No | End of port range (inclusive). Without this, single port match. |
 | `proxy_port` | integer | No | Internal HTTP proxy port. Auto-allocated if omitted. |
 | `proxy_listen` | string | No | Bind address for internal proxy. Default: `127.0.0.1`. |
+| `capture_local_traffic` | boolean | No (`false`) | Safety filter: when `false` (default), traffic to/from local interface addresses (loopback `127.0.0.0/8` and local interface IPs) is **never captured**, even if a `capture_dst` or `capture_listen` rule matches it. Set to `true` to allow local-to-local traffic to be captured by matching rules. |
 
 **Example:**
 
@@ -895,6 +896,7 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `hook` | object | Yes | Hook egress configuration object |
+| `hook.capture_local_traffic` | boolean | No (`false`) | Safety filter: when `false` (default), accepted connections from local interface addresses (loopback `127.0.0.0/8` and local interface IPs) are **never encrypted**, even if a `capture_listen` rule matches the port. Set to `true` to allow local-to-local traffic to be encrypted by matching rules. |
 | `hook.capture_listen` | array | Yes | List of ports to intercept |
 | `hook.capture_listen[].port` | number | Yes | Port to intercept |
 | `hook.capture_listen[].host` | string | No | IPv4 address to match (default: `0.0.0.0` — any IP) |

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -485,6 +485,7 @@ flowchart TD
 | `capture_dst[].port_end` | 整数 | 否 | 端口范围结束（包含）。省略时为单端口匹配。 |
 | `proxy_port` | 整数 | 否 | 内部 HTTP 代理端口。省略时自动分配。 |
 | `proxy_listen` | 字符串 | 否 | 内部代理的绑定地址。默认：`127.0.0.1`。 |
+| `capture_local_traffic` | 布尔值 | 否（`false`） | 安全过滤：默认为 `false` 时，**永远不会**捕获目标为本地接口地址（回环 `127.0.0.0/8` 和本机接口 IP）的流量，即使 `capture_dst` 规则显式匹配该 IP。设置为 `true` 时，匹配规则的本地到本地流量才会被捕获。 |
 
 **示例：**
 
@@ -895,6 +896,7 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
 | 字段 | 类型 | 必填 | 说明 |
 |-------|------|------|------|
 | `hook` | object | 是 | Hook egress 配置对象 |
+| `hook.capture_local_traffic` | 布尔值 | 否（`false`） | 安全过滤：默认为 `false` 时，**永远不会**加密来自本地接口地址（回环 `127.0.0.0/8` 和本机接口 IP）的已接受连接，即使 `capture_listen` 规则匹配了该端口。设置为 `true` 时，匹配规则的本地到本地流量才会被加密。 |
 | `hook.capture_listen` | array | 是 | 要拦截的端口列表 |
 | `hook.capture_listen[].port` | number | 是 | 要拦截的端口 |
 | `hook.capture_listen[].host` | string | 否 | 要匹配的 IPv4 地址（默认：`0.0.0.0` — 任意 IP） |

--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -175,7 +175,8 @@ fn init() {
             tracing::debug!("init: TNG_HOOK_INGRESS_MAPPINGS={}", truncated);
             match serde_json::from_str::<IngressHookMappingTable>(&json) {
                 Ok(table) => {
-                    let entries: usize = table.proxies.iter().map(|p| p.capture_rules.len()).sum();
+                    let entries: usize =
+                        table.ingresses.iter().map(|p| p.capture_rules.len()).sum();
                     let lookup = IngressHookLookup::from_table(&table);
                     let _ = INGRESS_LOOKUP.set(lookup);
                     tracing::debug!("init: ingress mapping loaded with {} entries", entries);

--- a/tng-hook/types/Cargo.toml
+++ b/tng-hook/types/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 
 [dependencies]
 cidr = {workspace = true}
+local-ip-address = "0.6"
 serde = {workspace = true}
 
 [dev-dependencies]

--- a/tng-hook/types/src/ingress.rs
+++ b/tng-hook/types/src/ingress.rs
@@ -6,23 +6,29 @@ use serde::{Deserialize, Serialize};
 ///
 /// Serialized as JSON and passed via `TNG_HOOK_INGRESS_MAPPINGS` environment variable.
 /// Groups capture rules by their shared proxy port — one ingress hook rule
-/// produces one `IngressHookProxy` entry.
+/// produces one `IngressInstance` entry.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct IngressHookMappingTable {
     /// One entry per unique HTTP proxy port. Each proxy groups its
     /// capture rules that should be routed through it.
-    pub proxies: Vec<IngressHookProxy>,
+    pub ingresses: Vec<IngressInstance>,
 }
 
-/// A single HTTP proxy endpoint with its associated capture rules.
+/// A single ingress instance: which proxy port to use, which
+/// destination rules trigger capture, and whether local-IP traffic
+/// should also be captured.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IngressHookProxy {
+pub struct IngressInstance {
     /// The internal HTTP proxy port on the TNG main process that
     /// handles CONNECT requests for the associated capture rules.
     pub proxy_port: u16,
 
     /// Capture rules that map to this proxy port.
     pub capture_rules: Vec<IngressHookCaptureRule>,
+
+    /// Mirrors the config-level capture_local_traffic for this instance.
+    /// When false, connections to local interface IPs are excluded.
+    pub capture_local_traffic: bool,
 }
 
 /// A single capture rule: match destination IP+port and route to the proxy.
@@ -44,22 +50,22 @@ pub struct IngressHookCaptureRule {
 ///
 /// Built once at library init time, read-only thereafter.
 pub struct IngressHookLookup {
-    proxies: Vec<IngressHookProxy>,
+    ingresses: Vec<IngressInstance>,
 }
 
 impl IngressHookLookup {
     /// Build the lookup from a deserialized `IngressHookMappingTable`.
     pub fn from_table(table: &IngressHookMappingTable) -> Self {
         Self {
-            proxies: table.proxies.clone(),
+            ingresses: table.ingresses.clone(),
         }
     }
 
     /// Find the proxy port for a given destination (IP, port).
     /// Returns the first matching proxy_port, or None.
-    /// Iterates proxies in order; within each proxy, checks capture_rules.
+    /// Iterates ingresses in order; within each ingress, checks capture_rules.
     pub fn find_proxy_port(&self, dst: SocketAddrV4) -> Option<u16> {
-        for proxy in &self.proxies {
+        for proxy in &self.ingresses {
             for rule in &proxy.capture_rules {
                 if rule.matches(dst) {
                     return Some(proxy.proxy_port);
@@ -140,22 +146,24 @@ mod tests {
     #[test]
     fn test_ingress_lookup_first_match_wins() {
         let table = IngressHookMappingTable {
-            proxies: vec![
-                IngressHookProxy {
+            ingresses: vec![
+                IngressInstance {
                     proxy_port: 49001,
                     capture_rules: vec![IngressHookCaptureRule {
                         host_cidr: "10.0.0.0/24".to_string(),
                         port: 80,
                         port_end: None,
                     }],
+                    capture_local_traffic: false,
                 },
-                IngressHookProxy {
+                IngressInstance {
                     proxy_port: 49002,
                     capture_rules: vec![IngressHookCaptureRule {
                         host_cidr: "*".to_string(),
                         port: 80,
                         port_end: None,
                     }],
+                    capture_local_traffic: false,
                 },
             ],
         };
@@ -179,8 +187,8 @@ mod tests {
     #[test]
     fn test_ingress_json_roundtrip() {
         let table = IngressHookMappingTable {
-            proxies: vec![
-                IngressHookProxy {
+            ingresses: vec![
+                IngressInstance {
                     proxy_port: 49001,
                     capture_rules: vec![
                         IngressHookCaptureRule {
@@ -194,22 +202,24 @@ mod tests {
                             port_end: None,
                         },
                     ],
+                    capture_local_traffic: false,
                 },
-                IngressHookProxy {
+                IngressInstance {
                     proxy_port: 49002,
                     capture_rules: vec![IngressHookCaptureRule {
                         host_cidr: "*".to_string(),
                         port: 8080,
                         port_end: Some(8090),
                     }],
+                    capture_local_traffic: true,
                 },
             ],
         };
         let json = serde_json::to_string(&table).unwrap();
         let parsed: IngressHookMappingTable = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.proxies.len(), 2);
-        assert_eq!(parsed.proxies[0].proxy_port, 49001);
-        assert_eq!(parsed.proxies[0].capture_rules.len(), 2);
-        assert_eq!(parsed.proxies[1].capture_rules[0].port_end, Some(8090));
+        assert_eq!(parsed.ingresses.len(), 2);
+        assert_eq!(parsed.ingresses[0].proxy_port, 49001);
+        assert_eq!(parsed.ingresses[0].capture_rules.len(), 2);
+        assert_eq!(parsed.ingresses[1].capture_rules[0].port_end, Some(8090));
     }
 }

--- a/tng-hook/types/src/ingress.rs
+++ b/tng-hook/types/src/ingress.rs
@@ -1,4 +1,5 @@
-use std::net::SocketAddrV4;
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 
 use serde::{Deserialize, Serialize};
 
@@ -51,6 +52,8 @@ pub struct IngressHookCaptureRule {
 /// Built once at library init time, read-only thereafter.
 pub struct IngressHookLookup {
     ingresses: Vec<IngressInstance>,
+    /// Cached set of local interface IPs, built at init time.
+    local_ips: HashSet<Ipv4Addr>,
 }
 
 impl IngressHookLookup {
@@ -58,6 +61,7 @@ impl IngressHookLookup {
     pub fn from_table(table: &IngressHookMappingTable) -> Self {
         Self {
             ingresses: table.ingresses.clone(),
+            local_ips: get_local_ips(),
         }
     }
 
@@ -68,12 +72,42 @@ impl IngressHookLookup {
         for proxy in &self.ingresses {
             for rule in &proxy.capture_rules {
                 if rule.matches(dst) {
+                    // When capture_local_traffic is false, skip if destination
+                    // is a local interface IP.
+                    if !proxy.capture_local_traffic && self.local_ips.contains(dst.ip()) {
+                        return None;
+                    }
                     return Some(proxy.proxy_port);
                 }
             }
         }
         None
     }
+}
+
+/// Collect all local interface IPv4 addresses at load time.
+///
+/// Includes the full 127.0.0.0/8 loopback range and all IPs
+/// from `local_ip_address::list_afinet_netifas()`. If the
+/// interface enumeration fails, only loopback addresses are returned.
+fn get_local_ips() -> HashSet<Ipv4Addr> {
+    let mut ips = HashSet::new();
+
+    // 127.0.0.0/8 loopback range
+    for b in 0..=255u8 {
+        ips.insert(Ipv4Addr::new(127, b, 0, 1));
+    }
+
+    // Runtime interfaces
+    if let Ok(ifaces) = local_ip_address::list_afinet_netifas() {
+        for (_, addr) in ifaces {
+            if let IpAddr::V4(v4) = addr {
+                ips.insert(v4);
+            }
+        }
+    }
+
+    ips
 }
 
 impl IngressHookCaptureRule {
@@ -221,5 +255,71 @@ mod tests {
         assert_eq!(parsed.ingresses[0].proxy_port, 49001);
         assert_eq!(parsed.ingresses[0].capture_rules.len(), 2);
         assert_eq!(parsed.ingresses[1].capture_rules[0].port_end, Some(8090));
+    }
+
+    #[test]
+    fn test_find_proxy_port_skips_local_ip_when_capture_local_traffic_false() {
+        // Build a table with capture_local_traffic: false
+        let table = IngressHookMappingTable {
+            ingresses: vec![IngressInstance {
+                proxy_port: 49001,
+                capture_rules: vec![IngressHookCaptureRule {
+                    host_cidr: "*".to_string(), // match any
+                    port: 80,
+                    port_end: None,
+                }],
+                capture_local_traffic: false,
+            }],
+        };
+        let lookup = IngressHookLookup::from_table(&table);
+
+        // 127.0.0.1 is a local IP -> should be skipped
+        assert!(lookup
+            .find_proxy_port(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80))
+            .is_none());
+    }
+
+    #[test]
+    fn test_find_proxy_port_captures_local_ip_when_capture_local_traffic_true() {
+        let table = IngressHookMappingTable {
+            ingresses: vec![IngressInstance {
+                proxy_port: 49001,
+                capture_rules: vec![IngressHookCaptureRule {
+                    host_cidr: "*".to_string(),
+                    port: 80,
+                    port_end: None,
+                }],
+                capture_local_traffic: true,
+            }],
+        };
+        let lookup = IngressHookLookup::from_table(&table);
+
+        // 127.0.0.1 is local but capture_local_traffic is true -> should match
+        assert_eq!(
+            lookup.find_proxy_port(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80)),
+            Some(49001)
+        );
+    }
+
+    #[test]
+    fn test_find_proxy_port_non_local_ip_always_matches() {
+        let table = IngressHookMappingTable {
+            ingresses: vec![IngressInstance {
+                proxy_port: 49001,
+                capture_rules: vec![IngressHookCaptureRule {
+                    host_cidr: "*".to_string(),
+                    port: 80,
+                    port_end: None,
+                }],
+                capture_local_traffic: false,
+            }],
+        };
+        let lookup = IngressHookLookup::from_table(&table);
+
+        // 10.0.0.5 is not local -> should match even with capture_local_traffic: false
+        assert_eq!(
+            lookup.find_proxy_port(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 5), 80)),
+            Some(49001)
+        );
     }
 }

--- a/tng-hook/types/src/ingress.rs
+++ b/tng-hook/types/src/ingress.rs
@@ -73,8 +73,10 @@ impl IngressHookLookup {
             for rule in &proxy.capture_rules {
                 if rule.matches(dst) {
                     // When capture_local_traffic is false, skip if destination
-                    // is a local interface IP.
-                    if !proxy.capture_local_traffic && self.local_ips.contains(dst.ip()) {
+                    // is a local interface IP or a loopback address.
+                    if !proxy.capture_local_traffic
+                        && (dst.ip().is_loopback() || self.local_ips.contains(dst.ip()))
+                    {
                         return None;
                     }
                     return Some(proxy.proxy_port);
@@ -85,24 +87,22 @@ impl IngressHookLookup {
     }
 }
 
-/// Collect all local interface IPv4 addresses at load time.
+/// Collect IPv4 addresses of non-loopback network interfaces at load time.
 ///
-/// Includes the full 127.0.0.0/8 loopback range and all IPs
-/// from `local_ip_address::list_afinet_netifas()`. If the
-/// interface enumeration fails, only loopback addresses are returned.
+/// Uses `local_ip_address::list_afinet_netifas()` to enumerate all interfaces.
+/// Loopback addresses are handled separately via `is_loopback()` in
+/// `find_proxy_port()`. If interface enumeration fails, an empty set is
+/// returned.
 fn get_local_ips() -> HashSet<Ipv4Addr> {
     let mut ips = HashSet::new();
 
-    // 127.0.0.0/8 loopback range
-    for b in 0..=255u8 {
-        ips.insert(Ipv4Addr::new(127, b, 0, 1));
-    }
-
-    // Runtime interfaces
+    // Runtime interfaces (non-loopback — loopback is checked via is_loopback())
     if let Ok(ifaces) = local_ip_address::list_afinet_netifas() {
         for (_, addr) in ifaces {
             if let IpAddr::V4(v4) = addr {
-                ips.insert(v4);
+                if !v4.is_loopback() {
+                    ips.insert(v4);
+                }
             }
         }
     }

--- a/tng-hook/types/src/lib.rs
+++ b/tng-hook/types/src/lib.rs
@@ -3,5 +3,5 @@ mod ingress;
 
 pub use egress::{EgressHookMappingEntry, EgressHookMappingLookup, EgressHookMappingTable};
 pub use ingress::{
-    IngressHookCaptureRule, IngressHookLookup, IngressHookMappingTable, IngressHookProxy,
+    IngressHookCaptureRule, IngressHookLookup, IngressHookMappingTable, IngressInstance,
 };

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -249,3 +249,8 @@ name = "egress_hook_capture_local_traffic"
 path = "tests/hook/egress_hook_capture_local_traffic.rs"
 required-features = ["on-bin"]
 
+[[test]]
+name = "ingress_hook_capture_local_traffic_true"
+path = "tests/hook/ingress_hook_capture_local_traffic_true.rs"
+required-features = ["on-bin"]
+

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -239,3 +239,13 @@ name = "go_sdk_rats_tls"
 path = "tests/go_sdk_http/go_sdk_rats_tls.rs"
 required-features = ["go-sdk"]
 
+[[test]]
+name = "ingress_hook_capture_local_traffic"
+path = "tests/hook/ingress_hook_capture_local_traffic.rs"
+required-features = ["on-bin"]
+
+[[test]]
+name = "egress_hook_capture_local_traffic"
+path = "tests/hook/egress_hook_capture_local_traffic.rs"
+required-features = ["on-bin"]
+

--- a/tng-testsuite/src/netns.rs
+++ b/tng-testsuite/src/netns.rs
@@ -236,7 +236,7 @@ impl BridgeNetwork {
                 })
                 .unwrap_or("");
 
-            if ifname.starts_with("tngtest-br") || ifname.starts_with("tngtest-veth") {
+            if ifname.starts_with("tngtest-br") || ifname.starts_with("tngtest-v") {
                 if let Err(e) = handle.link().del(msg.header.index).execute().await {
                     tracing::warn!(
                         link_idx = msg.header.index,
@@ -314,11 +314,11 @@ impl VethPair {
         // Generate a random veth name
         let random_part: String = rand::rng()
             .sample_iter(&Alphanumeric)
-            .take(2) // Fixed length characters
+            .take(5) // 5 random chars + "tngtest-v"(9) + suffix(1) = 15 chars, fits IFNAMSIZ(15)
             .map(char::from)
             .collect();
-        let veth: String = format!("tngtest-veth{}o", random_part);
-        let veth_2: String = format!("tngtest-veth{}i", random_part);
+        let veth: String = format!("tngtest-v{}o", random_part);
+        let veth_2: String = format!("tngtest-v{}i", random_part);
 
         handle
             .link()

--- a/tng-testsuite/tests/hook/egress_hook_capture_local_traffic.rs
+++ b/tng-testsuite/tests/hook/egress_hook_capture_local_traffic.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use tng_testsuite::{
+    run_test,
+    task::tng::TngExecTask,
+    task::NodeType,
+    task::Task as _,
+};
+
+/// Test egress hook with `capture_local_traffic` defaulting to `false`.
+///
+/// Architecture:
+/// - Server side: `tng exec` with egress hook `capture_listen: [{"host":
+///   "127.0.0.1", "port": 20001}]` (no `capture_local_traffic` field ->
+///   defaults to `false`) wrapping a Python echo server that binds to
+///   127.0.0.1:20001. Inside the wrapper, a local TCP client connects to
+///   127.0.0.1:20001, sends data, and verifies the echo response.
+///
+/// Flow:
+/// 1. `tng exec` starts on the server node with egress hook configuration.
+/// 2. The Python echo server binds to 127.0.0.1:20001 (loopback).
+/// 3. Since `127.0.0.1` is a local IP and `capture_local_traffic` defaults
+///    to `false`, the egress hook does NOT intercept this bind/listen.
+///    `encrypted()` returns `false` for connections to this endpoint.
+/// 4. A local TCP client inside the same `tng exec` wrapper connects to
+///    127.0.0.1:20001, sends a payload, and receives the echo response.
+///
+/// Expected result:
+/// - The echo round-trip succeeds DIRECTLY on loopback, proving the tunnel
+///   did NOT capture this local traffic. If the tunnel had captured it,
+///   the connection would have been routed through the tunnel infrastructure
+///   and likely failed or produced different behavior.
+///
+/// This test requires `libtng_hook.so` to be installed alongside the `tng`
+/// binary, so it only runs in `on-bin` mode (via `required-features`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test() -> Result<()> {
+    run_test!(vec![
+        // Server side: tng exec wrapping a Python echo server on 127.0.0.1:20001.
+        // capture_listen: [{"host": "127.0.0.1", "port": 20001}] with NO
+        // capture_local_traffic field -> defaults to false.
+        //
+        // Inside the `tng exec` wrapper:
+        // 1. Echo server starts on 127.0.0.1:20001 (background thread).
+        // 2. Local TCP client connects to 127.0.0.1:20001, sends data, verifies echo.
+        //
+        // Since capture_local_traffic defaults to false and 127.0.0.1 is a local IP,
+        // the hook does NOT intercept -> connection goes directly to the echo server.
+        // Successful echo proves local traffic bypassed the tunnel.
+        TngExecTask::new(
+            r#"{"add_egress": [{"hook": {"capture_listen": [{"host": "127.0.0.1", "port": 20001}]}, "no_ra": true}]}"#.to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                concat!(
+                    "python3 -c '\n",
+                    "import socket, threading, time\n",
+                    "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
+                    "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n",
+                    "s.bind((\"127.0.0.1\", 20001))\n",
+                    "s.listen(5)\n",
+                    "def handle():\n",
+                    "    while True:\n",
+                    "        c, a = s.accept()\n",
+                    "        d = c.recv(4096)\n",
+                    "        if d: c.sendall(d)\n",
+                    "        c.close()\n",
+                    "threading.Thread(target=handle, daemon=True).start()\n",
+                    "time.sleep(1)\n",
+                    "c = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
+                    "c.connect((\"127.0.0.1\", 20001))\n",
+                    "c.sendall(b\"Hello from local bypass!\")\n",
+                    "c.shutdown(socket.SHUT_WR)\n",
+                    "d = c.recv(4096)\n",
+                    "assert d == b\"Hello from local bypass!\", f\"Expected echo, got: {d}\"\n",
+                    "c.close()\n",
+                    "print(\"OK: egress hook local traffic bypass verified\")\n",
+                    "'",
+                )
+                .to_string(),
+            ],
+            false,
+            NodeType::Server,
+        )
+        .boxed(),
+    ])
+    .await?;
+    Ok(())
+}

--- a/tng-testsuite/tests/hook/egress_hook_capture_local_traffic.rs
+++ b/tng-testsuite/tests/hook/egress_hook_capture_local_traffic.rs
@@ -1,10 +1,5 @@
 use anyhow::Result;
-use tng_testsuite::{
-    run_test,
-    task::tng::TngExecTask,
-    task::NodeType,
-    task::Task as _,
-};
+use tng_testsuite::{run_test, task::tng::TngExecTask, task::NodeType, task::Task as _};
 
 /// Test egress hook with `capture_local_traffic` defaulting to `false`.
 ///

--- a/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic.rs
+++ b/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic.rs
@@ -1,0 +1,134 @@
+use anyhow::Result;
+use tng_testsuite::{
+    run_test,
+    task::{
+        shell::{ShellMode, ShellTask},
+        tng::{TngExecTask, TngInstance},
+        NodeType, Task as _,
+    },
+};
+
+/// Test ingress hook with `capture_local_traffic` defaulting to `false`.
+///
+/// Architecture:
+/// - Server side: Echo server on port 30001 + TNG with egress mapping
+///   (0.0.0.0:20001 -> 127.0.0.1:30001).
+/// - Client side: `tng exec` with ingress hook `capture_dst: [{"port": 20001}]`
+///   (no `capture_local_traffic` field -> defaults to `false`) running a
+///   Python TCP client.
+///
+/// Flow:
+/// 1. Echo server listens on 0.0.0.0:30001 (server node).
+/// 2. Python client attempts to connect to 127.0.0.1:20001 (loopback).
+/// 3. Since `127.0.0.1` is a local IP and `capture_local_traffic` defaults
+///    to `false`, the ingress hook does NOT intercept this connection.
+/// 4. The connection goes directly to 127.0.0.1:20001 on the client machine,
+///    where there is no listener -> "Connection refused".
+///
+/// Expected result:
+/// - The connection is REFUSED, proving the tunnel was NOT established for
+///   local traffic. This verifies the default behavior of excluding local
+///   interface IP traffic from hook-based capture.
+///
+/// This test requires `libtng_hook.so` to be installed alongside the `tng`
+/// binary, so it only runs in `on-bin` mode (via `required-features`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test() -> Result<()> {
+    run_test!(vec![
+        // Echo server on the Server node, port 30001.
+        ShellTask {
+            name: "echo server".to_owned(),
+            node_type: NodeType::Server,
+            script: r#"
+python3 -c '
+import socket, threading, time
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", 30001))
+s.listen(5)
+def handle():
+    while True:
+        c, a = s.accept()
+        d = c.recv(4096)
+        if d: c.sendall(d)
+        c.close()
+threading.Thread(target=handle, daemon=True).start()
+time.sleep(120)
+' &
+sleep 120
+                "#
+            .to_owned(),
+            mode: ShellMode::BackgroundContinue,
+        }
+        .boxed(),
+        // Server side: TNG with egress mapping.
+        // Traffic arriving on 20001 is forwarded locally to echo server on 30001.
+        TngInstance::TngServer(
+            r#"{
+                "add_egress": [{
+                    "mapping": {
+                        "in": {"host": "0.0.0.0", "port": 20001},
+                        "out": {"host": "127.0.0.1", "port": 30001}
+                    },
+                    "no_ra": true
+                }]
+            }"#,
+        )
+        .boxed(),
+        // Client side: tng exec with ingress hook.
+        // capture_dst: [{"port": 20001}] with NO capture_local_traffic field -> defaults to false.
+        //
+        // The Python client attempts to connect to 127.0.0.1:20001 (loopback).
+        // Since 127.0.0.1 is a local IP and capture_local_traffic defaults to
+        // false, the ingress hook does NOT intercept -> connection goes directly
+        // to 127.0.0.1:20001 on the client, where there is no listener.
+        //
+        // We verify the connection is REFUSED (ConnectionRefusedError), which
+        // proves the tunnel was NOT used for this local traffic.
+        //
+        // If capture_local_traffic were true (or the check were missing/broken),
+        // the hook would intercept the connection, tunnel it to the server, and
+        // the echo response would arrive -> the test below would fail (unexpected
+        // success means the tunnel captured local traffic).
+        TngExecTask::new(
+            r#"{
+                "add_ingress": [{
+                    "hook": {
+                        "capture_dst": [{"port": 20001}]
+                    },
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+python3 -c '
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(5)
+try:
+    s.connect(("127.0.0.1", 20001))
+    # If we get here, the tunnel captured local traffic -> test FAILS
+    print("UNEXPECTED: connection succeeded - tunnel captured local traffic!", file=sys.stderr)
+    sys.exit(1)
+except ConnectionRefusedError:
+    # Expected: no local listener on 127.0.0.1:20001, proving tunnel was NOT used
+    print("OK: connection refused as expected - local traffic bypassed tunnel")
+    sys.exit(0)
+except Exception as e:
+    print(f"UNEXPECTED error: {e}", file=sys.stderr)
+    sys.exit(1)
+'
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Client,
+        )
+        .boxed(),
+    ])
+    .await?;
+    Ok(())
+}

--- a/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic.rs
+++ b/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic.rs
@@ -3,48 +3,47 @@ use tng_testsuite::{
     run_test,
     task::{
         shell::{ShellMode, ShellTask},
-        tng::{TngExecTask, TngInstance},
+        tng::TngExecTask,
         NodeType, Task as _,
     },
 };
 
 /// Test ingress hook with `capture_local_traffic` defaulting to `false`.
 ///
-/// Architecture:
-/// - Server side: Echo server on port 30001 + TNG with egress mapping
-///   (0.0.0.0:20001 -> 127.0.0.1:30001).
-/// - Client side: `tng exec` with ingress hook `capture_dst: [{"port": 20001}]`
-///   (no `capture_local_traffic` field -> defaults to `false`) running a
-///   Python TCP client.
+/// Architecture (all on the Client node):
+/// - Echo server listens on 127.0.0.1:20001 (loopback).
+/// - `tng exec` with ingress hook `capture_dst: [{"port": 20001}]`
+///   (no `capture_local_traffic` field -> defaults to `false`) runs a
+///   Python TCP client that connects to 127.0.0.1:20001.
 ///
 /// Flow:
-/// 1. Echo server listens on 0.0.0.0:30001 (server node).
-/// 2. Python client attempts to connect to 127.0.0.1:20001 (loopback).
+/// 1. Echo server starts on 127.0.0.1:20001.
+/// 2. Python client inside `tng exec` attempts to connect to 127.0.0.1:20001.
 /// 3. Since `127.0.0.1` is a local IP and `capture_local_traffic` defaults
 ///    to `false`, the ingress hook does NOT intercept this connection.
-/// 4. The connection goes directly to 127.0.0.1:20001 on the client machine,
-///    where there is no listener -> "Connection refused".
+/// 4. The connection goes directly to the echo server on 127.0.0.1:20001.
 ///
 /// Expected result:
-/// - The connection is REFUSED, proving the tunnel was NOT established for
-///   local traffic. This verifies the default behavior of excluding local
-///   interface IP traffic from hook-based capture.
+/// - Echo round-trip succeeds, proving the tunnel was NOT used for this
+///   local traffic. If the hook had captured the connection, it would have
+///   been routed through the tunnel (and likely failed since no tunnel
+///   endpoint exists for this flow).
 ///
 /// This test requires `libtng_hook.so` to be installed alongside the `tng`
 /// binary, so it only runs in `on-bin` mode (via `required-features`).
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test() -> Result<()> {
     run_test!(vec![
-        // Echo server on the Server node, port 30001.
+        // Echo server on the Client node, loopback only.
         ShellTask {
-            name: "echo server".to_owned(),
-            node_type: NodeType::Server,
+            name: "echo server on loopback".to_owned(),
+            node_type: NodeType::Client,
             script: r#"
 python3 -c '
 import socket, threading, time
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-s.bind(("0.0.0.0", 30001))
+s.bind(("127.0.0.1", 20001))
 s.listen(5)
 def handle():
     while True:
@@ -61,35 +60,17 @@ sleep 120
             mode: ShellMode::BackgroundContinue,
         }
         .boxed(),
-        // Server side: TNG with egress mapping.
-        // Traffic arriving on 20001 is forwarded locally to echo server on 30001.
-        TngInstance::TngServer(
-            r#"{
-                "add_egress": [{
-                    "mapping": {
-                        "in": {"host": "0.0.0.0", "port": 20001},
-                        "out": {"host": "127.0.0.1", "port": 30001}
-                    },
-                    "no_ra": true
-                }]
-            }"#,
-        )
-        .boxed(),
         // Client side: tng exec with ingress hook.
         // capture_dst: [{"port": 20001}] with NO capture_local_traffic field -> defaults to false.
         //
-        // The Python client attempts to connect to 127.0.0.1:20001 (loopback).
+        // The Python client connects to 127.0.0.1:20001 (loopback).
         // Since 127.0.0.1 is a local IP and capture_local_traffic defaults to
         // false, the ingress hook does NOT intercept -> connection goes directly
-        // to 127.0.0.1:20001 on the client, where there is no listener.
+        // to the echo server on 127.0.0.1:20001.
         //
-        // We verify the connection is REFUSED (ConnectionRefusedError), which
-        // proves the tunnel was NOT used for this local traffic.
-        //
-        // If capture_local_traffic were true (or the check were missing/broken),
-        // the hook would intercept the connection, tunnel it to the server, and
-        // the echo response would arrive -> the test below would fail (unexpected
-        // success means the tunnel captured local traffic).
+        // Successful echo proves local traffic bypassed the tunnel.
+        // If capture_local_traffic were true (or the check were broken),
+        // the hook would intercept, tunnel the connection, and it would fail.
         TngExecTask::new(
             r#"{
                 "add_ingress": [{
@@ -105,21 +86,15 @@ sleep 120
                 "-c".to_string(),
                 r#"
 python3 -c '
-import socket, sys
+import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(5)
-try:
-    s.connect(("127.0.0.1", 20001))
-    # If we get here, the tunnel captured local traffic -> test FAILS
-    print("UNEXPECTED: connection succeeded - tunnel captured local traffic!", file=sys.stderr)
-    sys.exit(1)
-except ConnectionRefusedError:
-    # Expected: no local listener on 127.0.0.1:20001, proving tunnel was NOT used
-    print("OK: connection refused as expected - local traffic bypassed tunnel")
-    sys.exit(0)
-except Exception as e:
-    print(f"UNEXPECTED error: {e}", file=sys.stderr)
-    sys.exit(1)
+s.settimeout(10)
+s.connect(("127.0.0.1", 20001))
+s.sendall(b"Hello from local bypass!")
+s.shutdown(socket.SHUT_WR)
+d = s.recv(4096)
+assert d == b"Hello from local bypass!", f"Expected echo, got: {d}"
+print("OK: local traffic bypassed tunnel via ingress hook")
 '
 "#
                 .to_string(),

--- a/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic_true.rs
+++ b/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic_true.rs
@@ -77,7 +77,7 @@ sleep 120
         // traffic interception with capture_local_traffic: true.
         TngInstance::TngClient(
             r#"{
-                "add_ingress": [{
+                "add_egress": [{
                     "mapping": {
                         "in": {"host": "127.0.0.1", "port": 20001},
                         "out": {"host": "127.0.0.1", "port": 30001}

--- a/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic_true.rs
+++ b/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic_true.rs
@@ -1,0 +1,136 @@
+use anyhow::Result;
+use tng_testsuite::{
+    run_test,
+    task::{
+        shell::{ShellMode, ShellTask},
+        tng::{TngExecTask, TngInstance},
+        NodeType, Task as _,
+    },
+};
+
+/// Test ingress hook with `capture_local_traffic: true` — local traffic
+/// SHOULD be captured and tunneled.
+///
+/// NOTE: This test intentionally runs the echo server and the TNG egress
+/// mapping on the Client node (not the Server node). This is NOT a mistake —
+/// the purpose is to test `capture_local_traffic: true` on loopback traffic.
+/// With `capture_local_traffic: true`, the ingress hook intercepts the local
+/// connection to 127.0.0.1:20001, tunnels it to the TNG egress mapping on
+/// the same node, which forwards to the echo server on 127.0.0.1:30001.
+///
+/// Architecture (all on the Client node):
+/// - Echo server on 127.0.0.1:30001.
+/// - TNG Client with ingress mapping (127.0.0.1:20001 → 127.0.0.1:30001).
+/// - `tng exec` with ingress hook `capture_dst: [{"port": 20001}]`
+///   and `capture_local_traffic: true` running a Python TCP client.
+///
+/// Flow:
+/// 1. Echo server listens on 127.0.0.1:30001 (client node).
+/// 2. TNG Client ingress mapping forwards 127.0.0.1:20001 → 127.0.0.1:30001.
+/// 3. Python client connects to 127.0.0.1:20001 (loopback).
+/// 4. Since `capture_local_traffic: true`, the ingress hook DOES intercept
+///    this local connection, tunneling it through to the TNG Client mapping.
+/// 5. TNG Client mapping forwards to 127.0.0.1:30001 → echo server.
+/// 6. Echo response travels back through the tunnel to client.
+///
+/// Expected result:
+/// - Echo round-trip succeeds, proving the tunnel WAS used for local traffic
+///   when `capture_local_traffic: true`. This is the opposite of the default
+///   (`false`) behavior where local traffic bypasses the tunnel.
+///
+/// This test requires `libtng_hook.so` to be installed alongside the `tng`
+/// binary, so it only runs in `on-bin` mode (via `required-features`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test() -> Result<()> {
+    run_test!(vec![
+        // Echo server on the Client node, loopback only on port 30001.
+        // NOTE: This is intentional — we test capture_local_traffic: true
+        // with all components on the same node's loopback interface.
+        ShellTask {
+            name: "echo server on loopback".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+python3 -c '
+import socket, threading, time
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", 30001))
+s.listen(5)
+def handle():
+    while True:
+        c, a = s.accept()
+        d = c.recv(4096)
+        if d: c.sendall(d)
+        c.close()
+threading.Thread(target=handle, daemon=True).start()
+time.sleep(120)
+' &
+sleep 120
+                "#
+            .to_owned(),
+            mode: ShellMode::BackgroundContinue,
+        }
+        .boxed(),
+        // TNG Client with ingress mapping on the Client node.
+        // Traffic arriving on 127.0.0.1:20001 is forwarded to echo server on 127.0.0.1:30001.
+        // NOTE: This runs on Client (not Server) because we are testing loopback
+        // traffic interception with capture_local_traffic: true.
+        TngInstance::TngClient(
+            r#"{
+                "add_ingress": [{
+                    "mapping": {
+                        "in": {"host": "127.0.0.1", "port": 20001},
+                        "out": {"host": "127.0.0.1", "port": 30001}
+                    },
+                    "no_ra": true
+                }]
+            }"#,
+        )
+        .boxed(),
+        // Client side: tng exec with ingress hook, capture_local_traffic: true.
+        //
+        // The Python client connects to 127.0.0.1:20001 (loopback).
+        // Since capture_local_traffic is true, the ingress hook DOES intercept
+        // this local connection and tunnels it to the TNG Client mapping,
+        // which forwards to the echo server.
+        //
+        // Successful echo proves local traffic WAS captured by the tunnel.
+        // If capture_local_traffic were false (default), the connection would
+        // go directly to 127.0.0.1:20001 where there is no listener, and fail.
+        TngExecTask::new(
+            r#"{
+                "add_ingress": [{
+                    "hook": {
+                        "capture_dst": [{"port": 20001}],
+                        "capture_local_traffic": true
+                    },
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+python3 -c '
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(10)
+s.connect(("127.0.0.1", 20001))
+s.sendall(b"Hello from captured local traffic!")
+s.shutdown(socket.SHUT_WR)
+d = s.recv(4096)
+assert d == b"Hello from captured local traffic!", f"Expected echo, got: {d}"
+print("OK: local traffic tunneled via ingress hook with capture_local_traffic: true")
+'
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Client,
+        )
+        .boxed(),
+    ])
+    .await?;
+    Ok(())
+}

--- a/tng/src/config/egress_hook.rs
+++ b/tng/src/config/egress_hook.rs
@@ -17,6 +17,12 @@ fn wildcard_ip() -> Ipv4Addr {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EgressHookArgs {
+    /// When `false` (default), accepted connections whose peer IP is a local
+    /// interface address are excluded from the encrypted tunnel. Set to `true`
+    /// to also capture local-to-local traffic.
+    #[serde(default)]
+    pub capture_local_traffic: bool,
+
     #[serde_as(as = "OneOrMany<_, PreferMany>")]
     #[serde(default = "Vec::new")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -393,5 +399,24 @@ mod tests {
         .unwrap();
         let (entries, _) = entry.expand_mappings(40000).unwrap();
         assert!(entries[0].ifname.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_egress_hook_capture_local_traffic() -> Result<()> {
+        let args: EgressHookArgs = serde_json::from_value(json!({
+            "capture_listen": [{ "port": 8080 }],
+            "capture_local_traffic": true
+        }))?;
+        assert!(args.capture_local_traffic);
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_egress_hook_capture_local_traffic_default() -> Result<()> {
+        let args: EgressHookArgs = serde_json::from_value(json!({
+            "capture_listen": [{ "port": 8080 }]
+        }))?;
+        assert!(!args.capture_local_traffic);
+        Ok(())
     }
 }

--- a/tng/src/config/ingress.rs
+++ b/tng/src/config/ingress.rs
@@ -197,6 +197,12 @@ pub struct IngressHookArgs {
     /// Optional bind address for the internal HTTP proxy (default: 127.0.0.1).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proxy_listen: Option<String>,
+
+    /// When `false` (default), connections whose destination IP is a local
+    /// interface address are excluded from capture. Set to `true` to also
+    /// capture local-to-local traffic.
+    #[serde(default)]
+    pub capture_local_traffic: bool,
 }
 
 /// A single capture destination rule for ingress hook mode.
@@ -371,6 +377,41 @@ mod tests {
     use super::{
         AddIngressArgs, IngressMode, IngressNetfilterCaptureDst, IngressNetfilterCaptureDstArgs,
     };
+
+    #[test]
+    fn test_deserialize_ingress_hook_capture_local_traffic() -> Result<()> {
+        let args: AddIngressArgs = serde_json::from_value(json!({
+            "hook": {
+                "capture_dst": [{ "port": 80 }],
+                "capture_local_traffic": true
+            },
+            "no_ra": true
+        }))?;
+        match args.ingress_mode {
+            IngressMode::Hook(hook_args) => {
+                assert!(hook_args.capture_local_traffic);
+            }
+            _ => panic!("expected hook mode"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_ingress_hook_capture_local_traffic_default() -> Result<()> {
+        let args: AddIngressArgs = serde_json::from_value(json!({
+            "hook": {
+                "capture_dst": [{ "port": 80 }]
+            },
+            "no_ra": true
+        }))?;
+        match args.ingress_mode {
+            IngressMode::Hook(hook_args) => {
+                assert!(!hook_args.capture_local_traffic);
+            }
+            _ => panic!("expected hook mode"),
+        }
+        Ok(())
+    }
 
     fn test_deserialize_netfilter_common(value: serde_json::Value) -> Result<()> {
         // Check deserialize

--- a/tng/src/config/mod.rs
+++ b/tng/src/config/mod.rs
@@ -15,7 +15,7 @@ pub mod ra;
 // Shared types used by both tng and tng-hook
 pub use tng_hook_types::{
     EgressHookMappingEntry, EgressHookMappingTable, IngressHookCaptureRule,
-    IngressHookMappingTable, IngressHookProxy,
+    IngressHookMappingTable, IngressInstance,
 };
 
 // Internal TNG types (not serialized to .so)

--- a/tng/src/control_interface/restful.rs
+++ b/tng/src/control_interface/restful.rs
@@ -1,6 +1,6 @@
 use std::{convert::Infallible, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use axum::{extract::Path, routing::get, Json, Router};
 use http::{HeaderValue, StatusCode};
 use tower::ServiceBuilder;
@@ -81,7 +81,12 @@ impl RestfulControlInterface {
             port = addr.1,
             "Restful Control interface listening"
         );
-        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let listener = tokio::net::TcpListener::bind(addr).await.with_context(|| {
+            format!(
+                "Failed to bind REST control interface on {}:{}",
+                addr.0, addr.1
+            )
+        })?;
         axum::serve(listener, app).await?;
 
         tracing::info!("Restful Control interface stopping");

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -182,7 +182,7 @@ impl TngExec {
         if let Some(ref json) = egress_json {
             child_cmd.env("TNG_HOOK_EGRESS_MAPPINGS", json);
         }
-        // Always set ingress mapping (even if empty proxies, for consistency)
+        // Always set ingress mapping (even if empty ingresses, for consistency)
         child_cmd.env("TNG_HOOK_INGRESS_MAPPINGS", &ingress_json);
 
         if let Some(ref log_file) = log_file {

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -12,7 +12,7 @@ use crate::config::ingress::IngressHookArgs;
 use crate::config::ingress::IngressMode as IngressHookMode;
 use crate::config::{
     EgressHookMappingEntry, EgressHookMappingTable, IngressHookCaptureRule,
-    IngressHookMappingTable, IngressHookProxy, TngConfig, TngEgressHookMappingEntry,
+    IngressHookMappingTable, IngressInstance, TngConfig, TngEgressHookMappingEntry,
 };
 use crate::tunnel::access_log::EgressAccessMode;
 use crate::tunnel::access_log::IngressAccessMode;
@@ -127,7 +127,7 @@ impl TngExec {
 
         // 3. Build ingress mapping table and serialize
         let ingress_table = Self::build_ingress_mapping_table(&mut config, &mut port_alloc)?;
-        let has_ingress_hooks = !ingress_table.proxies.is_empty();
+        let has_ingress_hooks = !ingress_table.ingresses.is_empty();
         let ingress_json = serde_json::to_string(&ingress_table)
             .context("Failed to serialize ingress mapping table")?;
 
@@ -402,13 +402,13 @@ impl TngExec {
         for (i, ingress) in config.add_ingress.iter_mut().enumerate() {
             if let IngressHookMode::Hook(args) = &mut ingress.ingress_mode {
                 let proxy = Self::build_ingress_proxy(i, args, port_alloc)?;
-                mapping_table.proxies.push(proxy);
+                mapping_table.ingresses.push(proxy);
             }
         }
 
-        if !mapping_table.proxies.is_empty() {
+        if !mapping_table.ingresses.is_empty() {
             tracing::info!(
-                proxies = mapping_table.proxies.len(),
+                ingresses = mapping_table.ingresses.len(),
                 "Built ingress hook mapping table"
             );
         }
@@ -416,7 +416,7 @@ impl TngExec {
         Ok(mapping_table)
     }
 
-    /// Build a single IngressHookProxy from an IngressHookArgs.
+    /// Build a single IngressInstance from an IngressHookArgs.
     ///
     /// If `args.proxy_port` is not set, a port is auto-allocated via the shared
     /// allocator and written back to `args.proxy_port` so the runtime uses the
@@ -425,7 +425,7 @@ impl TngExec {
         _entry_index: usize,
         args: &mut IngressHookArgs,
         port_alloc: &mut PortAllocator,
-    ) -> Result<IngressHookProxy> {
+    ) -> Result<IngressInstance> {
         let proxy_port = match args.proxy_port {
             Some(port) => {
                 port_alloc
@@ -459,9 +459,10 @@ impl TngExec {
             bail!("Ingress hook entry has no capture_dst rules. At least one is required.");
         }
 
-        Ok(IngressHookProxy {
+        Ok(IngressInstance {
             proxy_port,
             capture_rules,
+            capture_local_traffic: args.capture_local_traffic,
         })
     }
 

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -97,14 +97,12 @@ impl HookEgress {
 
         // Collect local interface IPs for capture_local_traffic filtering.
         let mut local_ips = HashSet::new();
-        // 127.0.0.0/8 loopback
-        for b in 0..=255u8 {
-            local_ips.insert(Ipv4Addr::new(127, b, 0, 1));
-        }
         if let Ok(ifaces) = local_ip_address::list_afinet_netifas() {
             for (_, addr) in ifaces {
                 if let IpAddr::V4(v4) = addr {
-                    local_ips.insert(v4);
+                    if !v4.is_loopback() {
+                        local_ips.insert(v4);
+                    }
                 }
             }
         }
@@ -133,8 +131,9 @@ impl HookEgress {
             IpAddr::V6(_) => return false,
         };
 
-        // When capture_local_traffic is false, skip if peer IP is local.
-        if !self.capture_local_traffic && self.local_ips.contains(&ip) {
+        // When capture_local_traffic is false, skip if peer IP is local
+        // (loopback or a network interface address).
+        if !self.capture_local_traffic && (ip.is_loopback() || self.local_ips.contains(&ip)) {
             return false;
         }
 
@@ -287,7 +286,9 @@ mod tests {
         HookEgress {
             id: 0,
             entries,
-            capture_local_traffic: false,
+            // Default to true so existing tests exercise the host/ifname
+            // matching logic without local-IP filtering.
+            capture_local_traffic: true,
             local_ips: HashSet::new(),
         }
     }

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -121,19 +121,25 @@ impl HookEgress {
     /// Returns true if local_addr matches any entry's host AND ifname filter.
     /// When no entries are configured, defaults to encrypted (backward compatible).
     /// IPv6 connections always return false.
-    pub fn encrypted(&self, local_addr: SocketAddr) -> bool {
+    pub fn encrypted(&self, peer_addr: SocketAddr, local_addr: SocketAddr) -> bool {
         if self.entries.is_empty() {
             return true;
         }
 
+        let peer_ip = match peer_addr.ip() {
+            IpAddr::V4(ip) => ip,
+            IpAddr::V6(_) => return false,
+        };
         let ip = match local_addr.ip() {
             IpAddr::V4(ip) => ip,
             IpAddr::V6(_) => return false,
         };
 
-        // When capture_local_traffic is false, skip if peer IP is local
-        // (loopback or a network interface address).
-        if !self.capture_local_traffic && (ip.is_loopback() || self.local_ips.contains(&ip)) {
+        // When capture_local_traffic is false, skip only if the connection
+        // is purely local — source is also a local address. An external
+        // source connecting to a local destination must still be encrypted.
+        let peer_is_local = peer_ip.is_loopback() || self.local_ips.contains(&peer_ip);
+        if !self.capture_local_traffic && peer_is_local {
             return false;
         }
 
@@ -257,7 +263,7 @@ impl EgressTrait for HookEgress {
                                     info.local_addr,
                                     EgressAccessMode::Hook,
                                 );
-                                let encrypted = self.encrypted(local);
+                                let encrypted = self.encrypted(peer_addr, local);
 
                                 yield Ok(AcceptedStream {
                                     stream: Box::new(crate::ContextualStream::new(stream, "egress-hook")),
@@ -284,12 +290,14 @@ impl EgressTrait for HookEgress {
 mod tests {
     use super::*;
 
+    // ── helpers ──────────────────────────────────────────────────────────────
+
     fn make_egress(entries: Vec<ResolvedEgressEntry>) -> HookEgress {
         HookEgress {
             id: 0,
             entries,
-            // Default to true so existing tests exercise the host/ifname
-            // matching logic without local-IP filtering.
+            // Default to true so host/ifname matching tests aren't affected
+            // by the local-traffic filter.
             capture_local_traffic: true,
             local_ips: HashSet::new(),
         }
@@ -309,32 +317,38 @@ mod tests {
         }
     }
 
+    // Well-known IPs used across tests for clarity.
+    const LOOPBACK: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+    const EXT: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 99); // "external" non-local
+    const IFACE1: Ipv4Addr = Ipv4Addr::new(172, 17, 89, 111); // simulated interface IP
+    const IFACE2: Ipv4Addr = Ipv4Addr::new(172, 17, 89, 112); // another interface IP
+
+    fn peer(ip: Ipv4Addr) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(ip), 12345)
+    }
+
+    fn dest(ip: Ipv4Addr) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(ip), 5600)
+    }
+
+    // ── host / ifname matching (capture_local_traffic = true, local_ips empty)
+    // These tests isolate the host/ifname filter without the local-traffic
+    // shortcut.
+
     #[test]
     fn test_encrypted_empty_entries_returns_true() {
         let egress = make_egress(vec![]);
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 5600);
-        assert!(egress.encrypted(addr));
+        assert!(egress.encrypted(peer(EXT), dest(LOOPBACK)));
     }
 
     #[test]
     fn test_encrypted_wildcard_host_matches_all() {
-        // host = 0.0.0.0, no ifname -> always true
         let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
         let egress = make_egress(vec![entry]);
 
-        // Any IP should match
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            5600
-        )));
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
-            5600
-        )));
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            5600
-        )));
+        assert!(egress.encrypted(peer(EXT), dest(LOOPBACK)));
+        assert!(egress.encrypted(peer(EXT), dest(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(egress.encrypted(peer(EXT), dest(EXT)));
     }
 
     #[test]
@@ -342,22 +356,12 @@ mod tests {
         let entry = make_entry(Ipv4Addr::new(172, 17, 80, 1), None, 5600, 9600);
         let egress = make_egress(vec![entry]);
 
-        // Exact match
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
-            5600
-        )));
-
-        // Different IP -> fail
-        assert!(!egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            5600
-        )));
+        assert!(egress.encrypted(peer(EXT), dest(Ipv4Addr::new(172, 17, 80, 1))));
+        assert!(!egress.encrypted(peer(EXT), dest(LOOPBACK)));
     }
 
     #[test]
     fn test_encrypted_ifname_filter() {
-        // host = 0.0.0.0, ifname resolved to specific IPs
         let mut ips = HashSet::new();
         ips.insert(Ipv4Addr::new(172, 17, 80, 1));
         ips.insert(Ipv4Addr::new(172, 17, 80, 2));
@@ -365,47 +369,34 @@ mod tests {
         let entry = make_entry(Ipv4Addr::UNSPECIFIED, Some(ips), 5600, 9600);
         let egress = make_egress(vec![entry]);
 
-        // IP in the resolved set -> match
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
-            5600
-        )));
-
-        // IP not in the set -> no match
-        assert!(!egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            5600
-        )));
+        assert!(egress.encrypted(peer(EXT), dest(Ipv4Addr::new(172, 17, 80, 1))));
+        assert!(!egress.encrypted(peer(EXT), dest(LOOPBACK)));
     }
 
     #[test]
     fn test_encrypted_host_and_ifname_and() {
-        // host = 172.17.80.1 AND ifname_ips contains 172.17.80.1
         let mut ips = HashSet::new();
         ips.insert(Ipv4Addr::new(172, 17, 80, 1));
 
         let entry = make_entry(Ipv4Addr::new(172, 17, 80, 1), Some(ips.clone()), 5600, 9600);
         let egress = make_egress(vec![entry]);
 
-        // Both match -> true
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
-            5600
-        )));
+        // Both match
+        assert!(egress.encrypted(peer(EXT), dest(Ipv4Addr::new(172, 17, 80, 1))));
+        // Neither matches
+        assert!(!egress.encrypted(peer(EXT), dest(Ipv4Addr::new(172, 17, 80, 2))));
 
-        // IP matches neither host nor ifname -> false
-        assert!(!egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 2)),
-            5600
-        )));
-
-        // IP matches ifname but not host (different entry) -> false
+        // IP matches ifname but not host (separate entry)
         let entry2 = make_entry(Ipv4Addr::new(10, 0, 0, 1), Some(ips), 5601, 9601);
         let egress2 = make_egress(vec![entry2]);
-        assert!(!egress2.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(172, 17, 80, 1)),
-            5601
-        )));
+        assert!(!egress2.encrypted(peer(EXT), dest(Ipv4Addr::new(172, 17, 80, 1))));
+    }
+
+    #[test]
+    fn test_encrypted_ifname_no_ips_blocks_all() {
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, Some(HashSet::new()), 5600, 9600);
+        let egress = make_egress(vec![entry]);
+        assert!(!egress.encrypted(peer(EXT), dest(EXT)));
     }
 
     #[test]
@@ -414,68 +405,182 @@ mod tests {
         let egress = make_egress(vec![entry]);
 
         let addr = SocketAddr::new(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST), 5600);
-        assert!(!egress.encrypted(addr));
+        assert!(!egress.encrypted(peer(EXT), addr));
     }
 
-    #[test]
-    fn test_encrypted_ifname_no_ips_blocks_all() {
-        // ifname configured but interface has no IPs -> empty Some -> nothing matches
-        let entry = make_entry(Ipv4Addr::UNSPECIFIED, Some(HashSet::new()), 5600, 9600);
-        let egress = make_egress(vec![entry]);
-        // No IPs to match -> nothing is encrypted
-        assert!(!egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            5600
-        )));
-    }
+    // ── capture_local_traffic = false: peer locality is the gatekeeper ───────
+    //
+    // When false, the only question for the local-traffic shortcut is:
+    // "is the peer local?"  If yes → skip encryption.  If no → proceed to
+    // host/ifname matching normally.
 
-    #[test]
-    fn test_encrypted_local_ip_skipped_when_capture_local_traffic_false() {
-        // Host = 0.0.0.0 (wildcard), capture_local_traffic = false
-        // 127.0.0.1 is a local IP -> should return false
+    fn egress_no_capture(local_ips: HashSet<Ipv4Addr>) -> HookEgress {
         let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+        HookEgress {
+            id: 0,
+            entries: vec![entry],
+            capture_local_traffic: false,
+            local_ips,
+        }
+    }
+
+    #[test]
+    fn test_no_capture_loopback_peer_always_skipped() {
+        // Loopback peer is always local (is_loopback()), regardless of dest
+        // or local_ips contents.
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        let egress = egress_no_capture(ips);
+
+        // Loopback peer → loopback dest
+        assert!(!egress.encrypted(peer(LOOPBACK), dest(LOOPBACK)));
+        // Loopback peer → interface dest
+        assert!(!egress.encrypted(peer(LOOPBACK), dest(IFACE1)));
+        // Loopback peer → external dest
+        assert!(!egress.encrypted(peer(LOOPBACK), dest(EXT)));
+    }
+
+    #[test]
+    fn test_no_capture_interface_peer_always_skipped() {
+        // Peer is a known interface IP → local → skip, regardless of dest.
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        ips.insert(IFACE2);
+        let egress = egress_no_capture(ips);
+
+        // Interface peer → interface dest
+        assert!(!egress.encrypted(peer(IFACE1), dest(IFACE2)));
+        // Interface peer → loopback dest
+        assert!(!egress.encrypted(peer(IFACE1), dest(LOOPBACK)));
+        // Interface peer → external dest (the bug scenario: external-looking
+        // dest but local peer → must skip)
+        assert!(!egress.encrypted(peer(IFACE1), dest(EXT)));
+    }
+
+    #[test]
+    fn test_no_capture_external_peer_to_local_dest_is_encrypted() {
+        // The bug fix: external peer → local dest must be encrypted.
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        let egress = egress_no_capture(ips);
+
+        // External → interface dest: encrypted
+        assert!(egress.encrypted(peer(EXT), dest(IFACE1)));
+        // External → loopback dest: encrypted
+        assert!(egress.encrypted(peer(EXT), dest(LOOPBACK)));
+        // External → external dest: encrypted
+        assert!(egress.encrypted(peer(EXT), dest(EXT)));
+    }
+
+    #[test]
+    fn test_no_capture_empty_local_ips_only_loopback_is_local() {
+        // With no interface IPs in local_ips, only loopback peers are local.
+        let egress = egress_no_capture(HashSet::new());
+
+        // Loopback peer → skipped
+        assert!(!egress.encrypted(peer(LOOPBACK), dest(LOOPBACK)));
+        // Any non-loopback peer → encrypted (wildcard entry always matches)
+        assert!(egress.encrypted(peer(EXT), dest(LOOPBACK)));
+        assert!(egress.encrypted(peer(IFACE1), dest(IFACE1)));
+    }
+
+    #[test]
+    fn test_no_capture_loopback_range_coverage() {
+        // is_loopback() covers all of 127.0.0.0/8, not just 127.0.0.1.
+        let egress = egress_no_capture(HashSet::new());
+
+        assert!(!egress.encrypted(peer(Ipv4Addr::new(127, 0, 0, 1)), dest(EXT)));
+        assert!(!egress.encrypted(peer(Ipv4Addr::new(127, 0, 0, 2)), dest(EXT)));
+        assert!(!egress.encrypted(peer(Ipv4Addr::new(127, 1, 2, 3)), dest(EXT)));
+    }
+
+    #[test]
+    fn test_no_capture_external_peer_host_mismatch_still_false() {
+        // External peer passes the local-traffic gate, but host/ifname
+        // matching can still reject the connection.
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        let entry = make_entry(Ipv4Addr::new(10, 10, 10, 10), None, 5600, 9600);
         let egress = HookEgress {
             id: 0,
             entries: vec![entry],
             capture_local_traffic: false,
-            local_ips: {
-                let mut ips = HashSet::new();
-                ips.insert(Ipv4Addr::new(127, 0, 0, 1));
-                ips
-            },
+            local_ips: ips,
         };
 
-        assert!(!egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            5600
-        )));
+        // External peer passes gate, but dest doesn't match host → false
+        assert!(!egress.encrypted(peer(EXT), dest(IFACE1)));
+        // External peer passes gate, dest matches host → true
+        assert!(egress.encrypted(peer(EXT), dest(Ipv4Addr::new(10, 10, 10, 10))));
+    }
 
-        // Non-local IP should still match
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            5600
-        )));
+    // ── capture_local_traffic = true: local-traffic shortcut is disabled ─────
+    //
+    // All connections proceed to host/ifname matching, regardless of peer
+    // locality.
+
+    fn egress_capture_local(local_ips: HashSet<Ipv4Addr>) -> HookEgress {
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+        HookEgress {
+            id: 0,
+            entries: vec![entry],
+            capture_local_traffic: true,
+            local_ips,
+        }
     }
 
     #[test]
-    fn test_encrypted_local_ip_captured_when_capture_local_traffic_true() {
-        // Host = 0.0.0.0 (wildcard), capture_local_traffic = true
-        // 127.0.0.1 is local but should be captured
-        let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+    fn test_capture_local_loopback_peer_encrypted() {
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        let egress = egress_capture_local(ips);
+
+        // Loopback peer → any dest: still encrypted (wildcard entry)
+        assert!(egress.encrypted(peer(LOOPBACK), dest(LOOPBACK)));
+        assert!(egress.encrypted(peer(LOOPBACK), dest(IFACE1)));
+        assert!(egress.encrypted(peer(LOOPBACK), dest(EXT)));
+    }
+
+    #[test]
+    fn test_capture_local_interface_peer_encrypted() {
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        ips.insert(IFACE2);
+        let egress = egress_capture_local(ips);
+
+        // Interface peer → any dest: still encrypted
+        assert!(egress.encrypted(peer(IFACE1), dest(IFACE2)));
+        assert!(egress.encrypted(peer(IFACE1), dest(LOOPBACK)));
+        assert!(egress.encrypted(peer(IFACE1), dest(EXT)));
+    }
+
+    #[test]
+    fn test_capture_local_external_peer_encrypted() {
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        let egress = egress_capture_local(ips);
+
+        assert!(egress.encrypted(peer(EXT), dest(IFACE1)));
+        assert!(egress.encrypted(peer(EXT), dest(LOOPBACK)));
+    }
+
+    #[test]
+    fn test_capture_local_host_mismatch_still_rejects() {
+        // Even with capture_local_traffic = true, host/ifname matching still
+        // applies.
+        let mut ips = HashSet::new();
+        ips.insert(IFACE1);
+        let entry = make_entry(Ipv4Addr::new(10, 10, 10, 10), None, 5600, 9600);
         let egress = HookEgress {
             id: 0,
             entries: vec![entry],
             capture_local_traffic: true,
-            local_ips: {
-                let mut ips = HashSet::new();
-                ips.insert(Ipv4Addr::new(127, 0, 0, 1));
-                ips
-            },
+            local_ips: ips,
         };
 
-        assert!(egress.encrypted(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            5600
-        )));
+        // Dest doesn't match host → false (even though peer is external)
+        assert!(!egress.encrypted(peer(EXT), dest(IFACE1)));
+        // Dest matches host → true
+        assert!(egress.encrypted(peer(EXT), dest(Ipv4Addr::new(10, 10, 10, 10))));
     }
 }

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::stream::select_all;
@@ -215,7 +215,9 @@ impl EgressTrait for HookEgress {
             let addr = format!("0.0.0.0:{}", entry.origin_port);
             tracing::debug!(%addr, real_port = entry.real_port, "Hook egress: Add TCP listener on origin port");
 
-            let listener = TcpListener::bind(&addr).await?;
+            let listener = TcpListener::bind(&addr)
+                .await
+                .with_context(|| format!("Failed to bind hook egress listener on {addr}"))?;
             listener.set_listener_common_sock_opts()?;
             let local_addr = listener.local_addr()?;
 

--- a/tng/src/tunnel/egress/hook.rs
+++ b/tng/src/tunnel/egress/hook.rs
@@ -46,6 +46,11 @@ pub struct ResolvedEgressEntry {
 pub struct HookEgress {
     id: usize,
     entries: Vec<ResolvedEgressEntry>,
+    /// Whether to capture traffic where the peer IP is a local interface
+    /// address. When false, local-traffic is excluded from the tunnel.
+    capture_local_traffic: bool,
+    /// Cached set of local interface IPs.
+    local_ips: HashSet<Ipv4Addr>,
 }
 
 impl HookEgress {
@@ -90,7 +95,26 @@ impl HookEgress {
             }
         }
 
-        Self { id, entries }
+        // Collect local interface IPs for capture_local_traffic filtering.
+        let mut local_ips = HashSet::new();
+        // 127.0.0.0/8 loopback
+        for b in 0..=255u8 {
+            local_ips.insert(Ipv4Addr::new(127, b, 0, 1));
+        }
+        if let Ok(ifaces) = local_ip_address::list_afinet_netifas() {
+            for (_, addr) in ifaces {
+                if let IpAddr::V4(v4) = addr {
+                    local_ips.insert(v4);
+                }
+            }
+        }
+
+        Self {
+            id,
+            entries,
+            capture_local_traffic: hook_args.capture_local_traffic,
+            local_ips,
+        }
     }
 
     /// Check whether a connection arriving at local_addr should go through
@@ -108,6 +132,11 @@ impl HookEgress {
             IpAddr::V4(ip) => ip,
             IpAddr::V6(_) => return false,
         };
+
+        // When capture_local_traffic is false, skip if peer IP is local.
+        if !self.capture_local_traffic && self.local_ips.contains(&ip) {
+            return false;
+        }
 
         for entry in &self.entries {
             let host_match = entry.host.is_unspecified() || entry.host == ip;
@@ -255,7 +284,12 @@ mod tests {
     use super::*;
 
     fn make_egress(entries: Vec<ResolvedEgressEntry>) -> HookEgress {
-        HookEgress { id: 0, entries }
+        HookEgress {
+            id: 0,
+            entries,
+            capture_local_traffic: false,
+            local_ips: HashSet::new(),
+        }
     }
 
     fn make_entry(
@@ -388,6 +422,56 @@ mod tests {
         // No IPs to match -> nothing is encrypted
         assert!(!egress.encrypted(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            5600
+        )));
+    }
+
+    #[test]
+    fn test_encrypted_local_ip_skipped_when_capture_local_traffic_false() {
+        // Host = 0.0.0.0 (wildcard), capture_local_traffic = false
+        // 127.0.0.1 is a local IP -> should return false
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+        let egress = HookEgress {
+            id: 0,
+            entries: vec![entry],
+            capture_local_traffic: false,
+            local_ips: {
+                let mut ips = HashSet::new();
+                ips.insert(Ipv4Addr::new(127, 0, 0, 1));
+                ips
+            },
+        };
+
+        assert!(!egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            5600
+        )));
+
+        // Non-local IP should still match
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            5600
+        )));
+    }
+
+    #[test]
+    fn test_encrypted_local_ip_captured_when_capture_local_traffic_true() {
+        // Host = 0.0.0.0 (wildcard), capture_local_traffic = true
+        // 127.0.0.1 is local but should be captured
+        let entry = make_entry(Ipv4Addr::UNSPECIFIED, None, 5600, 9600);
+        let egress = HookEgress {
+            id: 0,
+            entries: vec![entry],
+            capture_local_traffic: true,
+            local_ips: {
+                let mut ips = HashSet::new();
+                ips.insert(Ipv4Addr::new(127, 0, 0, 1));
+                ips
+            },
+        };
+
+        assert!(egress.encrypted(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             5600
         )));
     }

--- a/tng/src/tunnel/egress/mapping.rs
+++ b/tng/src/tunnel/egress/mapping.rs
@@ -91,7 +91,9 @@ impl EgressTrait for MappingEgress {
                     let addr = format!("{host}:{port}");
                     tracing::debug!(%addr, "Add TCP listener");
 
-                    let listener = TcpListener::bind(&addr).await?;
+                    let listener = TcpListener::bind(&addr).await.with_context(|| {
+                        format!("Failed to bind mapping egress listener on {addr}")
+                    })?;
                     listener.set_listener_common_sock_opts()?;
                     let local_addr = listener.local_addr()?;
                     let out_ep = Arc::new(TngEndpoint::new(out_host.to_owned(), out_port));
@@ -106,7 +108,9 @@ impl EgressTrait for MappingEgress {
                 let addr = format!("{host}:{}", rule.r#in.port);
                 tracing::debug!(%addr, "Add TCP listener");
 
-                let listener = TcpListener::bind(&addr).await?;
+                let listener = TcpListener::bind(&addr)
+                    .await
+                    .with_context(|| format!("Failed to bind mapping egress listener on {addr}"))?;
                 listener.set_listener_common_sock_opts()?;
                 let local_addr = listener.local_addr()?;
                 let out_ep = Arc::new(TngEndpoint::new(out_host.to_owned(), rule.out.port));

--- a/tng/src/tunnel/egress/netfilter/mod.rs
+++ b/tng/src/tunnel/egress/netfilter/mod.rs
@@ -97,7 +97,9 @@ impl EgressTrait for NetfilterEgress {
         // Setup iptables
         let iptables_guard = IptablesExecutor::setup(self).await?;
 
-        let listener = TcpListener::bind(listen_addr).await?;
+        let listener = TcpListener::bind(&listen_addr).await.with_context(|| {
+            format!("Failed to bind netfilter egress listener on {listen_addr}")
+        })?;
         listener.set_listener_common_sock_opts()?;
 
         let listen_addr = listener.local_addr()?;

--- a/tng/src/tunnel/ingress/hook.rs
+++ b/tng/src/tunnel/ingress/hook.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -69,7 +69,11 @@ impl HookIngress {
         // before the listener is ready.
         let listen_addr_full = format!("{}:{}", listen_addr, listen_port);
         tracing::debug!(%listen_addr_full, "Add TCP listener for hook ingress");
-        let listener = TcpListener::bind(&listen_addr_full).await?;
+        let listener = TcpListener::bind(&listen_addr_full)
+            .await
+            .with_context(|| {
+                format!("Failed to bind hook ingress listener on {listen_addr_full}")
+            })?;
         listener.set_listener_common_sock_opts()?;
         let listener_addr = listener.local_addr()?;
 

--- a/tng/src/tunnel/ingress/http_proxy.rs
+++ b/tng/src/tunnel/ingress/http_proxy.rs
@@ -288,7 +288,9 @@ impl HttpProxyIngress {
         // The port is bound here at construction time.
         let listen_addr_full = format!("{}:{}", listen_addr, listen_port);
         tracing::debug!(%listen_addr_full, "Add TCP listener");
-        let std_listener = std::net::TcpListener::bind(&listen_addr_full)?;
+        let std_listener = std::net::TcpListener::bind(&listen_addr_full).with_context(|| {
+            format!("Failed to bind http_proxy ingress listener on {listen_addr_full}")
+        })?;
         std_listener
             .set_nonblocking(true)
             .context("Failed to set nonblocking on listener")?;

--- a/tng/src/tunnel/ingress/mapping.rs
+++ b/tng/src/tunnel/ingress/mapping.rs
@@ -95,7 +95,9 @@ impl IngressTrait for MappingIngress {
                     let addr = format!("{host}:{port}");
                     tracing::debug!(%addr, "Add TCP listener");
 
-                    let listener = TcpListener::bind(&addr).await?;
+                    let listener = TcpListener::bind(&addr).await.with_context(|| {
+                        format!("Failed to bind mapping ingress listener on {addr}")
+                    })?;
                     listener.set_listener_common_sock_opts()?;
                     let local_addr = listener.local_addr()?;
                     let out_ep = Arc::new(TngEndpoint::new(out_host.to_owned(), out_port));
@@ -110,7 +112,9 @@ impl IngressTrait for MappingIngress {
                 let addr = format!("{host}:{}", rule.r#in.port);
                 tracing::debug!(%addr, "Add TCP listener");
 
-                let listener = TcpListener::bind(&addr).await?;
+                let listener = TcpListener::bind(&addr).await.with_context(|| {
+                    format!("Failed to bind mapping ingress listener on {addr}")
+                })?;
                 listener.set_listener_common_sock_opts()?;
                 let local_addr = listener.local_addr()?;
                 let out_ep = Arc::new(TngEndpoint::new(out_host.to_owned(), rule.out.port));

--- a/tng/src/tunnel/ingress/netfilter/mod.rs
+++ b/tng/src/tunnel/ingress/netfilter/mod.rs
@@ -96,7 +96,9 @@ impl IngressTrait for NetfilterIngress {
         // Setup iptables
         let iptables_guard = IptablesExecutor::setup(self).await?;
 
-        let listener = TcpListener::bind(listen_addr).await?;
+        let listener = TcpListener::bind(&listen_addr).await.with_context(|| {
+            format!("Failed to bind netfilter ingress listener on {listen_addr}")
+        })?;
         listener.set_listener_common_sock_opts()?;
         listener.set_listener_tproxy_sock_opts()?;
 

--- a/tng/src/tunnel/ingress/socks5.rs
+++ b/tng/src/tunnel/ingress/socks5.rs
@@ -133,7 +133,9 @@ impl IngressTrait for Socks5Ingress {
         let listen_addr = format!("{}:{}", self.listen_addr, self.listen_port);
         tracing::debug!(%listen_addr, "Add TCP listener");
 
-        let listener = TcpListener::bind(listen_addr).await?;
+        let listener = TcpListener::bind(&listen_addr)
+            .await
+            .with_context(|| format!("Failed to bind socks5 ingress listener on {listen_addr}"))?;
         listener.set_listener_common_sock_opts()?;
 
         let listener_addr = listener.local_addr()?;


### PR DESCRIPTION
## Bug

When `capture_local_traffic=false` (the default), the egress hook `encrypted()` method checked only the **destination IP** against `local_ips` to decide whether to skip encryption. This meant traffic from an **external source** to a **local destination** would incorrectly bypass the encrypted tunnel.

### Example

```\n172.17.89.112:49014 → TNG(4600) → 172.17.89.111:24809 — encrypted=false\n```\n\nExternal peer (`172.17.89.112`) connecting to local service (`172.17.89.111`) was marked `encrypted=false` because the destination IP matched `local_ips`. The source IP was never checked.

## Root Cause

`HookEgress::encrypted(local_addr)` only received the destination address. It checked `ip.is_loopback() || self.local_ips.contains(&ip)` against the destination — which is always a local address for an accepted connection, making the check meaningless.

## Fix

- Add `peer_addr: SocketAddr` parameter to `HookEgress::encrypted()`
- Extract `peer_is_local = peer_ip.is_loopback() || local_ips.contains(&peer_ip)`
- Skip encryption **only when peer is local** AND `capture_local_traffic=false`
- The destination is always local for an accepted connection; the real question is whether the source is also local

## Tests

Rewrote unit tests with a full decision matrix (15 tests):

| `capture_local_traffic` | peer type | dest type | encrypted? |
|------------------------|-----------|-----------|------------|
| false | loopback | any | false |
| false | interface IP | any | false |
| false | external | any | true (host/ifname permitting) |
| true | loopback | any | true |
| true | interface IP | any | true |
| true | external | any | true (host/ifname permitting) |

New tests:
- `test_no_capture_loopback_peer_always_skipped` — loopback peer skipped for all dest types
- `test_no_capture_interface_peer_always_skipped` — interface peer skipped for all dest types
- `test_no_capture_external_peer_to_local_dest_is_encrypted` — the bug fix verification
- `test_no_capture_empty_local_ips_only_loopback_is_local` — only 127.0.0.0/8 when no interface IPs cached
- `test_no_capture_loopback_range_coverage` — 127.0.0.0/8 fully covered by `is_loopback()`
- `test_no_capture_external_peer_host_mismatch_still_false` — external peer passes gate but host still rejects
- `test_capture_local_loopback_peer_encrypted` — local peer encrypted when flag is true
- `test_capture_local_interface_peer_encrypted` — interface peer encrypted when flag is true
- `test_capture_local_external_peer_encrypted` — external peer encrypted when flag is true
- `test_capture_local_host_mismatch_still_rejects` — host/ifname matching still applies with flag=true