### PR TITLE
docs: add live demo links and Go SDK references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,24 @@ When creating or amending commits:
 - **Never commit plan or spec files** (e.g. `docs/*-plan.md`, `docs/*-design.md`, `docs/*-spec.md`, or anything under `docs/superpowers/`). These should be gitignored (already covered by `.gitignore`) and kept local only.
 - **Never commit any file that is already gitignored** — if a file matches `.gitignore`, it is intentionally local-only.
 
+## Bilingual Documentation Convention
+
+This project maintains paired English/Chinese documentation throughout the repo. Whenever you update any documentation, **update both the English and the Chinese counterpart together**:
+
+- Each crate has a `README.md` paired with a `README_zh.md` (e.g. `tng-wasm/README.md` ↔ `tng-wasm/README_zh.md`, same for `tng-go`, `tng-hook`, `tng-python`).
+- `docs/` files are paired as `*.md` ↔ `*_zh.md` (e.g. `docs/configuration.md` ↔ `docs/configuration_zh.md`, same for `architecture`, `developer`, `version_compatibility`, etc.).
+
+Do not update one language and leave the other stale. If a section is added/removed on one side, mirror it on the other.
+
+## GitHub Pages Demo Site
+
+The `tng-wasm/www/` directory is the source for the live demo published at **<https://inclavare-containers.github.io/TNG/>** (it contains `index.html`, `js/`, and the built `tng_wasm_bg.wasm` / `tng_wasm.js`). When changing the JavaScript SDK or the demo page, remember this site is a published artifact — do not delete `www/`, and rebuild/sync the `.wasm` bundle there when the SDK changes so the live demo stays up to date.
+
 ## PR Requirements
 
 When creating a pull request, always:
 
