### PR TITLE
refactor(time): switch to web-time-compat for wasm-safe SystemTime/Instant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8078,7 +8078,7 @@ dependencies = [
  "url",
  "uuid",
  "wasm-bindgen-futures",
- "web-time",
+ "web-time-compat",
  "which 7.0.3",
  "ws_stream_tungstenite",
  "ws_stream_wasm",
@@ -9365,6 +9365,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time-compat"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39819265f219f60a92312f2755262dba9fff180a4ec281556863d69fa36adc59"
+dependencies = [
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ wasm-bindgen-futures = "0.4.50"
 wasm-streams = "0.4.2"
 web-sys = {version = "0.3.77"}
 web-time = "1.1.0"
+web-time-compat = "0.1.0"
 which = "7.0.3"
 ws_stream_tungstenite = "0.13.0"
 ws_stream_wasm = "=0.7.5"

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,4 +4,6 @@ disallowed-methods = [
   {path = "tokio::task::spawn", reason = "please use 'TokioRuntime::spawn_*()' methods instaed"},
   {path = "tokio::spawn", reason = "please use 'TokioRuntime::spawn_*()' methods instaed"},
   {path = "tokio::runtime::handle::Handle::spawn", reason = "please use 'TokioRuntime::spawn_*()' methods instaed"},
+  {path = "std::time::SystemTime::now", reason = "use 'web_time_compat::SystemTimeExt::get()' instead — it is wasm-safe (std::time::SystemTime::now panics on wasm32-unknown-unknown)"},
+  {path = "std::time::Instant::now", reason = "use 'web_time_compat::InstantExt::get()' instead — it is wasm-safe (std::time::Instant::now panics on wasm32-unknown-unknown)"},
 ]

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -106,6 +106,7 @@ tracing-opentelemetry = {workspace = true, optional = true}
 tracing-subscriber = {workspace = true}
 url = {workspace = true}
 uuid = {workspace = true, features = ["v4"], optional = true}
+web-time-compat = {workspace = true}
 which = {workspace = true, optional = true}
 x509-cert = {workspace = true}
 
@@ -137,7 +138,6 @@ serde-wasm-bindgen = {workspace = true}
 tokio = {workspace = true, default-features = false}
 tokio_with_wasm = {workspace = true}
 wasm-bindgen-futures = {workspace = true}
-web-time = {workspace = true}
 ws_stream_wasm = {workspace = true}
 
 [build-dependencies]

--- a/tng/src/observability/metric/simple_exporter/falcon.rs
+++ b/tng/src/observability/metric/simple_exporter/falcon.rs
@@ -202,7 +202,7 @@ impl SimpleMetricExporter for FalconExporter {
 #[cfg(test)]
 mod tests {
 
-    use std::time::SystemTime;
+    use web_time_compat::{SystemTime, SystemTimeExt};
 
     use crate::{config::TngConfig, runtime::TngRuntime};
     use axum::{extract::State, routing::post, Json, Router};
@@ -273,7 +273,7 @@ mod tests {
             value: 1.into(),
             value_type: ValueType::Gauge,
             attributes: Default::default(),
-            time: SystemTime::now(),
+            time: SystemTime::get(),
         })?;
         assert!(falcon_metric.timestamp > 0);
         falcon_metric.timestamp = timestamp; // Let's ignore the timestamp difference
@@ -299,7 +299,7 @@ mod tests {
             value: 256.into(),
             value_type: ValueType::Counter,
             attributes: [("ingress_id".to_string(), "10".to_string())].into(),
-            time: SystemTime::now(),
+            time: SystemTime::get(),
         })?;
         assert!(falcon_metric.timestamp > 0);
         falcon_metric.timestamp = timestamp; // Let's ignore the timestamp difference
@@ -325,7 +325,7 @@ mod tests {
             value: 20.into(),
             value_type: ValueType::Gauge,
             attributes: [("ingress_id".to_string(), "5".to_string())].into(),
-            time: SystemTime::now(),
+            time: SystemTime::get(),
         })?;
 
         assert!(falcon_metric.timestamp > 0);

--- a/tng/src/tunnel/egress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/egress/datagram_flow/mod.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use web_time_compat::{Duration, Instant, InstantExt};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -191,7 +191,7 @@ impl DatagramEgressFlow {
         }
 
         let idle_timeout = Duration::from_secs(idle_timeout_secs);
-        let last_activity = Arc::new(Mutex::new(Instant::now()));
+        let last_activity = Arc::new(Mutex::new(Instant::get()));
         let check_interval = Duration::from_secs(5);
 
         let conn_clone = connection.clone();
@@ -208,7 +208,7 @@ impl DatagramEgressFlow {
                         match datagram_result {
                             Ok(payload) => {
                                 let _ = backend_socket_a.send(&payload).await;
-                                *last_act_a.lock().await = Instant::now();
+                                *last_act_a.lock().await = Instant::get();
                             }
                             Err(_) => break,
                         }
@@ -243,7 +243,7 @@ impl DatagramEgressFlow {
                                     tracing::warn!(error = %e, "Failed to send datagram to QUIC");
                                     break;
                                 }
-                                *last_act_b.lock().await = Instant::now();
+                                *last_act_b.lock().await = Instant::get();
                             }
                             Err(_) => break,
                         }

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/mod.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/mod.rs
@@ -8,7 +8,7 @@
 use crate::status::StatusProvider;
 use crate::tunnel::ohttp::key_config::PublicKeyData;
 use crate::{error::TngError, tunnel::ohttp::key_config::KeyConfigExtend};
