### PR TITLE
fix(ci): install chromedriver matching installed Chrome major version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,23 @@ wasm-unit-test: wasm-unit-test-chrome
 .PHONE: wasm-unit-test-chrome
 wasm-unit-test-chrome: install-wasm-build-dependencies
 	if ! command -v google-chrome; then echo -e '[google-chrome]\nname=google-chrome\nbaseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64\nenabled=1\ngpgcheck=1\ngpgkey=https://dl.google.com/linux/linux_signing_key.pub' | tee /etc/yum.repos.d/google-chrome.repo; yum install google-chrome-stable -y ; fi
+	@# Install a chromedriver whose major version matches the installed
+	@# google-chrome, and expose it on PATH. wasm-pack's chromedriver fetcher
+	@# checks `which chromedriver` first and uses it instead of downloading the
+	@# latest Chrome-for-Testing stable, which is a *separate* release channel
+	@# from the RPM "stable" channel that yum installs Chrome from. Left
+	@# unsynced, the two drift apart (e.g. Chrome 150 from yum vs. chromedriver
+	@# 151 from CfT) and ChromeDriver refuses to drive the installed Chrome.
+	@# https://github.com/rustwasm/wasm-pack/blob/master/src/test/webdriver/chromedriver.rs
+	command -v unzip >/dev/null || yum install -y unzip ; \
+	CHROME_VERSION=$$(google-chrome --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+') ; \
+	CHROME_MAJOR=$$(echo $$CHROME_VERSION | cut -d. -f1) ; \
+	CDR_VERSION=$$(curl -fsSL "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$$CHROME_MAJOR") ; \
+	echo "Installed Chrome $$CHROME_VERSION -> matching chromedriver $$CDR_VERSION" ; \
+	curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/$$CDR_VERSION/linux64/chromedriver-linux64.zip" -o /tmp/chromedriver.zip && \
+	unzip -o -q /tmp/chromedriver.zip -d /tmp/chromedriver-tmp && \
+	install -m 0755 /tmp/chromedriver-tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
+	rm -rf /tmp/chromedriver.zip /tmp/chromedriver-tmp
 	RUSTUP_TOOLCHAIN=nightly-2025-07-07 RUSTFLAGS='--cfg getrandom_backend="wasm_js" -C target-feature=+atomics,+bulk-memory,+mutable-globals' wasm-pack test --headless --chrome ./tng-wasm -Z build-std=std,panic_abort -- --nocapture
 
 .PHONE: wasm-unit-test-firefox


### PR DESCRIPTION
## Problem

The `wasm-unit-test-chrome` CI job has been failing intermittently (e.g. run [29985181665](https://github.com/inclavare-containers/TNG/actions/runs/29985181665), job `Run wasm unit test`) with `http status: 404` during test session creation.

Root cause: Chrome and chromedriver come from two **unsynchronized release channels**.

- **Chrome** is installed via `yum` from Google's RPM `stable` channel → e.g. `150.0.7871.181`.
- **chromedriver** is **not** installed on the system, so `wasm-pack test --chrome` downloads its own from Chrome-for-Testing's `last-known-good-versions.json` Stable → e.g. `151.0.7922.47`.

wasm-pack's chromedriver fetcher ([`chromedriver.rs`](https://github.com/rustwasm/wasm-pack/blob/master/src/test/webdriver/chromedriver.rs)) explicitly returns the latest CfT stable **without checking the installed Chrome version**. When the RPM `stable` channel lags the CfT `last-known-good stable` by a major version (150 vs 151), ChromeDriver refuses to drive the installed Chrome and the headless test dies with a 404.

## Fix

In the `wasm-unit-test-chrome` Makefile target, after installing `google-chrome-stable`, install a chromedriver whose **major version matches** the installed Chrome and expose it on `PATH`:

1. Parse the installed Chrome version, take the major number.
2. Resolve the matching chromedriver patch via `https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_<major>`.
3. Download + unzip the chromedriver from `chrome-for-testing-public` and `install` it to `/usr/local/bin/chromedriver`.

wasm-pack's `get_or_install_chromedriver` checks `which chromedriver` first and uses that path directly, so it now reuses the matched system chromedriver instead of downloading the latest CfT stable. Chrome and chromedriver are always on the same major version; ChromeDriver is cross-patch compatible within a major, so the pair stays valid.

## Verification

- `make -p wasm-unit-test-chrome` parses cleanly (rc=0).
- Dry-run of the version-match logic locally: `google-chrome 150.0.7871.114` → `LATEST_RELEASE_150` → `150.0.7871.124`; the corresponding chromedriver zip returns `HTTP 200 / application/zip`.
- CI base image (alinux3) does not ship `unzip`, so the recipe guards with `command -v unzip || yum install -y unzip`.

## Scope

CI/Makefile-internal fix only — no Rust code, no API/config/wire-format changes, no backward-compatibility impact. No docs require updating: `docs/developer.md`'s "Running Tests" section does not document this CI target's Chrome installation, and the `access/wasm.sh` chromedriver note (Playwright/CDP) is a separate, still-accurate concern.

Assisted-by: Claude:glm-5.2
