### PR TITLE
refactor(cfg): unify wasm target cfg via cfg_aliases across all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3615,6 +3615,7 @@ dependencies = [
 name = "hyper-util"
 version = "0.1.7"
 dependencies = [
+ "cfg_aliases",
  "hyper-util 0.1.7 (git+https://github.com/inclavare-containers/hyper-util.git?rev=4854ab5e5d67ff38a038ab22a1bd25087456bc84)",
  "hyper-util-wasm",
 ]
@@ -6272,6 +6273,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "canon-json",
+ "cfg_aliases",
  "ciborium",
  "const-oid",
  "ctor",
@@ -8156,6 +8158,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.4",
  "bytes",
+ "cfg_aliases",
  "console_error_panic_hook",
  "futures",
  "getrandom 0.2.15",

--- a/deps/hyper-util-shim/Cargo.toml
+++ b/deps/hyper-util-shim/Cargo.toml
@@ -16,6 +16,9 @@ hyper-util = {git = "https://github.com/inclavare-containers/hyper-util.git", re
 # The wasm patched version of hyper-util.
 hyper-util-wasm = {git = "https://github.com/r58Playz/hyper-util-wasm.git", rev = "c582f05daa6529a75f6838a26ebf29ff09f62921", default-features = false}
 
+[build-dependencies]
+cfg_aliases = {workspace = true}
+
 [features]
 client = ["hyper-util/client", "hyper-util-wasm/client"]
 client-legacy = ["hyper-util/client-legacy", "hyper-util-wasm/client-legacy"]

--- a/deps/hyper-util-shim/build.rs
+++ b/deps/hyper-util-shim/build.rs
@@ -1,0 +1,9 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+        // Platforms
+        wasm: { all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown") },
+        // "unix" is already defined by rustc so we skip it here: https://doc.rust-lang.org/reference/conditional-compilation.html#unix-and-windows
+    }
+}

--- a/deps/hyper-util-shim/src/lib.rs
+++ b/deps/hyper-util-shim/src/lib.rs
@@ -1,13 +1,5 @@
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
+#[cfg(wasm)]
 pub use hyper_util_wasm::*;
 
-#[cfg(not(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-)))]
+#[cfg(not(wasm))]
 pub use hyper_util::*;

--- a/rats-cert/Cargo.toml
+++ b/rats-cert/Cargo.toml
@@ -136,5 +136,6 @@ tracing-subscriber = {workspace = true}
 wiremock = "0.6"
 
 [build-dependencies]
+cfg_aliases = {workspace = true}
 tonic-prost-build = {workspace = true, optional = true}
 ttrpc-codegen = {workspace = true, optional = true}

--- a/rats-cert/build.rs
+++ b/rats-cert/build.rs
@@ -1,7 +1,15 @@
 #[cfg(feature = "attester-coco")]
 use ttrpc_codegen::{Codegen, Customize, ProtobufCustomize};
 
+use cfg_aliases::cfg_aliases;
+
 fn main() {
+    cfg_aliases! {
+        // Platforms
+        wasm: { all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown") },
+        // "unix" is already defined by rustc so we skip it here: https://doc.rust-lang.org/reference/conditional-compilation.html#unix-and-windows
+    }
+
     #[cfg(feature = "attester-coco")]
     {
         // Build for connecting AA with ttrpc

--- a/rats-cert/src/errors.rs
+++ b/rats-cert/src/errors.rs
@@ -49,11 +49,7 @@ pub enum Error {
     NoTrustSource,
 
     // gRPC AS related errors
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    )))]
+    #[cfg(not(wasm))]
     #[error("Failed to create gRPC endpoint for AS address `{as_addr}`")]
     GrpcEndpointCreateFailed {
         as_addr: String,
@@ -61,11 +57,7 @@ pub enum Error {
         source: tonic::transport::Error,
     },
 
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    )))]
+    #[cfg(not(wasm))]
     #[error("Failed to connect to gRPC AS address `{as_addr}`")]
     GrpcConnectFailed {
         as_addr: String,
@@ -265,19 +257,11 @@ pub enum Error {
     },
 
     // Task spawning
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    ))]
+    #[cfg(wasm)]
     #[error("Failed to spawn async task")]
     TaskSpawnFailed(#[source] tokio_with_wasm::task::JoinError),
 
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    )))]
+    #[cfg(not(wasm))]
     #[error("Failed to spawn async task")]
     TaskSpawnFailed(#[source] tokio::task::JoinError),
 

--- a/rats-cert/src/tee/coco/converter/grpc.rs
+++ b/rats-cert/src/tee/coco/converter/grpc.rs
@@ -139,11 +139,7 @@ impl CocoGrpcConverter {
 
         let mut client =
             {
-                #[cfg(not(all(
-                    target_arch = "wasm32",
-                    target_vendor = "unknown",
-                    target_os = "unknown"
-                )))]
+                #[cfg(not(wasm))]
                 {
                     let endpoint = tonic::transport::Endpoint::new(self.as_addr.to_string())
                         .map_err(|e| Error::GrpcEndpointCreateFailed {
@@ -160,11 +156,7 @@ impl CocoGrpcConverter {
                             })?,
                     )
                 }