-use std::time::SystemTime;
+use web_time_compat::{SystemTime, SystemTimeExt};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -121,7 +121,7 @@ impl KeyInfo {
         )
         .map_err(TngError::from)?;
 
-        let actived_at = SystemTime::now();
+        let actived_at = SystemTime::get();
         // For file-based keys, we set rotation_interval to 30 years (in seconds)
         // to make stale_at and expire_at far in the future
         let rotation_interval = 86400u64 * 365 * 30;
@@ -159,19 +159,11 @@ impl std::fmt::Debug for KeyInfo {
 
 /// Format a `SystemTime` for debug output.
 ///
-/// On unix we use `chrono` for a human-readable string, but on wasm the
-/// `SystemTime` may be `web_time::SystemTime` which chrono doesn't know
-/// about, so we fall back to printing the unix timestamp.
-#[cfg(not(wasm))]
+/// `SystemTime` is `std::time::SystemTime` on both native and wasm (via
+/// `web-time-compat`), so `chrono::DateTime<Utc>::from()` works everywhere —
+/// no need for a wasm-specific fallback path.
 fn format_system_time(t: SystemTime) -> String {
     chrono::DateTime::<chrono::Utc>::from(t).to_string()
-}
-#[cfg(wasm)]
-fn format_system_time(t: SystemTime) -> String {
-    match t.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(d) => format!("{}.{:09}", d.as_secs(), d.subsec_nanos()),
-        Err(_) => "before-epoch".to_string(),
-    }
 }
 
 /// Trait for managing OHTTP key configurations
@@ -197,7 +189,7 @@ pub trait KeyManager: StatusProvider + Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use web_time_compat::Duration;
 
     fn make_test_key_info(key_id: u8) -> KeyInfo {
         KeyInfo {
@@ -211,9 +203,9 @@ mod tests {
             )
             .expect("create key config"),
             status: KeyStatus::Active,
-            actived_at: SystemTime::now(),
-            stale_at: SystemTime::now() + Duration::from_secs(300),
-            expire_at: SystemTime::now() + Duration::from_secs(600),
+            actived_at: SystemTime::get(),
+            stale_at: SystemTime::get() + Duration::from_secs(300),
+            expire_at: SystemTime::get() + Duration::from_secs(600),
         }
     }
 

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/cluster_key_set.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/cluster_key_set.rs
@@ -5,7 +5,7 @@ use anyhow::Context as _;
 use itertools::Itertools as _;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::SystemTime;
+use web_time_compat::{SystemTime, SystemTimeExt};
 
 /// Cluster key set containing all keys indexed by public_key.
 ///
