### PR TITLE
build(rats-cert): use cfg_alias `wasm` + `async_trait(?Send)` to drop tokio_with_wasm spawn workarounds

### DIFF
--- a/rats-cert/src/tee/coco/asr_attester/mod.rs
+++ b/rats-cert/src/tee/coco/asr_attester/mod.rs
@@ -26,7 +26,8 @@ impl CocoAsrAttester {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericAttester for CocoAsrAttester {
     type Evidence = CocoEvidence;
 

--- a/rats-cert/src/tee/coco/attester/mod.rs
+++ b/rats-cert/src/tee/coco/attester/mod.rs
@@ -28,7 +28,8 @@ impl CocoAttester {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericAttester for CocoAttester {
     type Evidence = CocoEvidence;
 

--- a/rats-cert/src/tee/coco/converter/grpc.rs
+++ b/rats-cert/src/tee/coco/converter/grpc.rs
@@ -69,7 +69,8 @@ impl CocoGrpcConverter {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericConverter for CocoGrpcConverter {
     type InEvidence = CocoEvidence;
     type OutEvidence = CocoAsToken;
@@ -162,24 +163,13 @@ impl CocoGrpcConverter {
                 )
             };
 
-        let fut = async move {
-            let response: as_api::v1_6_0::AttestationResponse = client
-                .attestation_evaluate(request)
-                .await
-                .map_err(|e| {
-                    Error::AttestationServiceGrpcAttestationEvaluateFailed(GrpcAsVersion::V1_6_0, e)
-                })?
-                .into_inner();
-            Ok::<_, Error>(response)
-        };
-
-        #[cfg(wasm)]
-        // In wasm32 (web), the tonic Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Sen. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
-        let response = tokio_with_wasm::task::spawn(fut)
+        let response: as_api::v1_6_0::AttestationResponse = client
+            .attestation_evaluate(request)
             .await
-            .map_err(Error::TaskSpawnFailed)??;
-        #[cfg(not(wasm))]
-        let response = fut.await?;
+            .map_err(|e| {
+                Error::AttestationServiceGrpcAttestationEvaluateFailed(GrpcAsVersion::V1_6_0, e)
+            })?
+            .into_inner();
 
         let attestation_token = response.attestation_token;
 
@@ -239,25 +229,13 @@ impl CocoGrpcConverter {
                 )
             };
 
-        let fut = async move {
-            let response: as_api::v1_5_2::AttestationResponse = client
-                .attestation_evaluate(request)
-                .await
-                .map_err(|e| {
-                    Error::AttestationServiceGrpcAttestationEvaluateFailed(GrpcAsVersion::V1_5_2, e)
-                })?
-                .into_inner();
-            Ok::<_, Error>(response)
-        };
-
-        #[cfg(wasm)]
-        // In wasm32 (web), the tonic Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Sen. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
-        let response = tokio_with_wasm::task::spawn(fut)
+        let response: as_api::v1_5_2::AttestationResponse = client
+            .attestation_evaluate(request)
             .await
-            .map_err(Error::TaskSpawnFailed)??;
-        #[cfg(not(wasm))]
-        let response = fut.await?;
-
+            .map_err(|e| {
+                Error::AttestationServiceGrpcAttestationEvaluateFailed(GrpcAsVersion::V1_5_2, e)
+            })?
+            .into_inner();
         let attestation_token = response.attestation_token;
 
         CocoAsToken::new(attestation_token)

--- a/rats-cert/src/tee/coco/converter/mod.rs
+++ b/rats-cert/src/tee/coco/converter/mod.rs
@@ -38,7 +38,8 @@ pub enum CoCoNonce {
     Jwt(String),
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 
 impl GenericConverter for CocoConverter {
     type InEvidence = CocoEvidence;

--- a/rats-cert/src/tee/coco/converter/restful.rs
+++ b/rats-cert/src/tee/coco/converter/restful.rs
@@ -133,7 +133,8 @@ mod as_api {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericConverter for CocoRestfulConverter {
     type InEvidence = CocoEvidence;
     type OutEvidence = CocoAsToken;
@@ -153,40 +154,23 @@ impl GenericConverter for CocoRestfulConverter {
 
         let url = format!("{}/challenge", self.as_addr);
 
-        let client = self.client.clone();
-
-        let fut = async move {
-            let response = client
-                .post(url)
-                .json(&json!({}))
-                .send()
-                .await
-                .map_err(|e| {
-                    Error::AttestationServiceChallengeHttpRequestSendFailed(
-                        RestfulAsApiVersion::V1_6_0,
-                        e,
-                    )
-                })?;
-
-            let status = response.status();
-            let text = response.text().await.map_err(|e| {
-                Error::AttestationServiceChallengeHttpResponseReadFailed(
+        let response = self
+            .client
+            .post(&url)
+            .json(&json!({}))
+            .send()
+            .await
+            .map_err(|e| {
+                Error::AttestationServiceChallengeHttpRequestSendFailed(
                     RestfulAsApiVersion::V1_6_0,
                     e,
                 )
             })?;
 
-            Ok::<_, Error>((status, text))
-        };
-
-        #[cfg(wasm)]
-        // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Send. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
-        let (status, text) = tokio_with_wasm::task::spawn(fut)
-            .await
-            .map_err(|e| Error::TaskSpawnFailed(e))??;
-        #[cfg(not(wasm))]
-        let (status, text) = fut.await?;
-
+        let status = response.status();
+        let text = response.text().await.map_err(|e| {
+            Error::AttestationServiceChallengeHttpResponseReadFailed(RestfulAsApiVersion::V1_6_0, e)
+        })?;
         let body_text = match status {
             reqwest::StatusCode::OK => text,
             _ => {
@@ -248,33 +232,26 @@ impl CocoRestfulConverter {
             .collect::<Vec<_>>(),
             policy_ids: self.policy_ids.clone(),
         };
-        let client = self.client.clone();
-
-        let fut = async move {
-            let response = client.post(url).json(&body).send().await.map_err(|e| {
+        let response = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
                 Error::AttestationServiceAttestationHttpRequestSendFailed(
                     RestfulAsApiVersion::V1_6_0,
                     e,
                 )
             })?;
 
-            let status = response.status();
-            let text = response.text().await.map_err(|e| {
-                Error::AttestationServiceAttestationHttpResponseReadFailed(
-                    RestfulAsApiVersion::V1_6_0,
-                    e,
-                )
-            })?;
-            Ok::<_, Error>((status, text))
-        };
-
-        #[cfg(wasm)]
-        // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Send. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
-        let (status, text) = tokio_with_wasm::task::spawn(fut)
-            .await
-            .map_err(|e| Error::TaskSpawnFailed(e))??;
-        #[cfg(not(wasm))]
-        let (status, text) = fut.await?;
+        let status = response.status();
+        let text = response.text().await.map_err(|e| {
+            Error::AttestationServiceAttestationHttpResponseReadFailed(
+                RestfulAsApiVersion::V1_6_0,
+                e,
+            )
+        })?;
 
         let attestation_token = match status {
             reqwest::StatusCode::OK => text,
@@ -321,33 +298,27 @@ impl CocoRestfulConverter {
             )),
             runtime_data_hash_algorithm: Some(runtime_data_hash_algorithm.into()),
         };
-        let client = self.client.clone();
 
-        let fut = async move {
-            let response = client.post(url).json(&body).send().await.map_err(|e| {
+        let response = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
                 Error::AttestationServiceAttestationHttpRequestSendFailed(
                     RestfulAsApiVersion::V1_5_2,
                     e,
                 )
             })?;
 
-            let status = response.status();
-            let text = response.text().await.map_err(|e| {
-                Error::AttestationServiceAttestationHttpResponseReadFailed(
-                    RestfulAsApiVersion::V1_5_2,
-                    e,
-                )
-            })?;
-            Ok::<_, Error>((status, text))
-        };
-
-        #[cfg(wasm)]
-        // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Sen. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
-        let (status, text) = tokio_with_wasm::task::spawn(fut)
-            .await
-            .map_err(|e| Error::TaskSpawnFailed(e))??;
-        #[cfg(not(wasm))]
-        let (status, text) = fut.await?;
+        let status = response.status();
+        let text = response.text().await.map_err(|e| {
+            Error::AttestationServiceAttestationHttpResponseReadFailed(
+                RestfulAsApiVersion::V1_5_2,
+                e,
+            )
+        })?;
 
         let attestation_token = match status {
             reqwest::StatusCode::OK => text,

--- a/rats-cert/src/tee/coco/verifier/mod.rs
+++ b/rats-cert/src/tee/coco/verifier/mod.rs
@@ -17,7 +17,8 @@ pub enum CocoVerifier {
     Builtin(builtin::BuiltinCocoVerifier),
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericVerifier for CocoVerifier {
     type Evidence = CocoAsToken;
 

--- a/rats-cert/src/tee/coco/verifier/remote.rs
+++ b/rats-cert/src/tee/coco/verifier/remote.rs
@@ -67,7 +67,8 @@ impl CocoRemoteVerifier {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericVerifier for CocoRemoteVerifier {
     type Evidence = CocoAsToken;
 

--- a/rats-cert/src/tee/coco/verifier/token/jwk.rs
+++ b/rats-cert/src/tee/coco/verifier/token/jwk.rs
@@ -69,41 +69,25 @@ async fn get_jwks_from_file_or_url(
     match url.scheme() {
         "https" => {
             url.set_path(OPENID_CONFIG_URL_SUFFIX);
-
-            #[cfg(wasm)]
-            let client = client.clone(); // Fix compile lifetime error
-
-            let fut = async move {
-                let oidc = client
-                    .get(url.as_str())
-                    .send()
-                    .await
-                    .map_err(|e| JwksGetError::AccessFailed(e.to_string()))?
-                    .json::<OpenIDConfig>()
-                    .await
-                    .map_err(|e| JwksGetError::DeserializeSource(e.to_string()))?;
-
-                let jwkset = client
-                    .get(oidc.jwks_uri)
-                    .send()
-                    .await
-                    .map_err(|e| JwksGetError::AccessFailed(e.to_string()))?
-                    .json::<jwk::JwkSet>()
-                    .await
-                    .map_err(|e| JwksGetError::DeserializeSource(e.to_string()))?;
-
-                Ok(jwkset)
-            };
-
-            #[cfg(wasm)]
-            // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Send. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
-            let ret = tokio_with_wasm::task::spawn(fut)
+            let oidc = client
+                .get(url.as_str())
+                .send()
                 .await
-                .map_err(|e| JwksGetError::AccessFailed(e.to_string()))
-                .and_then(|e| e);
-            #[cfg(not(wasm))]
-            let ret = fut.await;
-            ret
+                .map_err(|e| JwksGetError::AccessFailed(e.to_string()))?
+                .json::<OpenIDConfig>()
+                .await
+                .map_err(|e| JwksGetError::DeserializeSource(e.to_string()))?;
+
+            let jwkset = client
+                .get(oidc.jwks_uri)
+                .send()
+                .await
+                .map_err(|e| JwksGetError::AccessFailed(e.to_string()))?
+                .json::<jwk::JwkSet>()
+                .await
+                .map_err(|e| JwksGetError::DeserializeSource(e.to_string()))?;
+
+            Ok(jwkset)
         }
         "file" => {
             #[cfg(not(wasm))]
@@ -211,42 +195,24 @@ impl JwkAttestationTokenVerifier {
         }
 
         let url = format!("{}/certificate", as_addr.trim_end_matches('/'));
+        let response = client
+            .get(&url)
+            .headers(headers)
+            .send()
+            .await?
+            .error_for_status()
+            .with_context(|| format!("HTTP error when fetching certificates from {}", url))?;
 
-        #[cfg(wasm)]
-        let client = client.clone(); // Fix compile lifetime error
-
-        let fut = async move {
-            let response = client
-                .get(&url)
-                .headers(headers)
-                .send()
-                .await?
-                .error_for_status()
-                .with_context(|| format!("HTTP error when fetching certificates from {}", url))?;
-
-            let cert_pem_chain = response.text().await.with_context(|| {
-                format!("Failed to read certificate chain response from {}", url)
-            })?;
-
-            let cert_ders = CertificateDer::pem_slice_iter(cert_pem_chain.as_bytes())
-                .collect::<Result<Vec<_>, _>>()
-                .with_context(|| {
-                    format!("Failed to parse PEM certificate chain from AS {}", url)
-                })?;
-
-            Ok(cert_ders)
-        };
-
-        #[cfg(wasm)]
-        let ret = tokio_with_wasm::task::spawn(fut)
+        let cert_pem_chain = response
+            .text()
             .await
-            .map_err(|e| anyhow!("Failed to spawn task: {}", e))
-            .and_then(|r| r);
+            .with_context(|| format!("Failed to read certificate chain response from {}", url))?;
 
-        #[cfg(not(wasm))]
-        let ret = fut.await;
+        let cert_ders = CertificateDer::pem_slice_iter(cert_pem_chain.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .with_context(|| format!("Failed to parse PEM certificate chain from AS {}", url))?;
 
-        ret
+        Ok(cert_ders)
     }
 
     fn verify_jwk_endorsement(&self, key: &Jwk) -> anyhow::Result<()> {

--- a/rats-cert/src/tee/ita/asr_attester.rs
+++ b/rats-cert/src/tee/ita/asr_attester.rs
@@ -32,7 +32,8 @@ impl ItaAsrAttester {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericAttester for ItaAsrAttester {
     type Evidence = ItaEvidence;
 

--- a/rats-cert/src/tee/ita/attester.rs
+++ b/rats-cert/src/tee/ita/attester.rs
@@ -50,7 +50,8 @@ impl ItaAttester {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericAttester for ItaAttester {
     type Evidence = ItaEvidence;
 

--- a/rats-cert/src/tee/ita/converter.rs
+++ b/rats-cert/src/tee/ita/converter.rs
@@ -100,16 +100,16 @@ impl ItaConverter {
     async fn ita_request(&self, request: reqwest::RequestBuilder, label: &str) -> Result<String> {
         let label = label.to_string();
 
-        let fut = async move {
-            let policy = RetryPolicy::exponential(ITA_RETRY_INITIAL_DELAY)
-                .with_max_delay(ITA_RETRY_MAX_DELAY)
-                .with_max_retries(ITA_MAX_RETRIES);
+        let policy = RetryPolicy::exponential(ITA_RETRY_INITIAL_DELAY)
+            .with_max_delay(ITA_RETRY_MAX_DELAY)
+            .with_max_retries(ITA_MAX_RETRIES);
 
-            let (status, body) = policy
-                .retry(|| async {
+        let (status, body) = policy
+            .retry(|| {
+                let request = request.try_clone().expect("request must be cloneable");
+                let label = label.clone();
+                async move {
                     let resp = request
-                        .try_clone()
-                        .expect("request must be cloneable")
                         .send()
                         .await
                         .map_err(|e| Error::ItaHttpRequestFailed {
@@ -121,39 +121,30 @@ impl ItaConverter {
                     if Self::is_retryable_error(status, &body) {
                         tracing::warn!(%status, body = %body, "{label} failed (retrying)");
                         return Err(Error::ItaHttpResponseError {
-                            endpoint: label.clone(),
+                            endpoint: label,
                             status_code: status.as_u16(),
                             response_body: body,
                         });
                     }
                     Ok((status, body))
-                })
-                .await?;
+                }
+            })
+            .await?;
 
-            if !status.is_success() {
-                return Err(Error::ItaHttpResponseError {
-                    endpoint: label,
-                    status_code: status.as_u16(),
-                    response_body: body,
-                });
-            }
+        if !status.is_success() {
+            return Err(Error::ItaHttpResponseError {
+                endpoint: label,
+                status_code: status.as_u16(),
+                response_body: body,
+            });
+        }
 
-            Ok(body)
-        };
-
-        #[cfg(wasm)]
-        let result = tokio_with_wasm::task::spawn(fut)
-            .await
-            .map_err(|e| Error::ItaError(format!("Failed to spawn ITA request task: {e}")))
-            .and_then(|e| e);
-        #[cfg(not(wasm))]
-        let result = fut.await;
-
-        result
+        Ok(body)
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericConverter for ItaConverter {
     type InEvidence = ItaEvidence;
     type OutEvidence = ItaToken;

--- a/rats-cert/src/tee/ita/verifier.rs
+++ b/rats-cert/src/tee/ita/verifier.rs
@@ -104,54 +104,41 @@ impl ItaVerifier {
     }
 
     async fn refresh_jwks(&self) -> Result<()> {
-        let jwks_url = self.jwks_url.clone();
-
-        let fut = async move {
-            let client = Client::new();
-            let resp = client
-                .get(&jwks_url)
-                .header("Accept", "application/json")
-                .send()
-                .await
-                .map_err(|e| Error::ItaHttpRequestFailed {
-                    endpoint: jwks_url.clone(),
-                    source: e,
-                })?;
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                return Err(Error::ItaHttpResponseError {
-                    endpoint: jwks_url,
-                    status_code: status.as_u16(),
-                    response_body: body,
-                });
-            }
-
-            let jwks: JwksResponse = resp
-                .json()
-                .await
-                .map_err(|e| Error::ItaError(format!("Failed to parse JWKS response: {e}")))?;
-
-            Ok(jwks
-                .keys
-                .into_iter()
-                .map(|k| CachedKey {
-                    kid: k.kid,
-                    n: k.n,
-                    e: k.e,
-                })
-                .collect::<Vec<CachedKey>>())
-        };
-
-        #[cfg(wasm)]
-        let keys = tokio_with_wasm::task::spawn(fut)
+        let client = Client::new();
+        let resp = client
+            .get(&self.jwks_url)
+            .header("Accept", "application/json")
+            .send()
             .await
-            .map_err(|e| Error::ItaError(format!("Failed to spawn JWKS refresh task: {e}")))
-            .and_then(|e| e)?;
-        #[cfg(not(wasm))]
-        let keys = fut.await?;
+            .map_err(|e| Error::ItaHttpRequestFailed {
+                endpoint: self.jwks_url.clone(),
+                source: e,
+            })?;
 
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::ItaHttpResponseError {
+                endpoint: self.jwks_url.clone(),
+                status_code: status.as_u16(),
+                response_body: body,
+            });
+        }
+
+        let jwks: JwksResponse = resp
+            .json()
+            .await
+            .map_err(|e| Error::ItaError(format!("Failed to parse JWKS response: {e}")))?;
+
+        let keys: Vec<CachedKey> = jwks
+            .keys
+            .into_iter()
+            .map(|k| CachedKey {
+                kid: k.kid,
+                n: k.n,
+                e: k.e,
+            })
+            .collect();
         let mut cache = JWKS_CACHE.write().await;
         cache.insert(self.jwks_url.clone(), keys);
 
@@ -260,7 +247,8 @@ impl ItaVerifier {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericVerifier for ItaVerifier {
     type Evidence = ItaToken;
 

--- a/rats-cert/src/tee/mod.rs
+++ b/rats-cert/src/tee/mod.rs
@@ -73,7 +73,8 @@ pub trait GenericEvidence: Any + Send {
 }
 
 /// Trait representing a generic attester.
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 pub trait GenericAttester {
     type Evidence: GenericEvidence;
 
@@ -82,7 +83,8 @@ pub trait GenericAttester {
 }
 
 /// Blanket implementation for references to attesters.
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl<A: GenericAttester + Sync> GenericAttester for &A {
     type Evidence = A::Evidence;
 
@@ -92,7 +94,8 @@ impl<A: GenericAttester + Sync> GenericAttester for &A {
 }
 
 /// Trait representing a generic verifier.
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 pub trait GenericVerifier {
     type Evidence: GenericEvidence;
 
@@ -104,7 +107,8 @@ pub trait GenericVerifier {
     ) -> Result<()>;
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 pub trait GenericConverter {
     type InEvidence: GenericEvidence;
     type OutEvidence: GenericEvidence;
@@ -116,7 +120,8 @@ pub trait GenericConverter {
 }
 
 /// Blanket implementation for references to attesters.
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl<A: GenericConverter + Sync> GenericConverter for &A
 where
     <A as GenericConverter>::InEvidence: Sync,
@@ -148,7 +153,8 @@ impl<A: GenericAttester, C: GenericConverter<InEvidence = A::Evidence>> Attester
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl<A, C> GenericAttester for AttesterPipeline<A, C>
 where
     A: GenericAttester + Sync,

--- a/tng/src/tunnel/provider/converter.rs
+++ b/tng/src/tunnel/provider/converter.rs
@@ -30,7 +30,8 @@ impl TngConverter {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericConverter for TngConverter {
     type InEvidence = TngEvidence;
     type OutEvidence = TngToken;

--- a/tng/src/tunnel/provider/verifier.rs
+++ b/tng/src/tunnel/provider/verifier.rs
@@ -20,7 +20,8 @@ impl TngVerifier {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(wasm, async_trait::async_trait(?Send))]
+#[cfg_attr(not(wasm), async_trait::async_trait)]
 impl GenericVerifier for TngVerifier {
     type Evidence = TngToken;
 


### PR DESCRIPTION
Replace the verbose `#[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]` + `tokio_with_wasm::task::spawn(fut)` pattern with a single `wasm` cfg_alias defined in `build.rs` and `#[cfg_attr(wasm, async_trait::async_trait(?Send))]` on the trait impls. This lets the non-Send reqwest/tonic futures be awaited directly on wasm, removing the duplicated spawn-vs-await branches across the CoCo/ITA attesters, converters, verifiers, and JWK fetch paths.