### PR TITLE
ci: add trusted publishing for npm and PyPI, remove obsolete native branch triggers, update README quick start

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'native'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - 'master'
-      - 'native'
 jobs:
   build-all:
     strategy:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'native'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - 'master'
-      - 'native'
 
 jobs:
   build:

--- a/.github/workflows/build-python-sdk.yml
+++ b/.github/workflows/build-python-sdk.yml
@@ -123,6 +123,18 @@ jobs:
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v7
 
+      - name: Collect wheels
+        run: |
+          mkdir -p dist
+          find wheel-* -name '*.whl' -exec cp {} dist/ \;
+          ls dist/
+
+      - name: Publish to PyPI
+        continue-on-error: true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/build-python-sdk.yml
+++ b/.github/workflows/build-python-sdk.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'native'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - 'master'
-      - 'native'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-python-sdk.yml
+++ b/.github/workflows/build-python-sdk.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - 'master'
       - 'native'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -129,14 +130,35 @@ jobs:
           find wheel-* -name '*.whl' -exec cp {} dist/ \;
           ls dist/
 
-      - name: Publish to PyPI
-        continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: "wheel-*/*.whl"
           generate_release_notes: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: >-
+      github.repository == 'inclavare-containers/TNG' &&
+      (
+        startsWith(github.ref, 'refs/tags/') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Collect wheels
+        run: |
+          mkdir -p dist
+          find wheel-* -name '*.whl' -exec cp {} dist/ \;
+          ls dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'native'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - 'master'
-      - 'native'
 
 jobs:
   build:

--- a/.github/workflows/build-wasm-sdk.yml
+++ b/.github/workflows/build-wasm-sdk.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - "master"
-      - "native"
     tags:
       - "v*.*.*"
   pull_request:
     branches:
       - "master"
-      - "native"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-wasm-sdk.yml
+++ b/.github/workflows/build-wasm-sdk.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - "master"
       - "native"
+  workflow_dispatch:
 
 jobs:
   build-and-release:
@@ -193,12 +194,35 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-npm:
+    name: Publish to npmjs.com
+    needs: build-and-release
+    if: >-
+      github.repository == 'inclavare-containers/TNG' &&
+      (
+        startsWith(github.ref, 'refs/tags/') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
+      - name: Download npm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
+
       - name: Publish to npmjs.com
-        if: startsWith(github.ref, 'refs/tags/')
-        continue-on-error: true
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc.publish
-          PKG=$(ls tng-wasm/pkg/*.tgz | head -1)
-          npm publish --registry=https://registry.npmjs.org/ --userconfig=~/.npmrc.publish "$PKG"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PKG=$(ls *.tgz | head -1)
+          echo "Publishing $PKG"
+          npm publish "$PKG" --provenance --access public

--- a/.github/workflows/build-wasm-sdk.yml
+++ b/.github/workflows/build-wasm-sdk.yml
@@ -185,10 +185,20 @@ jobs:
           path: |
             ./npm/*.tgz
 
-      - name: Publish NPM packages
+      - name: Publish NPM packages (GitHub Packages)
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           wasm-pack publish --target web --tag ${{ env.NPM_PKG_LABEL }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npmjs.com
+        if: startsWith(github.ref, 'refs/tags/')
+        continue-on-error: true
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc.publish
+          PKG=$(ls tng-wasm/pkg/*.tgz | head -1)
+          npm publish --registry=https://registry.npmjs.org/ --userconfig=~/.npmrc.publish "$PKG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "native"
       - "sdk-go"
     paths:
       - "tng-go/**"
@@ -15,7 +14,6 @@ on:
   pull_request:
     branches:
       - "master"
-      - "native"
       - "sdk-go"
     paths:
       - "tng-go/**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - 'master'
-      - 'native'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - 'master'
-      - 'native'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -15,12 +15,68 @@
 
 ## Quick Start
 
+TNG offers multiple integration modes — pick the one that fits your scenario.
+
+<details>
+<summary><b>Run with Docker</b> — fastest way to try TNG</summary>
+
 ```sh
-# Run TNG with a single command — just provide a JSON config
 docker run -it --rm --privileged --network host --cgroupns=host \
   ghcr.io/inclavare-containers/tng:latest \
   tng launch --config-content='<your config json>'
 ```
+
+No installation needed. Just provide a JSON config and TNG handles the rest.
+
+</details>
+
+<details>
+<summary><b>tng exec</b> — zero code changes for existing apps</summary>
+
+```sh
+# Start your existing app through TNG transparently
+tng exec --config-file config.json -- ./your-app
+```
+
+Your app talks to the backend as usual — TNG intercepts at the network layer and encrypts via remote attestation tunnel.
+
+</details>
+
+<details>
+<summary><b>JavaScript SDK</b> — browser-side encrypted requests</summary>
+
+```sh
+npm install @inclavare-containers/tng
+```
+
+```js
+import { TngClient } from '@inclavare-containers/tng';
+
+const client = new TngClient({ config: { /* your config */ } });
+const response = await client.fetch('https://your-tee-service/api/data');
+```
+
+Runs entirely in the browser via WebAssembly. No server-side proxy needed.
+
+</details>
+
+<details>
+<summary><b>Python SDK</b> — programmatic integration</summary>
+
+```sh
+pip install tng-sdk
+```
+
+```python
+from tng import TngClient
+
+client = TngClient(config={"ingress": {...}, "egress": {...}})
+response = client.request("https://your-tee-service/api/data")
+```
+
+Supports `httpx`, `requests`, and `openai` as optional backends.
+
+</details>
 
 See [Installation](#installation) for Docker, RPM, binary, and SDK options.
 
@@ -123,7 +179,7 @@ Download the pre-built binary from [Releases](https://github.com/inclavare-conta
 ### Option 4: JavaScript SDK (Browser)
 
 ```sh
