### PR TITLE
test(tng): mark ITA env-var tests serial to avoid env races

### DIFF
--- a/tng/src/config/ra.rs
+++ b/tng/src/config/ra.rs
@@ -1786,6 +1786,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_ita_api_key_defaults_from_env() {
         let env_key = "env-key-456";
         let json = json!({
@@ -1845,6 +1846,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_ita_background_check_verify_into_checked_rejects_missing_api_key() {
         std::env::remove_var(ITA_API_KEY_ENV);
         let json = json!({
@@ -1873,6 +1875,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_ita_passport_attest_into_checked_rejects_missing_api_key() {
         std::env::remove_var(ITA_API_KEY_ENV);
         let json = json!({


### PR DESCRIPTION
The ITA env-var tests mutate the shared process environment (`ITA_API_KEY`), so running them concurrently with other tests in the same process causes flaky failures when another test reads or sets that var mid-flight.

Annotate the three affected tests with `#[serial_test::serial]` to force serial execution. `serial_test` is already a workspace dependency of the `tng` crate.

## Why
- These tests call `std::env::set_var` / `remove_var` on `ITA_API_KEY_ENV`, which is process-global state. Under the default multi-threaded test runner they can race with sibling tests that touch the same var, producing intermittent failures that are unrelated to the code under test.
- Serializing only the tests that share this mutable env var avoids the race without slowing down the rest of the suite.

## What changed
- `tng/src/config/ra.rs`: add `#[serial_test::serial]` to:
  - `test_ita_api_key_defaults_from_env`
  - `test_ita_background_check_verify_into_checked_rejects_missing_api_key`
  - `test_ita_passport_attest_into_checked_rejects_missing_api_key`

No production code or behavior change — test-only.