-1. Update relevant documentation (both `docs/configuration.md` and `docs/configuration_zh.md`)
+1. Update relevant documentation **in both languages** — the English file and its `*_zh.md` counterpart (see the Bilingual Documentation Convention above; this includes each crate's `README.md`/`README_zh.md` and `docs/*.md`/`docs/*_zh.md`, notably `docs/configuration.md` ↔ `docs/configuration_zh.md`).
 2. Add or update integration tests for new features
 3. Never mention "🤖 Generated with Claude Code" in the PR description
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ Supports `httpx`, `requests`, and `openai` as optional backends.
 
 </details>
 
+<details>
+<summary><b>Go SDK</b> — programmatic integration for Go services</summary>
+
+```sh
+go get github.com/inclavare-containers/tng/tng-go
+```
+
+```go
+import "github.com/inclavare-containers/tng/tng-go"
+
+// Spawns a TNG subprocess with an http_proxy ingress automatically
+rt, err := tng.NewRoundTripper(&tng.Config{NoRA: true})
+if err != nil {
+    log.Fatal(err)
+}
+defer rt.Close()
+
+// Works with the standard http.Client
+client := &http.Client{Transport: rt}
+resp, err := client.Get("http://your-tee-service/api/data")
+```
+
+Pure Go, no CGO required. Drop-in `http.RoundTripper` for any Go HTTP client.
+
+</details>
+
 See [Installation](#installation) for Docker, RPM, binary, and SDK options.
 
 ---
@@ -195,6 +221,14 @@ pip install tng-sdk
 
 Full SDK docs: [tng-python/README.md](tng-python/README.md)
 
+### Option 6: Go SDK
+
+```sh
+go get github.com/inclavare-containers/tng/tng-go
+```
+
+Full SDK docs: [tng-go/README.md](tng-go/README.md)
+
 > [!TIP]
 > **New to TNG?** Start with [Core Concepts & Workflow](docs/architecture.md) to understand the Ingress/Egress model and remote attestation roles, then check the [Configuration Reference](docs/configuration.md) for all available fields.
 
@@ -206,6 +240,7 @@ rats-cert/       Certificate generation and management library
 tng-hook/        LD_PRELOAD hook library (libtng_hook.so) for `tng exec` transparent port interception
 tng-wasm/        WebAssembly module + JavaScript SDK for browsers
 tng-python/      Python SDK for programmatic integration
+tng-go/          Go SDK for programmatic integration
 tng-testsuite/   Integration and e2e test cases
 scripts/         Build, deploy, and CI helper scripts
 docs/            Architecture, configuration, scenarios, and developer guides
@@ -222,6 +257,7 @@ docs/            Architecture, configuration, scenarios, and developer guides
 | [Version Compatibility](docs/version_compatibility.md) | Breaking changes and migration notes between versions |
 | [JavaScript SDK](tng-wasm/README.md) | Browser-side SDK usage and examples |
 | [Python SDK](tng-python/README.md) | Python SDK usage and examples |
+| [Go SDK](tng-go/README.md) | Go SDK usage and examples |
 
 ## Contributing
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -139,6 +139,14 @@ pip install tng-sdk
 
 完整 SDK 文档：[tng-python/README_zh.md](tng-python/README_zh.md)
 
+### 方式六：Go SDK
+
+```sh
+go get github.com/inclavare-containers/tng/tng-go
+```
+
+完整 SDK 文档：[tng-go/README_zh.md](tng-go/README_zh.md)
+
 > [!TIP]
 > **刚接触 TNG？** 建议先阅读 [核心概念与工作原理](docs/architecture_zh.md) 了解 Ingress/Egress 模型和远程证明角色，然后查看 [配置参考](docs/configuration_zh.md) 了解所有可用字段。
 
@@ -150,6 +158,7 @@ rats-cert/       证书生成与管理库
 tng-hook/        LD_PRELOAD 钩子库（libtng_hook.so），用于 `tng exec` 透明端口拦截
 tng-wasm/        WebAssembly 模块 + 浏览器 JavaScript SDK
 tng-python/      Python SDK，用于程序化集成
+tng-go/          Go SDK，用于程序化集成
 tng-testsuite/   集成测试和端到端测试用例
 scripts/         构建、部署和 CI 辅助脚本
 docs/            架构、配置、场景和开发者指南
@@ -166,6 +175,7 @@ docs/            架构、配置、场景和开发者指南
 | [版本兼容性](docs/version_compatibility_zh.md) | 大版本间的变更和迁移说明 |
 | [JavaScript SDK](tng-wasm/README_zh.md) | 浏览器端 SDK 使用指南与示例 |
 | [Python SDK](tng-python/README_zh.md) | Python SDK 使用指南与示例 |
+| [Go SDK](tng-go/README_zh.md) | Go SDK 使用指南与示例 |
 
 ## 贡献
 

--- a/tng-wasm/README.md
+++ b/tng-wasm/README.md
@@ -4,6 +4,10 @@
 
 The TNG Client JavaScript SDK provides client functionality for use in browser environments, built with wasm-pack.
 
+## Live Demo
+
+A live demo of the TNG JavaScript SDK integrated into a web page is hosted on GitHub Pages: <https://inclavare-containers.github.io/TNG/>
+
 ## Getting the SDK
 
 You can obtain the TNG SDK in two ways:

--- a/tng-wasm/README_zh.md
+++ b/tng-wasm/README_zh.md
@@ -4,6 +4,10 @@
 
 TNG Client JavaScript SDK为浏览器环境提供客户端功能，使用wasm-pack构建。
 
+## 在线示例
+
+我们在 GitHub Pages 上提供了一个集成 TNG JavaScript SDK 的网页在线示例：<https://inclavare-containers.github.io/TNG/>
+
 ## 获取 SDK
 
 您可以通过两种方式获取 TNG SDK：


### PR DESCRIPTION
Documentation updates across the repo:

- `tng-wasm/README.md` / `README_zh.md`: add a link to the live GitHub Pages demo (https://inclavare-containers.github.io/TNG/)
- `CLAUDE.md`: add a bilingual documentation convention section, document the `tng-wasm/www/` GitHub Pages demo site, and generalize the PR requirement to cover all EN/Zh doc pairs
- `README.md` / `README_zh.md`: add Go SDK references (install, usage snippet, directory listing, links table)