-npm install tng-wasm-<version>.tgz
+npm install @inclavare-containers/tng
 ```
 
 Full SDK docs: [tng-wasm/README.md](tng-wasm/README.md)
@@ -131,7 +187,7 @@ Full SDK docs: [tng-wasm/README.md](tng-wasm/README.md)
 ### Option 5: Python SDK
 
 ```sh
-pip install tng-python
+pip install tng-sdk
 ```
 
 Full SDK docs: [tng-python/README.md](tng-python/README.md)

--- a/README_zh.md
+++ b/README_zh.md
@@ -123,7 +123,7 @@ sudo tng launch --config-file=/etc/tng/config.json
 ### 方式四：JavaScript SDK（浏览器端）
 
 ```sh
-npm install tng-wasm-<version>.tgz
+npm install @inclavare-containers/tng
 ```
 
 完整 SDK 文档：[tng-wasm/README_zh.md](tng-wasm/README_zh.md)
@@ -131,7 +131,7 @@ npm install tng-wasm-<version>.tgz
 ### 方式五：Python SDK
 
 ```sh
-pip install tng-python
+pip install tng-sdk
 ```
 
 完整 SDK 文档：[tng-python/README_zh.md](tng-python/README_zh.md)

--- a/tng-python/README.md
+++ b/tng-python/README.md
@@ -7,7 +7,7 @@ Trusted Network Gateway (TNG) Python SDK — encrypted HTTP requests with remote
 ## Quick Start
 
 ```bash
-pip install tng
+pip install tng-sdk
 ```
 
 ```python