@@ -238,7 +238,7 @@ impl ClusterKeySet {
             .filter(|k| k.status == KeyStatus::Active)
             .map(|k| k.stale_at)
             .max()
-            .unwrap_or_else(SystemTime::now);
+            .unwrap_or_else(SystemTime::get);
 
         // Generate new pending key
         let pending_key = KeyInfo::generate(
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_remove_expired_keys() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         // Create an active key that is NOT expired (to maintain Vec1 invariant)
         let active_key = KeyInfo {
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_get_client_visible_key_multiple_active_tiebreaker() {
         // Create two active keys with different expire_at
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         let key1 = KeyInfo {
             key_config: ohttp::KeyConfig::new(
@@ -570,7 +570,7 @@ mod tests {
 
     #[test]
     fn test_get_client_visible_key_ignores_pending_and_stale() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         let active_key = KeyInfo {
             key_config: ohttp::KeyConfig::new(
@@ -656,7 +656,7 @@ mod tests {
 
     #[test]
     fn test_merge_overlapping_keys_local_wins() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         // Create two keys with same public key (same underlying key pair) but different metadata
         let key1_old = KeyInfo {
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_next_deadline_mixed_statuses() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         let pending_key = KeyInfo {
             key_config: ohttp::KeyConfig::new(
@@ -839,7 +839,7 @@ mod tests {
             notify: None,
         };
 
-        // Should still generate a pending key (actived_at defaults to SystemTime::now)
+        // Should still generate a pending key (actived_at defaults to SystemTime::get)
         let result = cks.generate_pending_key_if_none();
         assert!(result.is_ok());
         assert!(result.unwrap().is_some());
@@ -852,7 +852,7 @@ mod tests {
 
     #[test]
     fn test_transition_active_to_stale_preserves_last_active() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         // Create a single active key whose stale_at is in the past
         let active_key = KeyInfo {
@@ -883,7 +883,7 @@ mod tests {
 
     #[test]
     fn test_transition_active_to_stale_with_multiple_active() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         let key1 = KeyInfo {
             key_config: ohttp::KeyConfig::new(
@@ -952,7 +952,7 @@ mod tests {
 
     #[test]
     fn test_transition_pending_to_active_boundary() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         let pending_key_at_boundary = KeyInfo {
             key_config: ohttp::KeyConfig::new(
@@ -1020,7 +1020,7 @@ mod tests {
 
     #[test]
     fn test_remove_expired_keys_all_active_expired_preserves_latest_stale() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
 
         let key1 = KeyInfo {
             key_config: ohttp::KeyConfig::new(

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/peer_shared/serf.rs
@@ -32,7 +32,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::SystemTime;
+use web_time_compat::{SystemTime, SystemTimeExt};
 
 use crate::tunnel::ra_context::RaContext;
 
@@ -384,7 +384,7 @@ impl PeerSharedKeyManager {
 
         // Bootstrap: create initial active key
         let initial_key =
-            KeyInfo::generate(0, KeyStatus::Active, SystemTime::now(), rotation_interval).map_err(
+            KeyInfo::generate(0, KeyStatus::Active, SystemTime::get(), rotation_interval).map_err(
                 |e| {
                     TngError::KeyUpdateMessageDecodeError(
                         anyhow::Error::from(e).context("Failed to generate initial key"),
@@ -417,7 +417,7 @@ impl PeerSharedKeyManager {
             tracing::info!("Starting key watcher");
 
             loop {
-                let now = SystemTime::now();
+                let now = SystemTime::get();
 
                 let should_check_rotation = {
                     let mut cks = inner.cluster_key_set.write().await;
@@ -1092,7 +1092,7 @@ mod tests {
     use crate::tunnel::egress::protocol::ohttp::security::key_manager::KeyManager;
     use anyhow::{anyhow, Result};
     use hex;
-    use std::time::Duration;
+    use web_time_compat::{Duration, Instant, InstantExt};
 
     // -----------------------------------------------------------------------
     // Helper functions
@@ -1125,7 +1125,7 @@ mod tests {
         expected: usize,
         timeout: Duration,
     ) -> Result<()> {
-        let start = std::time::Instant::now();
+        let start = Instant::get();
         loop {
             if start.elapsed() > timeout {
                 let members = target.serf.members().await;
@@ -1156,7 +1156,7 @@ mod tests {
         expected_pk: &PublicKeyData,
         timeout: Duration,
     ) -> Result<()> {
-        let start = std::time::Instant::now();
+        let start = Instant::get();
         loop {
             if start.elapsed() > timeout {
                 return Err(anyhow!(
@@ -1180,7 +1180,7 @@ mod tests {
         expected_count: usize,
         timeout: Duration,
     ) -> Result<()> {
-        let start = std::time::Instant::now();
+        let start = Instant::get();
         loop {
             if start.elapsed() > timeout {
                 let cks = target.inner.cluster_key_set.read().await;
@@ -1301,7 +1301,7 @@ mod tests {
         removed_pk: &PublicKeyData,
         timeout: Duration,
     ) -> Result<()> {
-        let start = std::time::Instant::now();
+        let start = Instant::get();
         loop {
             if start.elapsed() > timeout {
                 let cks = target.inner.cluster_key_set.read().await;

--- a/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/self_generated.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/key_manager/self_generated.rs
@@ -9,7 +9,7 @@ use crate::tunnel::utils::runtime::TokioRuntime;
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use web_time_compat::{Duration, SystemTime, SystemTimeExt};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -96,8 +96,8 @@ impl RandomKeyManagerInner {
     /// Calculate when the next key refresh should happen
     ///
     /// Returns the duration until the next refresh is needed
-    async fn calculate_next_refresh_time(&self) -> std::time::Duration {
-        let now = SystemTime::now();
+    async fn calculate_next_refresh_time(&self) -> Duration {
+        let now = SystemTime::get();
         let mut earliest_time = now + Duration::from_secs(self.rotation_interval);
 
         let keys = self.keys.read().await;
@@ -127,7 +127,7 @@ impl RandomKeyManagerInner {
     /// - Expired keys are removed
     /// - A new key is generated if no active key exists, with a lifetime of 2 * `rotation_interval`.
     async fn refresh_keys(&self) -> Result<(), TngError> {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
         let mut keys = self.keys.write().await;
 
         // Remove expired keys

--- a/tng/src/tunnel/egress/protocol/ohttp/security/server.rs
+++ b/tng/src/tunnel/egress/protocol/ohttp/security/server.rs
@@ -13,6 +13,7 @@ use tower_http::{
     },
     cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer, ExposeHeaders},
 };
+use web_time_compat::{Instant, InstantExt};
 
 use crate::status::{StatusProvider, StatusQueryResult};
 use crate::tunnel::ra_context::RaContext;
@@ -285,7 +286,7 @@ pub async fn log_request(
     let method = req.method().clone();
     let uri = req.uri().clone();
     let version = req.version();
-    let start = std::time::Instant::now();
+    let start = Instant::get();
 
     let ohttp_api = req
         .headers()

--- a/tng/src/tunnel/ingress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/ingress/datagram_flow/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use web_time_compat::{Duration, Instant, InstantExt};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -164,7 +164,7 @@ impl RegistedService for DatagramIngressFlow {
                             let access_established =
                                 access_routed.into_established(None, false);
 
-                            let last_activity = Arc::new(Mutex::new(Instant::now()));
+                            let last_activity = Arc::new(Mutex::new(Instant::get()));
 
                             let metrics = self.metrics.clone();
                             let active_cx = metrics.new_cx();
@@ -194,7 +194,7 @@ impl RegistedService for DatagramIngressFlow {
                                                             "Failed to send datagram to client"
                                                         );
                                                     } else {
-                                                        *last_activity_clone.lock().await = Instant::now();
+                                                        *last_activity_clone.lock().await = Instant::get();
                                                         success = true;
                                                     }
                                                 }
@@ -228,7 +228,7 @@ impl RegistedService for DatagramIngressFlow {
                     };
 
                     // Update activity and forward
-                    *session.last_activity.lock().await = Instant::now();
+                    *session.last_activity.lock().await = Instant::get();
                     if let Err(e) = session.tunnel.send_datagram(payload) {
                         tracing::warn!(
                             %client_src,

--- a/tng/src/tunnel/utils/maybe_cached.rs
+++ b/tng/src/tunnel/utils/maybe_cached.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use futures::FutureExt as _;
 use std::cmp::{Ord, Ordering, PartialOrd};
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{pin::Pin, sync::Arc};
 use tokio::select;
 
 #[cfg(not(wasm))]
@@ -14,10 +14,12 @@ use tokio::time as tokio_time;
 #[cfg(wasm)]
 use tokio_with_wasm::alias::time as tokio_time;
 
-#[cfg(not(wasm))]
-use std::time::SystemTime;
-#[cfg(wasm)]
-use web_time::SystemTime;
+// `web-time-compat` provides `SystemTime`/`Duration` (aliases for the `std`
+// types) and the `SystemTimeExt::get()` method, which is the wasm-safe
+// replacement for `SystemTime::get()` (the latter panics on
+// `wasm32-unknown-unknown`). Using a single, non-cfg-gated import means the
+// same code path works on both native and wasm.
+use web_time_compat::{Duration, SystemTime, SystemTimeExt};
 
 use crate::error::TngError;
 use crate::tunnel::utils::runtime::{
@@ -26,19 +28,11 @@ use crate::tunnel::utils::runtime::{
 
 /// Format a `SystemTime` as a human-readable string.
 ///
-/// On unix we can use `chrono::DateTime<Utc>::from()`, but on wasm the
-/// `SystemTime` is `web_time::SystemTime` which chrono doesn't know about,
-/// so we fall back to printing the unix timestamp.
-#[cfg(not(wasm))]
+/// `SystemTime` is `std::time::SystemTime` on both native and wasm (via
+/// `web-time-compat`), so `chrono::DateTime<Utc>::from()` works everywhere —
+/// no need for a wasm-specific fallback path.
 fn format_system_time(t: SystemTime) -> String {
     chrono::DateTime::<chrono::Utc>::from(t).to_string()
-}
-#[cfg(wasm)]
-fn format_system_time(t: SystemTime) -> String {
-    match t.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(d) => format!("{}.{:09}", d.as_secs(), d.subsec_nanos()),
-        Err(_) => "before-epoch".to_string(),
-    }
 }
 
 /// Represents an optional expiration time.
@@ -73,7 +67,7 @@ impl Ord for Expire {
 impl Expire {
     pub fn from_timestamp(timestamp_seconds: u64) -> Result<Self, TngError> {
         let input_system_time = SystemTime::UNIX_EPOCH
-            .checked_add(std::time::Duration::from_secs(timestamp_seconds))
+            .checked_add(Duration::from_secs(timestamp_seconds))
             .with_context(|| {
                 format!(
                     "the expire timestamp is too far in the future to be represented: {timestamp_seconds}"
@@ -81,12 +75,9 @@ impl Expire {
             }).map_err(TngError::BadExpireTimeStamp)?;
 
         // Sanity check
-        let now = SystemTime::now();
+        let now = SystemTime::get();
         if input_system_time < now.checked_sub(Duration::from_secs(120)).unwrap_or(now) {
             // Just log there instead of throw an error
-            // Use duration_since_unix_epoch to work on both unix (std::time::SystemTime)
-            // and wasm (web_time::SystemTime), since chrono::DateTime<Utc> only
-            // implements From<std::time::SystemTime>.
             tracing::warn!(
                 expire = format_system_time(input_system_time),
                 now = format_system_time(now),
@@ -178,7 +169,7 @@ impl<
                                         fut
                                     }
                                     Expire::ExpireAt(expire_time) => {
-                                        let now = SystemTime::now();
+                                        let now = SystemTime::get();
                                         let duration =
                                             expire_time.duration_since(now).unwrap_or_default(); // If already expired, set the duration to 0
                                                                                                  // Force a minimum sleep interval to prevent busy-wait loops
@@ -292,12 +283,11 @@ mod tests {
 
     use super::*;
     use crate::tests::run_test_with_tokio_runtime;
-    use std::time::Duration;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use web_time_compat::{Instant, InstantExt};
 
     #[test]
     fn test_expire_min_max() {
-        let now = SystemTime::now();
+        let now = SystemTime::get();
         let past = now - Duration::from_secs(3600);
         let future = now + Duration::from_secs(3600);
 
@@ -319,8 +309,8 @@ mod tests {
     #[test]
     fn test_expire_from_timestamp_valid_future() {
         // Create a future timestamp (current time + 100 seconds)
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+        let now = SystemTime::get()
+            .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
         let future_timestamp = now + 100;
@@ -338,8 +328,8 @@ mod tests {
     #[test]
     fn test_expire_from_timestamp_current_time() {
         // Use current timestamp
-        let current_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+        let current_timestamp = SystemTime::get()
+            .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
@@ -352,8 +342,8 @@ mod tests {
     #[test]
     fn test_expire_from_timestamp_past_time() {
         // Create a past timestamp (current time - 100 seconds)
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+        let now = SystemTime::get()
+            .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
         let past_timestamp = now - 100;
@@ -495,7 +485,7 @@ mod tests {
                         let count =
                             call_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
                         // Expire after 100ms
-                        let expire_at = SystemTime::now() + tokio_time::Duration::from_millis(1000);
+                        let expire_at = SystemTime::get() + tokio_time::Duration::from_millis(1000);
                         Ok((format!("value{count}"), Expire::ExpireAt(expire_at)))
                     })
                 },
@@ -556,7 +546,7 @@ mod tests {
                         let count =
                             call_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
                         // Expire after 100ms
-                        let expire_at = SystemTime::now() + tokio_time::Duration::from_secs(1000); // Long expire time, rely on refresh interval instead.
+                        let expire_at = SystemTime::get() + tokio_time::Duration::from_secs(1000); // Long expire time, rely on refresh interval instead.
                         Ok((format!("value{count}"), Expire::ExpireAt(expire_at)))
                     })
                 },
@@ -633,10 +623,10 @@ mod tests {
                 move || {
                     let call_times_clone = call_times_clone.clone();
                     Box::pin(async move {
-                        call_times_clone.lock().unwrap().push(std::time::Instant::now());
+                        call_times_clone.lock().unwrap().push(Instant::get());
                         // Return a PAST expire time (1 hour ago) to simulate
                         // a server returning an outdated timestamp.
-                        let past = SystemTime::now() - Duration::from_secs(3600);
+                        let past = SystemTime::get() - Duration::from_secs(3600);
                         Ok(("value".to_string(), Expire::ExpireAt(past)))
                     })
                 },


### PR DESCRIPTION
## Summary

Switch the project from the cfg-gated `web-time` pattern to [`web-time-compat`](https://crates.io/crates/web-time-compat), so `SystemTime`/`Instant` work uniformly on native **and** `wasm32-unknown-unknown` without cfg-gating the type.

`web-time-compat`'s philosophy: keep `SystemTime` as the `std::time::SystemTime` type on all targets (it's just a data type on wasm — only `now()` panics) and provide `SystemTimeExt::get()` / `InstantExt::get()` as the wasm-safe replacement for `::now()`.

## Changes

- **Deps**: add `web-time-compat = "0.1.0"` workspace dep; in `tng` move it to a normal `[dependencies]` entry and drop the wasm-gated `web-time` (compat pulls web-time on wasm automatically). Pinned to 0.1.0 because 0.2.0 needs rustc 1.91 while the active toolchain is 1.89; bump to 0.2.0 once the toolchain reaches 1.91+.
- **Migration**: every `SystemTime::now()` / `std::time::Instant::now()` call site in `tng` (including tests) → `SystemTime::get()` / `Instant::get()`, with imports switched to the `web_time_compat` aliases. Files: `maybe_cached`, `key_manager/{mod,self_generated}`, `peer_shared/{cluster_key_set,serf}`, `falcon`, `security/server`, `ingress+egress datagram_flow`.
- **Lint**: add `std::time::SystemTime::now` and `std::time::Instant::now` to `disallowed-methods` in `clippy.toml` so they can't sneak back in.
- **Cleanup**: unify the `format_system_time` helpers in `maybe_cached.rs` and `key_manager/mod.rs` — `SystemTime` is now the std type on both targets, so chrono works on wasm and the wasm-only fallback is removed.

`rats-cert` keeps its `web-time` dep (no direct `now()` usage); `serf_message.rs` / `peer_shared/key_manager.rs` keep `std::time::SystemTime` as a plain data type (no `now()`), which the crate explicitly endorses.

## Behavior

- Native: no change (`get()` == `now()` there).
- Wasm: the previously-panicking `now()` paths (e.g. `maybe_cached`, `ingress/datagram_flow`) now work via the compat layer; `format_system_time` now produces human-readable chrono output on wasm instead of a raw unix timestamp.

## Verification

- `cargo fmt` / `cargo fmt --check` ✅
- `make clippy` (`cargo clippy --all-targets -- -D warnings`, with the new `disallowed-methods` active) ✅
- `cargo build` ✅
- `make wasm-build-debug` (nightly-2025-07-07, wasm32) ✅ — confirms the `__ingress-common` slice (incl. `maybe_cached` + `ingress/datagram_flow` and the unified `format_system_time`) compiles and links on wasm.

> Note: egress / observability code (`key_manager`, `security/server`, `falcon`, `egress/datagram_flow`) is `#[cfg(not(wasm))]` / egress-feature-gated and is not part of the wasm build; it is covered by native `make clippy` + `cargo build` (the `disallowed-methods` lint enforces `get()` there too). No `version_compatibility` row since this is an internal refactor with no public API/behavior change.