### PR TITLE
feat(ohttp): add path_default option to control outer POST path fallback

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1526,6 +1526,7 @@ Enable OHTTP in `add_ingress` by specifying the `ohttp` field.
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `path_rewrites` | array [[PathRewrite](#pathrewrite)] | `[]` | Path rewrite rule list, matched in order |
+| `path_default` | string | `"root"` | Fallback outer path when no `path_rewrites` rule matches (unset/empty/no match). `"root"` → `/`; `"original"` → the inner request's original path |
 
 #### PathRewrite
 
@@ -1570,7 +1571,7 @@ Enable OHTTP in `add_ingress` by specifying the `ohttp` field.
 OHTTP-encrypted HTTP requests follow these rules for compatibility with L7 load balancers:
 
 1. Method is unified as `POST`
-2. Path defaults to `/`, can be rewritten via `path_rewrites`
+2. Path defaults to `/` (`path_default: "root"`); set `path_default: "original"` to preserve the inner request's path. Can additionally be rewritten via `path_rewrites`
 3. Host (or `:authority`) remains consistent with the inner business request
 4. `Content-Type` is `message/ohttp-chunked-req` for requests and `message/ohttp-chunked-res` for responses
 5. Does not include the original request and response headers of the encrypted request

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -1538,6 +1538,7 @@ OHTTP (Oblivious HTTP) 是一种旨在增强隐私保护的网络协议扩展，
 | 字段 | 类型 | 默认 | 说明 |
 |---|---|---|---|
 | `path_rewrites` | array [[PathRewrite](#pathrewrite)] | `[]` | Path 重写规则列表，按顺序匹配 |
+| `path_default` | string | `"root"` | 当没有 `path_rewrites` 规则命中（未设置/为空/未匹配）时的外层路径回退值。`"root"` → `/`；`"original"` → 内层请求的原始 path |
 
 #### PathRewrite
 
@@ -1582,7 +1583,7 @@ OHTTP (Oblivious HTTP) 是一种旨在增强隐私保护的网络协议扩展，
 OHTTP 加密后的 HTTP 请求遵循以下规则，以便与 L7 负载均衡器配合使用：
 
 1. Method 统一为 `POST`
-2. Path 默认为 `/`，可通过 `path_rewrites` 重写
+2. Path 默认为 `/`（`path_default: "root"`）；设置 `path_default: "original"` 可保留内层请求的原始 path。还可通过 `path_rewrites` 进一步重写
 3. Host（或 `:authority`）与内层业务请求保持一致
 4. `Content-Type` 分别为 `message/ohttp-chunked-req` 和 `message/ohttp-chunked-res`
 5. 不包含被加密请求的原始请求头和响应头

--- a/tng-python/tng/_tng.py
+++ b/tng-python/tng/_tng.py
@@ -61,7 +61,10 @@ class Tng:
             ohttp:
                 OHTTP configuration dict. Omitted keys use defaults.
                 Common keys: ``key`` (``{"source": "self_generated",
-                "rotation_interval": 300}``), ``path_rewrites``.
+                "rotation_interval": 300}``), ``path_rewrites``,
+                ``path_default`` (``"root"`` default, or ``"original"`` to
+                use the inner request's original path as the outer OHTTP POST
+                path when no ``path_rewrites`` rule matches).
             rats_tls:
                 rats-TLS configuration dict as an alternative to OHTTP.
                 Common keys: ``multiplex`` (enable connection multiplexing).

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -162,6 +162,10 @@ name = "header_passthrough"
 path = "tests/ohttp/header_passthrough.rs"
 
 [[test]]
+name = "ohttp_path_default"
+path = "tests/ohttp/ohttp_path_default.rs"
+
+[[test]]
 name = "server_netfilter"
 path = "tests/netfilter/server_netfilter.rs"
 

--- a/tng-testsuite/tests/ohttp/ohttp_path_default.rs
+++ b/tng-testsuite/tests/ohttp/ohttp_path_default.rs
@@ -1,0 +1,147 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, tng::TngInstance, Task as _},
+};
+
+/// With `path_default: "original"` and no `path_rewrites`, the outer OHTTP
+/// POST path equals the inner request's original path (`/foo/bar/www`). The
+/// LoadBalancer matches that path and forwards; the upstream HttpServer
+/// receives the decrypted inner request unchanged. If the implementation
+/// wrongly fell back to `/`, the LoadBalancer would 404 and this test fails.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ohttp_path_default_original() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "mapping": {
+                            "in": { "host": "0.0.0.0", "port": 20001 },
+                            "out": { "host": "127.0.0.1", "port": 30001 }
+                        },
+                        "ohttp": {},
+                        "no_ra": true
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": { "host": "0.0.0.0", "port": 10001 },
+                            "out": { "host": "192.168.1.252", "port": 20001 }
+                        },
+                        "ohttp": {
+                            "path_default": "original"
+                        },
+                        "no_ra": true
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        // LoadBalancer sits on the ingress->egress wire and observes the OUTER path.
+        // path_default "original" => outer path = "/foo/bar/www" (matches).
+        AppType::LoadBalancer {
+            listen_port: 20001,
+            upstream_servers: vec![("192.168.1.1".into(), 20001)],
+            path_matcher: r"^/foo/bar/www$",
+            rewrite_to: r"/foo/bar/www",
+        }
+        .boxed(),
+        AppType::HttpServer {
+            port: 30001,
+            expected_host_header: "example.com",
+            expected_path_and_query: "/foo/bar/www?type=1&case=1",
+        }
+        .boxed(),
+        AppType::HttpClient {
+            host: "127.0.0.1",
+            port: 10001,
+            host_header: "example.com",
+            path_and_query: "/foo/bar/www?type=1&case=1",
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// With `path_default` unset (default "root"), the outer OHTTP POST path is
+/// `/`. The LoadBalancer matches `^/$` and forwards. This pins the default
+/// behavior so a future regression that changes the fallback is caught.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ohttp_path_default_root_default() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "mapping": {
+                            "in": { "host": "0.0.0.0", "port": 20001 },
+                            "out": { "host": "127.0.0.1", "port": 30001 }
+                        },
+                        "ohttp": {},
+                        "no_ra": true
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+            {
+                "add_ingress": [
+                    {
+                        "mapping": {
+                            "in": { "host": "0.0.0.0", "port": 10001 },
+                            "out": { "host": "192.168.1.252", "port": 20001 }
+                        },
+                        "ohttp": {},
+                        "no_ra": true
+                    }
+                ]
+            }
+            "#,
+        )
+        .boxed(),
+        // Outer path is "/" (default root). The matcher requires exactly "/".
+        AppType::LoadBalancer {
+            listen_port: 20001,
+            upstream_servers: vec![("192.168.1.1".into(), 20001)],
+            path_matcher: r"^/$",
+            rewrite_to: r"/",
+        }
+        .boxed(),
+        AppType::HttpServer {
+            port: 30001,
+            expected_host_header: "example.com",
+            expected_path_and_query: "/foo/bar/www?type=1&case=1",
+        }
+        .boxed(),
+        AppType::HttpClient {
+            host: "127.0.0.1",
+            port: 10001,
+            host_header: "example.com",
+            path_and_query: "/foo/bar/www?type=1&case=1",
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng/src/config/ingress.rs
+++ b/tng/src/config/ingress.rs
@@ -313,11 +313,30 @@ pub struct Socks5AuthArgs {
     pub password: String,
 }
 
+/// Fallback outer OHTTP POST path used when no `path_rewrites` rule matches
+/// (including when `path_rewrites` is unset or empty).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub enum PathDefault {
+    /// Outer path = `/` (the historical default behavior).
+    #[default]
+    #[serde(rename = "root")]
+    Root,
+    /// Outer path = the inner request's original path.
+    #[serde(rename = "original")]
+    Original,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct OHttpArgs {
     #[serde(default)]
     pub path_rewrites: Vec<PathRewrite>,
+
+    /// Fallback outer path when no `path_rewrite` rule matches
+    /// (including when `path_rewrites` is unset/empty). Defaults to `Root`
+    /// (outer path `/`), preserving pre-2.8 behavior.
+    #[serde(default)]
+    pub path_default: PathDefault,
 
     /// Controls which headers from the downstream request are copied to the
     /// outer OHTTP POST request.
@@ -383,6 +402,7 @@ mod tests {
 
     use super::{
         AddIngressArgs, IngressMode, IngressNetfilterCaptureDst, IngressNetfilterCaptureDstArgs,
+        OHttpArgs, PathDefault,
     };
 
     #[test]
@@ -1016,5 +1036,44 @@ mod tests {
             _ => panic!("expected hook mode"),
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_ohttp_path_default_omitted_is_root() -> Result<()> {
+        let args: OHttpArgs = serde_json::from_str(r#"{}"#)?;
+        assert_eq!(args.path_default, PathDefault::Root);
+        assert!(args.path_rewrites.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_ohttp_path_default_original() -> Result<()> {
+        let args: OHttpArgs = serde_json::from_str(r#"{"path_default": "original"}"#)?;
+        assert_eq!(args.path_default, PathDefault::Original);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ohttp_path_default_root_explicit() -> Result<()> {
+        let args: OHttpArgs = serde_json::from_str(r#"{"path_default": "root"}"#)?;
+        assert_eq!(args.path_default, PathDefault::Root);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ohttp_path_default_unknown_value_errors() {
+        let result: anyhow::Result<OHttpArgs> =
+            serde_json::from_str(r#"{"path_default": "absolute"}"#).map_err(Into::into);
+        assert!(
+            result.is_err(),
+            "unknown path_default value must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_ohttp_path_default_typo_rejected_by_deny_unknown_fields() {
+        let result: anyhow::Result<OHttpArgs> =
+            serde_json::from_str(r#"{"path_defualt": "original"}"#).map_err(Into::into);
+        assert!(result.is_err(), "typo'd field name must be rejected");
     }
 }

--- a/tng/src/config/mod.rs
+++ b/tng/src/config/mod.rs
@@ -116,6 +116,7 @@ pub mod tests {
                             match_regex: "^/foo/bar/([^/]+)([/]?.*)$".to_owned(),
                             substitution: "/foo/bar/\\1".to_owned(),
                         }],
+                        path_default: ingress::PathDefault::Root,
                         header_passthrough: Some(IngressHeaderPassthroughConfig {
                             request_headers: vec!["x-trace-id".to_owned()],
                         }),
@@ -227,6 +228,7 @@ pub mod tests {
                     web_page_inject: false,
                     ohttp: Some(ingress::OHttpArgs {
                         path_rewrites: vec![],
+                        path_default: ingress::PathDefault::Root,
                         header_passthrough: Some(IngressHeaderPassthroughConfig {
                             request_headers: vec![
                                 "x-trace-id".to_owned(),

--- a/tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs
+++ b/tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs
@@ -10,7 +10,7 @@ use crate::tunnel::utils::socket::{
     TCP_KEEPALIVE_IDLE_SECS, TCP_KEEPALIVE_INTERVAL_SECS, TCP_KEEPALIVE_PROBE_COUNT,
 };
 use crate::{
-    config::ingress::OHttpArgs,
+    config::ingress::{OHttpArgs, PathDefault},
     error::TngError,
     tunnel::{
         endpoint::TngEndpoint,
@@ -33,6 +33,16 @@ use url::Url;
 /// Cached OHTTP client per base URL, lazily initialized on first use.
 type OhttpClientCache = RwLock<HashMap<Url, Arc<OnceCell<Arc<OHttpClient>>>>>;
 
+/// Compute the outer OHTTP POST path used when no `path_rewrites` rule matches
+/// (or `path_rewrites` is unset/empty). The caller is responsible for ensuring
+/// the result starts with `/` (see `construct_base_url`).
+fn fallback_outer_path(path_default: PathDefault, original_path: &str) -> String {
+    match path_default {
+        PathDefault::Root => "/".to_string(),
+        PathDefault::Original => original_path.to_string(),
+    }
+}
+
 /// Root status response for /status/.../ohttp/keys.
 #[derive(Serialize)]
 #[cfg_attr(wasm, allow(dead_code))]
@@ -45,6 +55,7 @@ pub struct OHttpSecurityLayer {
     http_client: Arc<reqwest::Client>,
     ohttp_clients: OhttpClientCache,
     path_rewrite_group: PathRewriteGroup,
+    path_default: PathDefault,
     runtime: TokioRuntime,
     passthrough_request_headers: Arc<Vec<String>>,
 }
@@ -101,6 +112,7 @@ impl OHttpSecurityLayer {
             http_client: Arc::new(http_client),
             ohttp_clients,
             path_rewrite_group: PathRewriteGroup::new(&ohttp_args.path_rewrites)?,
+            path_default: ohttp_args.path_default,
             runtime,
             passthrough_request_headers,
         })
@@ -133,10 +145,13 @@ impl OHttpSecurityLayer {
         let old_uri = request.uri();
         let base_url = {
             let original_path = old_uri.path();
+            // When no path_rewrite rule matches (path_rewrites unset/empty or
+            // no regex hit), fall back according to `path_default`: `/` (Root,
+            // the historical default) or the inner request's original path.
             let mut rewrited_path = self
                 .path_rewrite_group
                 .rewrite(original_path)
-                .unwrap_or_else(|| "/".to_string());
+                .unwrap_or_else(|| fallback_outer_path(self.path_default, original_path));
 
             if !rewrited_path.starts_with('/') {
                 rewrited_path.insert(0, '/');
@@ -226,7 +241,8 @@ impl StatusProvider for OHttpSecurityLayer {
 #[cfg(test)]
 mod tests {
     use super::client::ServerStatusEntry;
-    use super::ServersStatus;
+    use super::{fallback_outer_path, ServersStatus};
+    use crate::config::ingress::PathDefault;
 
     #[test]
     fn test_servers_status_collection() {
@@ -260,5 +276,27 @@ mod tests {
         let value = serde_json::to_value(&status).unwrap();
         let servers = value["servers"].as_array().unwrap();
         assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn test_fallback_outer_path_root() {
+        assert_eq!(fallback_outer_path(PathDefault::Root, "/foo/bar"), "/");
+    }
+
+    #[test]
+    fn test_fallback_outer_path_root_ignores_original() {
+        // Root always yields "/" regardless of the original path.
+        assert_eq!(
+            fallback_outer_path(PathDefault::Root, "/deeply/nested/path"),
+            "/"
+        );
+    }
+
+    #[test]
+    fn test_fallback_outer_path_original() {
+        assert_eq!(
+            fallback_outer_path(PathDefault::Original, "/foo/bar"),
+            "/foo/bar"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add an additive `ohttp.path_default` config option that controls the **outer OHTTP POST path** used when no `path_rewrites` rule matches (including when `path_rewrites` is unset or empty).

- `"root"` (default) — outer path `/` (the historical behavior; unchanged)
- `"original"` — outer path = the inner request's original path

The inner (decrypted) request path is unaffected either way — it is still forwarded to the upstream unchanged. Only the outer OHTTP envelope path changes, which matters for L7 intermediaries (ALB/WAF/LB) between Ingress and Egress that route by path.

## Why

Some deployments want the outer path to mirror the inner request's path without writing a catch-all regex in `path_rewrites`. This gives them a one-line toggle while keeping the default behavior backward-compatible.

## Changes

- `tng/src/config/ingress.rs` — new `PathDefault` enum (`Root`/`Original`, serde renames `"root"`/`"original"`, `#[default] Root`) + `path_default` field on `OHttpArgs` with `#[serde(default)]`.
- `tng/src/tunnel/ingress/protocol/ohttp/security/mod.rs` — store `path_default` on `OHttpSecurityLayer`, add a pure `fallback_outer_path` helper, and use it in `construct_base_url` as the fallback when `PathRewriteGroup::rewrite` returns `None`. The existing `starts_with('/')` guard normalizes an empty original path to `/`.
- `tng-python/tng/_tng.py` — docstring update (the `ohttp` dict is already passed through verbatim, so no code change).
- `docs/configuration.md` + `docs/configuration_zh.md` — new `path_default` table row + updated "L7 Gateway Compatibility" note (EN + ZH).
- `tng-testsuite/tests/ohttp/ohttp_path_default.rs` — integration test using `AppType::LoadBalancer` to observe the outer path on the ingress→egress wire (404 on non-match), covering both `original` and default `root`.

## Backward compatibility

Purely additive. `#[serde(default)]` + `#[default] Root` means configs that omit `path_default` deserialize to `Root` (= outer path `/`), identical to before. `deny_unknown_fields` is preserved. No existing endpoints, config fields, or struct fields are removed or renamed.

## Testing

- Unit: 5 config-deserialization tests (omitted→Root, explicit root/original, unknown-value error, typo rejected by `deny_unknown_fields`) + 3 `fallback_outer_path` helper tests. All pass.
- Integration: `ohttp_path_default` (2 tests, `no_ra: true` on both sides). Confirms the outer path is `/foo/bar/www` under `"original"` and `/` under the default, via a LoadBalancer that 404s on non-match. Both pass.

## Commits

1. `feat(config): add ohttp.path_default enum (root|original)`
2. `feat(ohttp): honor path_default fallback in construct_base_url`
3. `docs(python-sdk): document ohttp.path_default option`
4. `docs: document ohttp.path_default option`
5. `test(ohttp): add path_default integration test`