### PR TITLE
test(hook): stabilize echo server startup in ingress capture test

### DIFF
--- a/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic.rs
+++ b/tng-testsuite/tests/hook/ingress_hook_capture_local_traffic.rs
@@ -39,6 +39,8 @@ async fn test() -> Result<()> {
             name: "echo server on loopback".to_owned(),
             node_type: NodeType::Client,
             script: r#"
+set -euo pipefail
+
 python3 -c '
 import socket, threading, time
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -58,6 +60,16 @@ sleep 120
                 "#
             .to_owned(),
             mode: ShellMode::BackgroundContinue,
+        }
+        .boxed(),
+        ShellTask {
+            name: "sleep a bit for echo server to start".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+sleep 3
+            "#
+            .to_owned(),
+            mode: ShellMode::ForegroundContinue,
         }
         .boxed(),
         // Client side: tng exec with ingress hook.


### PR DESCRIPTION
Add `set -euo pipefail` to the echo server script and a short sleep task so the loopback echo server has time to bind before the client connects. This avoids sporadic 'connection refused' failures in `ingress_hook_capture_local_traffic`.