-                #[cfg(all(
-                    target_arch = "wasm32",
-                    target_vendor = "unknown",
-                    target_os = "unknown"
-                ))]
+                #[cfg(wasm)]
                 as_api::v1_6_0::attestation_service_client::AttestationServiceClient::new(
                     tonic_web_wasm_client::Client::new(self.as_addr.to_string()),
                 )
@@ -181,20 +173,12 @@ impl CocoGrpcConverter {
             Ok::<_, Error>(response)
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         // In wasm32 (web), the tonic Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Sen. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
         let response = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(Error::TaskSpawnFailed)??;
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let response = fut.await?;
 
         let attestation_token = response.attestation_token;
@@ -232,11 +216,7 @@ impl CocoGrpcConverter {
 
         let mut client =
             {
-                #[cfg(not(all(
-                    target_arch = "wasm32",
-                    target_vendor = "unknown",
-                    target_os = "unknown"
-                )))]
+                #[cfg(not(wasm))]
                 {
                     let endpoint = tonic::transport::Endpoint::new(self.as_addr.to_string())
                         .map_err(|e| Error::GrpcEndpointCreateFailed {
@@ -253,11 +233,7 @@ impl CocoGrpcConverter {
                             })?,
                     )
                 }
-                #[cfg(all(
-                    target_arch = "wasm32",
-                    target_vendor = "unknown",
-                    target_os = "unknown"
-                ))]
+                #[cfg(wasm)]
                 as_api::v1_5_2::attestation_service_client::AttestationServiceClient::new(
                     tonic_web_wasm_client::Client::new(self.as_addr.to_string()),
                 )