--- a/tng-python/README_zh.md
+++ b/tng-python/README_zh.md
@@ -7,7 +7,7 @@ Trusted Network Gateway (TNG) Python SDK — 加密 HTTP 请求与远程证明�
 ## 快速开始
 
 ```bash
-pip install tng
+pip install tng-sdk
 ```
 
 ```python

--- a/tng-python/pyproject.toml
+++ b/tng-python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "tng"
+name = "tng-sdk"
 version = "2.6.0"
 description = "TNG (Trusted Network Gateway) Python SDK — encrypted HTTP requests with remote attestation"
 readme = "README.md"

--- a/tng-wasm/README.md
+++ b/tng-wasm/README.md
@@ -8,10 +8,15 @@ The TNG Client JavaScript SDK provides client functionality for use in browser e
 
 You can obtain the TNG SDK in two ways:
 
-### 1. Download from GitHub Packages
+### 1. Install a pre-built package
 
-Download the precompiled npm package directly from the GitHub Packages page:
-[https://github.com/inclavare-containers/TNG/pkgs/npm/tng](https://github.com/inclavare-containers/TNG/pkgs/npm/tng)
+Install directly from npm:
+
+```bash
+npm install @inclavare-containers/tng
+```
+
+Alternatively, download from [GitHub Packages](https://github.com/inclavare-containers/TNG/pkgs/npm/tng).
 
 ### 2. Build from Source
 
@@ -80,7 +85,7 @@ The resulting `tar.gz` file will be placed in the `./tng-wasm/pkg/` directory, w
 ### Install the SDK to Your Project
 
 ```bash
-npm install tng-<version>.tgz
+npm install @inclavare-containers/tng
 ```
 
 ### Integrate the SDK in Your HTML

--- a/tng-wasm/README_zh.md
+++ b/tng-wasm/README_zh.md
@@ -8,10 +8,15 @@ TNG Client JavaScript SDK为浏览器环境提供客户端功能，使用wasm-pa
 
 您可以通过两种方式获取 TNG SDK：
 
-### 1. 从 GitHub Packages 下载
+### 1. 安装预编译包
 
-直接从 GitHub Packages 页面下载预编译的 npm 包：
-[https://github.com/inclavare-containers/TNG/pkgs/npm/tng](https://github.com/inclavare-containers/TNG/pkgs/npm/tng)
+直接从 npm 安装：
+
+```bash
+npm install @inclavare-containers/tng
+```
+
+也可从 [GitHub Packages](https://github.com/inclavare-containers/TNG/pkgs/npm/tng) 下载。
 
 ### 2. 从源码构建
 
@@ -80,7 +85,7 @@ make wasm-pack-debug
 ### 安装 SDK 到您的项目
 
 ```bash
-npm install tng-<version>.tgz
+npm install @inclavare-containers/tng
 ```
 
 ### 在您的 HTML 中集成 SDK


### PR DESCRIPTION
## Summary

Automate publishing of JavaScript and Python SDKs to public registries (npmjs.com and PyPI) via GitHub Actions Trusted Publishing (OIDC). No long-lived tokens needed.

## Changes

### Publishing (Trusted Publishing / OIDC)
- **npm** (): New `publish-npm` job on ubuntu-latest with Node.js 20, `id-token: write` permission, `npm publish --provenance`. Triggers on tag push or manual `workflow_dispatch`.
- **PyPI** (): New `publish-pypi` job on ubuntu-latest with `id-token: write` permission, `pypa/gh-action-pypi-publish` without password (OIDC). Triggers on tag push or manual `workflow_dispatch`.

### Cleanup
- Remove obsolete `native` branch trigger from all 7 workflow files (build-binary, build-docker, build-python-sdk, build-rpm, build-wasm-sdk, go-sdk, test).

### README
- Expand Quick Start with collapsible `<details>` examples for Docker, `tng exec`, JavaScript SDK, and Python SDK
- Update Installation section with correct package names: `@inclavare-containers/tng` (npm), `tng-sdk` (PyPI)
- Rename Python SDK package from `tng` to `tng-sdk` in `pyproject.toml`

## Package Names

| Platform | Package | Install | Import |
|---|---|---|---|
| npm | `@inclavare-containers/tng` | `npm install @inclavare-containers/tng` | `import { TngClient } from '@inclavare-containers/tng'` |
| PyPI | `tng-sdk` | `pip install tng-sdk` | `import tng` |

## Trusted Publisher Setup Required

- **npm**: Add Trusted Publisher for `@inclavare-containers/tng` → Repo: `inclavare-containers/TNG`, Workflow: `Build WASM SDK`, Branch: `master`
- **PyPI**: Add Trusted Publisher for `tng-sdk` → Repo: `inclavare-containers/TNG`, Workflow: `Build Python SDK`, Branch: `master`