### PR TITLE
fix(go-sdk): preserve request path when forwarding through TNG http_proxy

### DIFF
--- a/tng-go/client.go
+++ b/tng-go/client.go
@@ -147,5 +147,8 @@ func (t *TngRoundTripper) Close() error {
 	if t.closed.Swap(true) {
 		return nil
 	}
+	// Release idle connections to the local proxy before killing the
+	// subprocess that owns them.
+	t.transport.Close()
 	return t.proc.Close()
 }

--- a/tng-go/transport.go
+++ b/tng-go/transport.go
@@ -8,23 +8,42 @@ import (
 // Transport implements http.RoundTripper by forwarding requests
 // to a local TNG http_proxy instance.
 //
-// The TNG proxy reads the Host header to determine the backend
+// TNG is used as a standard forward HTTP proxy: the client emits the request
+// with the absolute target URI in the request line
+// (e.g. `POST http://target/path HTTP/1.1`) and the Host header set to the
+// target host. TNG reads that absolute URI to determine the backend
 // destination and applies OHTTP (or rats-TLS) encryption transparently.
+//
+// Forwarding is delegated to net/http's built-in proxy support via
+// http.Transport.Proxy, which emits exactly that absolute-URI request form —
+// the same form curl uses when given `all_proxy`. This preserves the request
+// path/query and reuses a single underlying *http.Transport so connections
+// are pooled.
 type Transport struct {
 	proxyURL *url.URL
-	// fallback transport for non-TNG URLs (optional)
+	// fallback transport for non-TNG URLs (optional). When set together with
+	// match, requests for which match(url) returns true bypass TNG and use
+	// fallback instead.
 	fallback http.RoundTripper
-	// match function: return true to use fallback for this URL
-	match func(*url.URL) bool
+	match    func(*url.URL) bool
+	// base carries the actual proxying. Its Proxy field returns proxyURL so
+	// net/http emits absolute-URI request lines to the local TNG ingress.
+	base *http.Transport
 }
 
 // NewTransport creates a Transport that forwards requests to the
 // TNG http_proxy at the given URL.
 func NewTransport(proxyURL *url.URL) *Transport {
-	return &Transport{
+	t := &Transport{
 		proxyURL: proxyURL,
 		fallback: http.DefaultTransport,
 	}
+	// Start from a clone of DefaultTransport (sensible timeouts, TLS config)
+	// and only override the proxy selector.
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.Proxy = http.ProxyURL(proxyURL)
+	t.base = tr
+	return t
 }
 
 // WithFallback sets a fallback transport for URLs matching the predicate.
@@ -38,24 +57,21 @@ func (t *Transport) WithFallback(rt http.RoundTripper, match func(*url.URL) bool
 
 // RoundTrip implements http.RoundTripper.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Check if this URL should bypass TNG
+	// Bypass TNG for URLs the caller opted out of.
 	if t.match != nil && t.match(req.URL) {
 		return t.fallback.RoundTrip(req)
 	}
+	// Otherwise let net/http forward to the TNG http_proxy with an
+	// absolute-URI request line (path/query preserved).
+	return t.base.RoundTrip(req)
+}
 
-	// Forward to TNG http_proxy.
-	//
-	// The http_proxy ingress expects standard HTTP requests:
-	// - The RequestURI field carries the full target URL
-	// - The Host header determines the backend destination
-	// - TNG handles OHTTP encryption transparently
-	proxyReq := req.Clone(req.Context())
-	proxyReq.URL = t.proxyURL
-	proxyReq.Host = req.URL.Host
-	proxyReq.RequestURI = req.URL.String()
-
-	// Use the default transport to send the request to the local proxy
-	return http.DefaultTransport.(*http.Transport).Clone().RoundTrip(proxyReq)
+// Close releases idle connections held by the underlying transport. It is
+// safe to call multiple times.
+func (t *Transport) Close() {
+	if t.base != nil {
+		t.base.CloseIdleConnections()
+	}
 }
 
 // ProxyURL returns the proxy URL this transport forwards to.

--- a/tng-go/transport_test.go
+++ b/tng-go/transport_test.go
@@ -70,42 +70,62 @@ func TestTransport_RoundTrip_Fallback(t *testing.T) {
 }
 
 func TestTransport_RoundTrip_NoFallback(t *testing.T) {
-	proxyURL, err := url.Parse("http://127.0.0.1:9999")
+	// Regression guard for the path-loss bug: a hand-rolled clone that set
+	// `proxyReq.URL = t.proxyURL` made net/http emit `POST /` (the proxy
+	// URL's path) as the request line, dropping the target path. The TNG
+	// ingress then derived the OHTTP key URL from `/` and forwarded `/` to
+	// the backend, 404'ing on backends that serve keys/content at a real path
+	// (e.g. PAI-EAS /api/predict/<svc>).
+	//
+	// We stand up a fake forward proxy and assert the request line carries the
+	// full absolute target URI (path + query preserved) and the Host header
+	// is the target host.
+	var gotRequestURI, gotHost string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequestURI = r.RequestURI
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
 	if err != nil {
 		t.Fatalf("unexpected error parsing proxy URL: %v", err)
 	}
 
-	NewTransport(proxyURL)
-	// No fallback set, so all requests should go through TNG path
+	tr := NewTransport(proxyURL)
+	// No fallback set, so the request must go through the proxy.
 
-	// We can't easily test the full TNG flow without a real proxy,
-	// but we can verify the match logic by checking that non-matching
-	// URLs do NOT use the fallback. Since no fallback is configured,
-	// the request would fail when trying to connect to the proxy.
-	// Instead, verify the internal state: match should be nil or not match.
-
-	targetURL, _ := url.Parse("https://example.com/test")
-	req, err := http.NewRequest("GET", targetURL.String(), nil)
+	// Use a non-resolvable target host: the proxy receives the absolute URI
+	// and does not connect onward, so no DNS is required.
+	req, err := http.NewRequest(http.MethodPost,
+		"http://target.example.com/api/predict/svc/v1/completions?foo=bar", nil)
 	if err != nil {
 		t.Fatalf("unexpected error creating request: %v", err)
 	}
 
-	// Clone the request and simulate what RoundTrip does internally
-	clonedReq := req.Clone(req.Context())
-	clonedReq.URL = proxyURL
-	clonedReq.Host = req.URL.Host
-	clonedReq.RequestURI = req.URL.String()
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error from RoundTrip: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
 
-	// Verify the clone was set up correctly for TNG forwarding
-	if clonedReq.URL.String() != proxyURL.String() {
-		t.Errorf("expected cloned URL %q, got %q", proxyURL.String(), clonedReq.URL.String())
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, resp.StatusCode)
 	}
-	if clonedReq.Host != targetURL.Host {
-		t.Errorf("expected cloned Host %q, got %q", targetURL.Host, clonedReq.Host)
+
+	wantURI := "http://target.example.com/api/predict/svc/v1/completions?foo=bar"
+	if gotRequestURI != wantURI {
+		t.Errorf("request line target URI = %q, want %q (path/query must be preserved)",
+			gotRequestURI, wantURI)
 	}
-	if clonedReq.RequestURI != targetURL.String() {
-		t.Errorf("expected cloned RequestURI %q, got %q", targetURL.String(), clonedReq.RequestURI)
+	if gotHost != "target.example.com" {
+		t.Errorf("Host header = %q, want target.example.com", gotHost)
 	}
+
+	// Closing must not panic and must release idle connections.
+	tr.Close()
 }
 
 func TestTransport_WithFallback(t *testing.T) {


### PR DESCRIPTION
## Problem

`Transport.RoundTrip` in the Go SDK replaced the request URL with the proxy URL and set `RequestURI` manually. But `net/http` derives the request line from `URL.RequestURI()` and **ignores `RequestURI` on client requests**, so the TNG ingress received `POST /` — dropping the target path entirely. Both the OHTTP key fetch and the inner forwarded request lost the path, 404'ing on backends that serve keys/content at a real path (e.g. PAI-EAS `/api/predict/<service>`).

The old code also cloned `http.DefaultTransport` per request, defeating connection pooling.

## Fix

Rewrite `Transport` to wrap a single `*http.Transport` with `Proxy: http.ProxyURL(proxyURL)`. `net/http` then emits the **absolute-URI** request line (`POST http://target/path HTTP/1.1`) that the TNG `http_proxy` ingress expects — the same form `curl` uses with `all_proxy` — preserving path/query and pooling connections.

- Add `Transport.Close()` to release idle connections, called from `TngRoundTripper.Close()`.
- Replace the clone-behavior unit test with a fake-forward-proxy regression test that asserts the absolute-URI request line and path preservation.

## Files

- `tng-go/client.go` — call `Transport.Close()` on shutdown.
- `tng-go/transport.go` — rewrite `Transport` around a pooled `*http.Transport` with `Proxy: http.ProxyURL`.
- `tng-go/transport_test.go` — regression test against a fake forward proxy.

## Verification

- `go test ./...` in `tng-go/` — the new fake-forward-proxy regression test asserts the absolute-URI request line and that the target path is preserved end-to-end.
- Manually validated against a PAI-EAS backend where the previous code 404'd on `/api/predict/<service>`.