@@ -274,20 +250,12 @@ impl CocoGrpcConverter {
             Ok::<_, Error>(response)
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         // In wasm32 (web), the tonic Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Sen. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
         let response = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(Error::TaskSpawnFailed)??;
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let response = fut.await?;
 
         let attestation_token = response.attestation_token;

--- a/rats-cert/src/tee/coco/converter/restful.rs
+++ b/rats-cert/src/tee/coco/converter/restful.rs
@@ -179,20 +179,12 @@ impl GenericConverter for CocoRestfulConverter {
             Ok::<_, Error>((status, text))
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Send. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
         let (status, text) = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(|e| Error::TaskSpawnFailed(e))??;
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let (status, text) = fut.await?;
 
         let body_text = match status {
@@ -276,20 +268,12 @@ impl CocoRestfulConverter {
             Ok::<_, Error>((status, text))
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Send. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
         let (status, text) = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(|e| Error::TaskSpawnFailed(e))??;
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let (status, text) = fut.await?;
 
         let attestation_token = match status {
@@ -357,20 +341,12 @@ impl CocoRestfulConverter {
             Ok::<_, Error>((status, text))
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Sen. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
         let (status, text) = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(|e| Error::TaskSpawnFailed(e))??;
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let (status, text) = fut.await?;
 
         let attestation_token = match status {

--- a/rats-cert/src/tee/coco/verifier/token/jwk.rs
+++ b/rats-cert/src/tee/coco/verifier/token/jwk.rs
@@ -14,20 +14,12 @@ use jsonwebtoken::{decode, decode_header, jwk, Algorithm, DecodingKey, Header, V
 use reqwest::Url;
 use rustls_pki_types::pem::PemObject;
 use rustls_pki_types::{CertificateDer, TrustAnchor, UnixTime};
-#[cfg(not(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown",
-)))]
+#[cfg(not(wasm))]
 use rustls_webpki::aws_lc_rs::{
     ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256, ECDSA_P384_SHA384,
     RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512,
 };
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown",
-))]
+#[cfg(wasm)]
 use rustls_webpki::ring::{
     ECDSA_P256_SHA256, ECDSA_P256_SHA384, ECDSA_P384_SHA256, ECDSA_P384_SHA384,
     RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512,
@@ -78,11 +70,7 @@ async fn get_jwks_from_file_or_url(
         "https" => {
             url.set_path(OPENID_CONFIG_URL_SUFFIX);
 
-            #[cfg(all(
-                target_arch = "wasm32",
-                target_vendor = "unknown",
-                target_os = "unknown"
-            ))]
+            #[cfg(wasm)]
             let client = client.clone(); // Fix compile lifetime error
 
             let fut = async move {
@@ -107,30 +95,18 @@ async fn get_jwks_from_file_or_url(
                 Ok(jwkset)
             };
 
-            #[cfg(all(
-                target_arch = "wasm32",
-                target_vendor = "unknown",
-                target_os = "unknown"
-            ))]
+            #[cfg(wasm)]
             // In wasm32 (web), the reqwest Response future is not `Send` but #[async_trait::async_trait] requires the function body to be Send. So we have to spawn it with tokio_with_wasm::task::spawn and await for it.
             let ret = tokio_with_wasm::task::spawn(fut)
                 .await
                 .map_err(|e| JwksGetError::AccessFailed(e.to_string()))
                 .and_then(|e| e);
