### PR TITLE
refactor(rats-cert): simplify CoCo token verifier error chain

### DIFF
--- a/rats-cert/src/errors.rs
+++ b/rats-cert/src/errors.rs
@@ -90,7 +90,7 @@ pub enum Error {
     ConnectAttestationAgentTtrpcFailed(#[source] ttrpc::Error),
 
     #[error("Coco token verifier error")]
-    CocoTokenVerifierError(#[source] crate::tee::coco::verifier::token::Error),
+    CocoTokenVerifierError(#[source] anyhow::Error),
 
     #[error("Signer transparency verification failed: {detail}")]
     SignerTransparencyVerificationFailed { detail: String },

--- a/rats-cert/src/tee/coco/verifier/common.rs
+++ b/rats-cert/src/tee/coco/verifier/common.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use std::collections::{HashMap, HashSet};
 
-use super::token::{AttestationTokenVerifierConfig, TokenVerifier};
+use super::token::{AttestationTokenVerifierConfig, TokenError, TokenVerifier};
 
 pub(super) struct CommonCocoVerifier {
     /// The token verifier used to validate JWT.
@@ -35,7 +35,11 @@ impl CommonCocoVerifier {
             .token_verifier
             .verify(token.to_string())
             .await
-            .map_err(Error::CocoTokenVerifierError)?;
+            .map_err(|e| match e {
+                TokenError::TokenVerificationFailed { source } => {
+                    Error::CocoTokenVerifierError(source)
+                }
+            })?;
 
         let is_ear = if let Some(eat_profile) = claims_value.get("eat_profile") {
             if eat_profile != "tag:github.com,2024:confidential-containers/Trustee" {

--- a/rats-cert/src/tee/coco/verifier/token/error.rs
+++ b/rats-cert/src/tee/coco/verifier/token/error.rs
@@ -14,10 +14,4 @@ pub enum Error {
         #[source]
         source: anyhow::Error,
     },
-
-    #[error("Failed to initialize Token Verifier")]
-    TokenVerifierInitialization {
-        #[source]
-        source: anyhow::Error,
-    },
 }

--- a/rats-cert/src/tee/coco/verifier/token/jwk.rs
+++ b/rats-cert/src/tee/coco/verifier/token/jwk.rs
@@ -187,7 +187,9 @@ impl JwkAttestationTokenVerifier {
             if let Some(as_addr) = &config.as_addr {
                 let certs = Self::fetch_certs_from_as(&client, as_addr, &config.as_headers)
                     .await
-                    .context("Failed to fetch certificates from AS")?;
+                    .with_context(|| {
+                        format!("Failed to fetch certificates from AS at {as_addr}")
+                    })?;
                 trusted_certs.extend(certs);
             }
 
@@ -258,8 +260,7 @@ impl JwkAttestationTokenVerifier {
                 .get(&url)
                 .headers(headers)
                 .send()
-                .await
-                .with_context(|| format!("Failed to fetch certificates chain from {}", url))?
+                .await?
                 .error_for_status()
                 .with_context(|| format!("HTTP error when fetching certificates from {}", url))?;
 

--- a/rats-cert/src/tee/coco/verifier/token/mod.rs
+++ b/rats-cert/src/tee/coco/verifier/token/mod.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 
 mod error;
 pub(crate) mod jwk;
+pub use error::Error as TokenError;
 pub use error::*;
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
@@ -72,10 +73,8 @@ impl TokenVerifier {
             .map_err(|e| Error::TokenVerificationFailed { source: e })
     }
 
-    pub async fn from_config(config: AttestationTokenVerifierConfig) -> Result<Self> {
-        let verifier = JwkAttestationTokenVerifier::new(&config)
-            .await
-            .map_err(|e| Error::TokenVerifierInitialization { source: e })?;
+    pub async fn from_config(config: AttestationTokenVerifierConfig) -> anyhow::Result<Self> {
+        let verifier = JwkAttestationTokenVerifier::new(&config).await?;
 
         Ok(Self { verifier })
     }


### PR DESCRIPTION
Remove redundant error wrapper layers in the CoCo token verifier initialization path, reducing the error chain from 7 layers to 5 with no duplicate information.

## Changes

- **Delete** `TokenVerifierInitialization` enum variant — it duplicated the "Failed to fetch certificates from AS" message without adding information
- **Change** `TokenVerifier::from_config` to return `anyhow::Result` directly instead of wrapping into a custom error
- **Change** `CocoTokenVerifierError` to wrap `anyhow::Error` instead of `token::Error`
- **Add** AS address to the context message in "Failed to fetch certificates from AS"
- **Remove** duplicate "fetch certificates chain from URL" context layer that repeated the URL already provided by the reqwest error message

## Before

```
0: Failed to initialize Token Verifier                              ← duplicate of layer 1
1: Failed to fetch certificates from AS                             ← no address
2: Failed to fetch certificates chain from http://...               ← duplicate, URL already in reqwest
3: error sending request for url (...)                              ← reqwest
4: client error (Connect)
5: tcp connect error: deadline has elapsed
6: deadline has elapsed
```

## After

```
0: Failed to fetch certificates from AS at 8.130.97.127:8081       ← action + address
1: error sending request for url (...)                              ← reqwest (preserved)
2: client error (Connect)                                           ← reqwest (preserved)
3: tcp connect error: deadline has elapsed                          ← root cause
4: deadline has elapsed                                             ← tokio internal (unchanged)
```

Every layer now carries new information.