### PR TITLE
docs(python-sdk): improve docstrings, add context manager support, and rats-TLS examples

### DIFF
--- a/tng-python/README.md
+++ b/tng-python/README.md
@@ -55,6 +55,19 @@ tng = Tng(
 )
 ```
 
+## Encryption Protocol
+
+```python
+# OHTTP is the default
+tng = Tng(no_ra=True)
+
+# Use rats-TLS instead of OHTTP (mutually exclusive)
+tng = Tng(no_ra=True, rats_tls={"multiplex": True})
+
+# Custom OHTTP
+tng = Tng(no_ra=True, ohttp={"key": {"source": "self_generated", "rotation_interval": 300}})
+```
+
 ## Documentation
 
 - **[Getting Started](docs/getting-started.md)** — Complete installation, usage, and configuration guide

--- a/tng-python/README_zh.md
+++ b/tng-python/README_zh.md
@@ -55,6 +55,19 @@ tng = Tng(
 )
 ```
 
+## 加密协议
+
+```python
+# 默认使用 OHTTP
+tng = Tng(no_ra=True)
+
+# 使用 rats-TLS 替代 OHTTP（二者互斥）
+tng = Tng(no_ra=True, rats_tls={"multiplex": True})
+
+# 自定义 OHTTP
+tng = Tng(no_ra=True, ohttp={"key": {"source": "self_generated", "rotation_interval": 300}})
+```
+
 ## 文档
 
 - **[快速入门](docs/getting-started_zh.md)** — 完整的安装、使用和配置指南

--- a/tng-python/docs/getting-started.md
+++ b/tng-python/docs/getting-started.md
@@ -257,6 +257,8 @@ async for chunk in await async_client.chat.completions.create(
 
 The server-side TNG process must be deployed separately. Here's a minimal config:
 
+### OHTTP Server
+
 ```json
 {
   "add_egress": [{
@@ -265,6 +267,23 @@ The server-side TNG process must be deployed separately. Here's a minimal config
       "out": { "host": "backend", "port": 30001 }
     },
     "ohttp": {},
+    "no_ra": true
+  }]
+}
+```
+
+### rats-TLS Server
+
+If the client uses rats-TLS, the server must match:
+
+```json
+{
+  "add_egress": [{
+    "mapping": {
+      "in":  { "host": "0.0.0.0", "port": 10001 },
+      "out": { "host": "backend", "port": 30001 }
+    },
+    "rats_tls": {},
     "no_ra": true
   }]
 }
@@ -321,10 +340,29 @@ RUST_LOG=debug tng launch --config-file /tmp/tng_cfg_xxxxx.json
 ```python
 tng = Tng(no_ra=True)
 try:
-    # use tng
-    ...
+    session = requests.Session()
+    tng.wrap_requests(session)
+    resp = session.get("http://tng-server:10001/api/data")
+    resp.raise_for_status()
+    print(resp.json())
 finally:
     tng.close()
+```
+
+### Context Manager (Recommended)
+
+The ``Tng`` class supports the context manager protocol for automatic cleanup:
+
+```python
+import requests
+from tng import Tng
+
+with Tng(no_ra=True) as tng:
+    session = requests.Session()
+    tng.wrap_requests(session)
+    resp = session.get("http://tng-server:10001/api/data")
+    print(resp.json())
+# TNG subprocess is automatically terminated on exit
 ```
 
 ### Automatic Cleanup

--- a/tng-python/docs/getting-started_zh.md
+++ b/tng-python/docs/getting-started_zh.md
@@ -257,6 +257,8 @@ async for chunk in await async_client.chat.completions.create(
 
 服务器侧的 TNG 进程需要单独部署。最小配置示例：
 
+### OHTTP 服务器
+
 ```json
 {
   "add_egress": [{
@@ -265,6 +267,23 @@ async for chunk in await async_client.chat.completions.create(
       "out": { "host": "backend", "port": 30001 }
     },
     "ohttp": {},
+    "no_ra": true
+  }]
+}
+```
+
+### rats-TLS 服务器
+
+如果客户端使用 rats-TLS，服务器端必须匹配：
+
+```json
+{
+  "add_egress": [{
+    "mapping": {
+      "in":  { "host": "0.0.0.0", "port": 10001 },
+      "out": { "host": "backend", "port": 30001 }
+    },
+    "rats_tls": {},
     "no_ra": true
   }]
 }
@@ -321,10 +340,29 @@ RUST_LOG=debug tng launch --config-file /tmp/tng_cfg_xxxxx.json
 ```python
 tng = Tng(no_ra=True)
 try:
-    # 使用 tng
-    ...
+    session = requests.Session()
+    tng.wrap_requests(session)
+    resp = session.get("http://tng-server:10001/api/data")
+    resp.raise_for_status()
+    print(resp.json())
 finally:
     tng.close()
+```
+
+### 上下文管理器（推荐）
+
+``Tng`` 类支持上下文管理器协议，可以自动清理资源：
+
+```python
+import requests
+from tng import Tng
+
+with Tng(no_ra=True) as tng:
+    session = requests.Session()
+    tng.wrap_requests(session)
+    resp = session.get("http://tng-server:10001/api/data")
+    print(resp.json())
+# 退出 with 块时，TNG 子进程自动终止
 ```
 
 ### 自动清理

--- a/tng-python/tests/test_unit.py
+++ b/tng-python/tests/test_unit.py
@@ -358,6 +358,28 @@ class TestTngSubprocess:
         tng._cleanup()  # should not raise
 
 
+class TestContextManager:
+    """Tests for Tng context manager support."""
+
+    def test_enter_returns_self(self, mock_tng_startup):
+        """__enter__ returns the Tng instance."""
+        tng = Tng(no_ra=True)
+        assert tng.__enter__() is tng
+
+    def test_context_manager_cleanup(self, mock_tng_startup):
+        """with Tng() as tng automatically cleans up on exit."""
+        with Tng(no_ra=True) as tng:
+            assert tng._proc is not None
+        assert tng._proc is None
+
+    def test_context_manager_exception_cleanup(self, mock_tng_startup):
+        """with Tng() cleans up even when an exception is raised."""
+        with pytest.raises(ValueError):
+            with Tng(no_ra=True) as tng:
+                raise ValueError("test")
+        assert tng._proc is None
+
+
 # ---------------------------------------------------------------------------
 # Test helpers
 # ---------------------------------------------------------------------------

--- a/tng-python/tng/_tng.py
+++ b/tng-python/tng/_tng.py
@@ -39,6 +39,56 @@ class Tng:
         ohttp: dict[str, Any] | None = None,
         rats_tls: dict[str, Any] | None = None,
     ) -> None:
+        """Create and start a local TNG proxy.
+
+        Spawns the ``tng`` binary as a subprocess with an auto-configured
+        ``http_proxy`` ingress, then provides ``wrap_*`` methods that route
+        HTTP traffic through the encrypted tunnel.
+
+        Args:
+            no_ra:
+                Disable remote attestation. Set to ``True`` for local testing
+                or when the AA/AS services are unavailable.
+            verify:
+                Verifier configuration for validating the remote server's
+                attestation. Keys: ``as_addr`` (Attestation Service URL),
+                ``policy_ids`` (list of policy IDs to verify against).
+            attest:
+                Attester configuration for providing the client's own
+                attestation to the server. Keys: ``aa_addr`` (Attestation
+                Agent socket path), ``model`` (e.g. ``"passport"``),
+                ``as_addr`` (optional, for nested attestation).
+            ohttp:
+                OHTTP configuration dict. Omitted keys use defaults.
+                Common keys: ``key`` (``{"source": "self_generated",
+                "rotation_interval": 300}``), ``path_rewrites``.
+            rats_tls:
+                rats-TLS configuration dict as an alternative to OHTTP.
+                Common keys: ``multiplex`` (enable connection multiplexing).
+
+        Raises:
+            ValueError: If both ``ohttp`` and ``rats_tls`` are provided
+                (they are mutually exclusive).
+            FileNotFoundError: If the ``tng`` binary cannot be found.
+            RuntimeError: If the TNG process fails to start.
+            TimeoutError: If the proxy port is not ready within 30 seconds.
+
+        Example::
+
+            # Simplest: no remote attestation
+            tng = Tng(no_ra=True)
+
+            # With server verification
+            tng = Tng(verify={"as_addr": "http://127.0.0.1:8080/", "policy_ids": ["default"]})
+
+            # Using rats-TLS instead of OHTTP
+            tng = Tng(no_ra=True, rats_tls={"multiplex": True})
+
+            # Context manager for automatic cleanup
+            with Tng(no_ra=True) as tng:
+                tng.wrap_requests(session)
+                resp = session.get("http://server:10001/api/data")
+        """
         # Validate mutual exclusivity: ohttp and rats_tls conflict
         if ohttp is not None and rats_tls is not None:
             raise ValueError("ohttp and rats_tls are mutually exclusive")
@@ -200,6 +250,12 @@ class Tng:
 
         Safe to call multiple times.
         """
+        self._cleanup()
+
+    def __enter__(self) -> "Tng":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self._cleanup()
 
 


### PR DESCRIPTION
## Summary

Improves the Python SDK documentation and developer experience.

### Changes

**Docstrings**
- Added comprehensive docstring to `Tng.__init__` with full Args, Raises, and Example sections covering all parameters (`no_ra`, `verify`, `attest`, `ohttp`, `rats_tls`)

**Context Manager Support**
- Added `__enter__`/`__exit__` to the `Tng` class, enabling idiomatic Python usage:
  ```python
  with Tng(no_ra=True) as tng:
      tng.wrap_requests(session)
      resp = session.get("http://server:10001/api/data")
  # TNG subprocess automatically terminated on exit
  ```

**Documentation Updates**
- Added rats-TLS server deployment config example (getting-started en/zh)
- Added context manager usage examples (getting-started en/zh)
- Added error handling examples with try/finally pattern
- Updated README and README_zh with encryption protocol section showing OHTTP, rats-TLS, and custom OHTTP options

**Tests**
- Added 3 unit tests for context manager: `__enter__` returns self, cleanup on normal exit, cleanup on exception