-            #[cfg(not(all(
-                target_arch = "wasm32",
-                target_vendor = "unknown",
-                target_os = "unknown"
-            )))]
+            #[cfg(not(wasm))]
             let ret = fut.await;
             ret
         }
         "file" => {
-            #[cfg(not(all(
-                target_arch = "wasm32",
-                target_vendor = "unknown",
-                target_os = "unknown"
-            )))]
+            #[cfg(not(wasm))]
             {
                 let file_content = tokio::fs::read(url.path()).await.map_err(|e| {
                     JwksGetError::AccessFailed(format!("open {}: {}", url.path(), e))
@@ -139,11 +115,7 @@ async fn get_jwks_from_file_or_url(
                 serde_json::from_slice(&file_content)
                     .map_err(|e| JwksGetError::DeserializeSource(e.to_string()))
             }
-            #[cfg(all(
-                target_arch = "wasm32",
-                target_vendor = "unknown",
-                target_os = "unknown"
-            ))]
+            #[cfg(wasm)]
             {
                 Err(JwksGetError::AccessFailed(format!(
                     "open {}: file access is not supported in wasm",
@@ -195,11 +167,7 @@ impl JwkAttestationTokenVerifier {
 
             // Load certificates from file paths
             for path in &config.trusted_certs_paths {
-                #[cfg(not(all(
-                    target_arch = "wasm32",
-                    target_vendor = "unknown",
-                    target_os = "unknown"
-                )))]
+                #[cfg(not(wasm))]
                 {
                     let cert_content = tokio::fs::read(path).await.map_err(|e| {
                         JwksGetError::AccessFailed(format!(
@@ -212,11 +180,7 @@ impl JwkAttestationTokenVerifier {
 
                     trusted_certs.push(cert_der);
                 }
-                #[cfg(all(
-                    target_arch = "wasm32",
-                    target_vendor = "unknown",
-                    target_os = "unknown"
-                ))]
+                #[cfg(wasm)]
                 {
                     Err(JwksGetError::AccessFailed(format!(
                         "failed to read certificate {path}: not supported in wasm"
@@ -248,11 +212,7 @@ impl JwkAttestationTokenVerifier {
 
         let url = format!("{}/certificate", as_addr.trim_end_matches('/'));
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         let client = client.clone(); // Fix compile lifetime error
 
         let fut = async move {
@@ -277,21 +237,13 @@ impl JwkAttestationTokenVerifier {
             Ok(cert_ders)
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         let ret = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(|e| anyhow!("Failed to spawn task: {}", e))
             .and_then(|r| r);
 
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let ret = fut.await;
 
         ret

--- a/rats-cert/src/tee/ita/converter.rs
+++ b/rats-cert/src/tee/ita/converter.rs
@@ -141,20 +141,12 @@ impl ItaConverter {
             Ok(body)
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         let result = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(|e| Error::ItaError(format!("Failed to spawn ITA request task: {e}")))
             .and_then(|e| e);
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let result = fut.await;
 
         result

--- a/rats-cert/src/tee/ita/retry.rs
+++ b/rats-cert/src/tee/ita/retry.rs
@@ -2,19 +2,11 @@ use std::future::Future;
 use std::time::Duration;
 
 async fn sleep(duration: Duration) {
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    ))]
+    #[cfg(wasm)]
     {
         tokio_with_wasm::alias::time::sleep(duration).await;
     }
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        target_vendor = "unknown",
-        target_os = "unknown"
-    )))]
+    #[cfg(not(wasm))]
     {
         tokio::time::sleep(duration).await;
     }

--- a/rats-cert/src/tee/ita/verifier.rs
+++ b/rats-cert/src/tee/ita/verifier.rs
@@ -144,20 +144,12 @@ impl ItaVerifier {
                 .collect::<Vec<CachedKey>>())
         };
 
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         let keys = tokio_with_wasm::task::spawn(fut)
             .await
             .map_err(|e| Error::ItaError(format!("Failed to spawn JWKS refresh task: {e}")))
             .and_then(|e| e)?;
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let keys = fut.await?;
 
         let mut cache = JWKS_CACHE.write().await;

--- a/tng-wasm/Cargo.toml
+++ b/tng-wasm/Cargo.toml
@@ -55,6 +55,9 @@ tokio_with_wasm_proc = {workspace = true}
 reqwest = {workspace = true}
 wasm-bindgen-test = "0.3.76"
 
+[build-dependencies]
+cfg_aliases = {workspace = true}
+
 # https://github.com/rustwasm/wasm-pack/issues/1351#issuecomment-2100231587
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 # this works the same as `--keep-debug` in wasm-bindgen

--- a/tng-wasm/build.rs
+++ b/tng-wasm/build.rs
@@ -1,0 +1,9 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+        // Platforms
+        wasm: { all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown") },
+        // "unix" is already defined by rustc so we skip it here: https://doc.rust-lang.org/reference/conditional-compilation.html#unix-and-windows
+    }
+}

--- a/tng-wasm/tests/fetch_error.rs
+++ b/tng-wasm/tests/fetch_error.rs
@@ -3,7 +3,7 @@
 //! browser-opacity hint. Exercises the patched reqwest fork's
 //! `crate::error::wasm()` end-to-end via the real `reqwest` wasm client.
 
-#![cfg(target_arch = "wasm32")]
+#![cfg(wasm)]
 
 extern crate wasm_bindgen_test;
 

--- a/tng-wasm/tests/web.rs
+++ b/tng-wasm/tests/web.rs
@@ -1,6 +1,6 @@
 //! Test suite for the Web and headless browsers.
 
-#![cfg(target_arch = "wasm32")]
+#![cfg(wasm)]
 #![feature(impl_trait_in_fn_trait_return)]
 
 extern crate wasm_bindgen_test;

--- a/tng/src/lib.rs
+++ b/tng/src/lib.rs
@@ -80,17 +80,9 @@ pub(crate) mod tests {
     #[ctor::ctor]
     fn init() {
         // Initialize rustls crypto provider
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        )))]
+        #[cfg(not(wasm))]
         let provider = rustls::crypto::aws_lc_rs::default_provider();
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ))]
+        #[cfg(wasm)]
         let provider = rustls::crypto::ring::default_provider();
         provider
             .install_default()

