### PR TITLE
fix(ci): pin rv-release-tool to fixed trustee commit 28ce0c6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ test-dep-as:
 		chmod +x /usr/local/bin/rekor-cli; \
 	fi; \
 	if ! command -v rv-release-tool > /dev/null; then \
-		curl -sSL -o /usr/local/bin/rv-release-tool https://raw.githubusercontent.com/openanolis/trustee/28e0dd301ce1848ae539ee201260d5b85409a3f4/tools/slsa/rv-release-tool; \
+		curl -sSL -o /usr/local/bin/rv-release-tool https://raw.githubusercontent.com/openanolis/trustee/28ce0c67eb7caf3356f1759d77ec0add56d39a46/tools/slsa/rv-release-tool; \
 		chmod +x /usr/local/bin/rv-release-tool; \
 	fi; \
 	if ! command -v python3 > /dev/null; then \


### PR DESCRIPTION
## Summary

The SLSA test dependency install in the `Makefile` downloads `rv-release-tool` from the `openanolis/trustee` repo at a pinned commit. The previously pinned commit (`28e0dd3`) is affected by the bug fixed in [openanolis/trustee@28ce0c67eb7caf3356f1759d77ec0add56d39a46](https://github.com/openanolis/trustee/commit/28ce0c67eb7caf3356f1759d77ec0add56d39a46). This PR repins the download URL to that fixed commit.

## Changes

- `Makefile`: update the `rv-release-tool` download URL from commit `28e0dd301ce1848ae539ee201260d5b85409a3f4` to `28ce0c67eb7caf3356f1759d77ec0add56d39a46`.

## Audit of other `rv-release-tool` references

Two other places in the repo mention `rv-release-tool`, but neither contains a download URL, so neither required a change:

- `trusted-network-gateway.spec` — a `%changelog` entry describing a past build fix (text only).
- `rats-cert/src/tee/coco/converter/builtin.rs` — a code comment referencing the tool by name (text only).