### PR TITLE
fix(python-sdk): correct wheel platform tagging and build paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,17 +514,12 @@ bench-multiplex:
 	TNG_MULTIPLEX=true bash ./scripts/bench.sh
 
 # Python wheel build for current platform
-# Requires: Rust toolchain, maturin (pip install maturin)
+# Requires: Rust toolchain and hatch (installed automatically if missing)
 # Builds tng binary for current platform, embeds it in Python wheel
-# Usage: make python-wheel [PYTHON=python3.11]
-PYTHON ?= python3.11
+# Usage: make python-wheel
 
 .PHONY: python-wheel
 python-wheel:
-	@if ! command -v maturin > /dev/null; then \
-		echo ">> maturin not found. Installing..."; \
-		pip install maturin; \
-	fi
 	@echo ">> Building tng binary for current platform..."
 	cargo build --release -p tng
 	@echo ">> Copying tng binary to tng-python/bin/scripts/"
@@ -544,7 +539,7 @@ python-wheel:
 .PHONY: python-wheel-install
 python-wheel-install: python-wheel
 	@echo ">> Installing Python wheel..."
-	pip install --force-reinstall target/wheels/*.whl
+	pip install --force-reinstall tng-python/dist/*.whl
 	@echo ">> Python wheel installed successfully!"
 
 # Run Python tests

--- a/tng-python/docs/getting-started.md
+++ b/tng-python/docs/getting-started.md
@@ -13,27 +13,31 @@ pip install tng-sdk
 Download the appropriate wheel for your platform from [GitHub Releases](https://github.com/inclavare-containers/TNG/releases):
 
 ```bash
-pip install tng_sdk-<version>-<platform>.whl
+pip install tng_sdk-<version>-py3-none-<platform>.whl
 ```
 
-Available platforms:
-- `x86_64-unknown-linux-gnu` (Linux x86_64)
-- `aarch64-unknown-linux-gnu` (Linux ARM64)
-- `x86_64-apple-darwin` (macOS Intel)
-- `aarch64-apple-darwin` (macOS Apple Silicon)
+Available platforms (the `<platform>` part of the filename):
+- `manylinux_2_17_x86_64` (Linux x86_64)
+- `manylinux_2_17_aarch64` (Linux ARM64)
+- `macosx_11_0_x86_64` (macOS Intel)
+- `macosx_11_0_arm64` (macOS Apple Silicon)
+- `win_amd64` (Windows x86_64)
+
+> `pip install tng-sdk` from PyPI selects the correct platform wheel automatically.
 
 ### From Source
 
-Requires Rust toolchain and maturin:
+Requires a Rust toolchain; `hatch` is installed automatically if missing.
 
 ```bash
-# Build the tng binary
-cargo build --release -p tng
-cp target/release/tng tng-python/bin/scripts/tng
+# From the repo root — builds the tng binary, the wheel, and installs it
+make python-wheel-install
+```
 
-# Build and install the Python SDK
-cd tng-python
-maturin develop
+To build the wheel without installing:
+
+```bash
+make python-wheel   # leaves the wheel at tng-python/dist/
 ```
 
 ### TNG Binary Requirement

--- a/tng-python/docs/getting-started_zh.md
+++ b/tng-python/docs/getting-started_zh.md
@@ -13,27 +13,31 @@ pip install tng-sdk
 从 [GitHub Releases](https://github.com/inclavare-containers/TNG/releases) 下载对应平台的 wheel：
 
 ```bash
-pip install tng_sdk-<version>-<platform>.whl
+pip install tng_sdk-<version>-py3-none-<platform>.whl
 ```
 
-支持的平台：
-- `x86_64-unknown-linux-gnu` (Linux x86_64)
-- `aarch64-unknown-linux-gnu` (Linux ARM64)
-- `x86_64-apple-darwin` (macOS Intel)
-- `aarch64-apple-darwin` (macOS Apple Silicon)
+支持的平台（即文件名中的 `<platform>` 部分）：
+- `manylinux_2_17_x86_64`（Linux x86_64）
+- `manylinux_2_17_aarch64`（Linux ARM64）
+- `macosx_11_0_x86_64`（macOS Intel）
+- `macosx_11_0_arm64`（macOS Apple Silicon）
+- `win_amd64`（Windows x86_64）
+
+> 使用 `pip install tng-sdk` 从 PyPI 安装时会自动选择对应平台的 wheel。
 
 ### 从源码构建
 
-需要 Rust 工具链和 maturin：
+需要 Rust 工具链；若未安装 `hatch`，将自动安装。
 
 ```bash
-# 编译 tng 二进制
-cargo build --release -p tng
-cp target/release/tng tng-python/bin/scripts/tng
+# 在仓库根目录执行 —— 编译 tng 二进制、构建 wheel 并安装
+make python-wheel-install
+```
 
-# 构建并安装 Python SDK
-cd tng-python
-maturin develop
+仅构建 wheel 而不安装：
+
+```bash
+make python-wheel   # 产物位于 tng-python/dist/
 ```
 
 ### TNG 二进制要求

--- a/tng-python/hatch_build.py
+++ b/tng-python/hatch_build.py
@@ -1,18 +1,25 @@
-"""Hatch build hook: pin the wheel platform tag from TNG_WHEEL_TAG.
+"""Hatch build hook: pin the wheel platform tag.
 
 The wheel bundles a pre-built, platform-specific `tng` binary, so it cannot
 use hatchling's default pure-python tag `py3-none-any`. With the default tag,
-every platform's wheel would share a single filename (`tng_sdk-<ver>-py3-none-any.whl`)
-and overwrite each other when the release job collects them into one dist/ —
-leaving PyPI with only one wheel instead of five.
+every platform's wheel would share a single filename
+(`tng_sdk-<ver>-py3-none-any.whl`) and overwrite each other when the release
+job collects them into one dist/ — leaving PyPI with only one wheel instead of
+five.
 
-CI sets TNG_WHEEL_TAG per matrix target, e.g. `py3-none-manylinux_2_17_x86_64`.
-This hook writes it into build_data["tag"], which hatchling uses for both the
-wheel filename and the `Tag` line in the WHEEL file.
+Tag selection:
+  * CI cross-compile builds set TNG_WHEEL_TAG explicitly per matrix target
+    (e.g. `py3-none-manylinux_2_17_x86_64`), because the binary's target
+    platform differs from the runner's host platform.
+  * Local builds (e.g. `make python-wheel`, which builds for the host) leave
+    TNG_WHEEL_TAG unset, so we infer a host platform tag from
+    `packaging.tags.sys_tags()`. This yields an honest tag for the host
+    (manylinux_<glibc>_<arch> / macosx_<ver>_<arch> / win_<arch>) and still
+    differs from py3-none-any so local wheels no longer masquerade as
+    platform-agnostic.
 
-When TNG_WHEEL_TAG is unset (local `hatch build`), the hook is a no-op and
-hatchling falls back to its default tag — convenient for development, since a
-local wheel only needs to run on the host.
+build_data["tag"] drives both the wheel filename and the `Tag` line in the
+WHEEL file.
 """
 
 import os
@@ -20,13 +27,22 @@ import os
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
+def _infer_host_platform_tag() -> str:
+    """Return a `py3-none-<platform>` tag for the current host."""
+    from packaging.tags import sys_tags
+
+    for tag in sys_tags():
+        if tag.platform and tag.platform != "any":
+            return f"py3-none-{tag.platform}"
+    return "py3-none-any"
+
+
 class WheelTagHook(BuildHookInterface):
-    """Pin the wheel tag from the TNG_WHEEL_TAG environment variable."""
+    """Pin the wheel tag from TNG_WHEEL_TAG, else infer it for the host."""
 
     PLUGIN_NAME = "wheel-tag"
 
     def initialize(self, version, build_data):
-        tag = os.environ.get("TNG_WHEEL_TAG")
-        if tag:
-            build_data["tag"] = tag
-            build_data["infer_tag"] = False
+        tag = os.environ.get("TNG_WHEEL_TAG") or _infer_host_platform_tag()
+        build_data["tag"] = tag
+        build_data["infer_tag"] = False


### PR DESCRIPTION
## Summary

Fixes the Python SDK wheel build so platform-tagged wheels build and install correctly on the host.

- `hatch_build.py`: infer the host platform tag for local wheel builds instead of relying on maturin leftovers, so wheels are tagged per-platform and all five ship to PyPI.
- `Makefile`: fix the `python-wheel-install` path and remove maturin leftovers.
- `tng-python/docs/getting-started.md` and `getting-started_zh.md`: align docs with the corrected build flow.

## Commits

- \`9dac1b4\` fix(python-sdk): infer host platform tag for local wheel builds
- \`f193d25\` docs(python-sdk): remove maturin leftovers, fix make python-wheel-install path