--- a/tng/src/tunnel/utils/http_inspector.rs
+++ b/tng/src/tunnel/utils/http_inspector.rs
@@ -5,17 +5,9 @@ use bytes::BytesMut;
 use http::{uri::Authority, Uri};
 use scopeguard::defer;
 use tokio::io::{AsyncReadExt, AsyncWriteExt as _};
-#[cfg(not(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-)))]
+#[cfg(not(wasm))]
 use tokio::time as tokio_time;
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
+#[cfg(wasm)]
 use tokio_with_wasm::alias::time as tokio_time;
 
 const HTTP_INSPECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);

--- a/tng/src/tunnel/utils/maybe_cached.rs
+++ b/tng/src/tunnel/utils/maybe_cached.rs
@@ -14,17 +14,9 @@ use tokio::time as tokio_time;
 #[cfg(wasm)]
 use tokio_with_wasm::alias::time as tokio_time;
 
-#[cfg(not(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-)))]
+#[cfg(not(wasm))]
 use std::time::SystemTime;
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
+#[cfg(wasm)]
 use web_time::SystemTime;
 
 use crate::error::TngError;


### PR DESCRIPTION
## Summary

Replace the verbose `#[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]` and its `not(...)` form with the short `#[cfg(wasm)]` / `#[cfg(not(wasm))]` alias throughout the source, and roll the `wasm` `cfg_alias` out to every crate that needs it.

`tng` already had the `wasm` alias in its `build.rs`; this PR applies the same alias to the remaining crates and converts their long-form cfgs:

- `rats-cert` — add `cfg_aliases` build-dep + macro to `build.rs`; convert `errors.rs`, `tee/coco/verifier/token/jwk.rs`, `tee/coco/converter/{grpc,restful}.rs`, `tee/ita/{converter,retry,verifier}.rs`
- `deps/hyper-util-shim` — new `build.rs` + `cfg_aliases`; convert `src/lib.rs`
- `tng-wasm` — new `build.rs` + `cfg_aliases`; convert test gates in `tests/{web,fetch_error}.rs`
- `tng` — mop up residual long forms in `src/lib.rs` and `src/tunnel/utils/{http_inspector,maybe_cached}.rs`

`Cargo.toml` `[target.'cfg(...)'.dependencies]` sections are intentionally left in long form — they are evaluated by cargo itself and are unaffected by `cfg_aliases`, which only applies to `#[cfg(...)]` in Rust source.

No behavior change.

## Verification

- `cargo fmt` ✅
- `cargo check` ✅ (native, covers `tng` + dep chain `rats-cert` / `hyper-util-shim` / `tng-hook-types`)
- `cargo build -p tng` / `cargo build -p rats-cert` ✅ (native)
- `make wasm-build-debug` ✅ (wasm32-unknown-unknown; alias verified on both native and wasm sides)
- `make clippy` ✅
- grep audit: no full-triple wasm cfg remains in `.rs` source (only the alias definitions in each `build.rs`)