### PR TITLE
test: harden curl-based integration checks

### DIFF
--- a/tng-testsuite/tests/netfilter/client_socks5_server_netfilter.rs
+++ b/tng-testsuite/tests/netfilter/client_socks5_server_netfilter.rs
@@ -10,10 +10,8 @@ use tng_testsuite::{
     },
 };
 
-#[serial]
-#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
-async fn test() -> Result<()> {
-    let tng_server = TngInstance::TngServer(
+fn tng_server() -> TngInstance {
+    TngInstance::TngServer(
         r#"
         {
             "add_egress": [
@@ -30,218 +28,199 @@ async fn test() -> Result<()> {
             ]
         }
         "#,
-    );
+    )
+}
 
-    // Test socks5 with no auth requirement
-    run_test!(vec![
-        tng_server.clone().boxed(),
-        TngInstance::TngClient(
-            r#"
+fn tng_client_no_auth() -> TngInstance {
+    TngInstance::TngClient(
+        r#"
+        {
+            "add_ingress": [
                 {
-                    "add_ingress": [
-                        {
-                            "socks5": {
-                                "proxy_listen": {
-                                    "host": "0.0.0.0",
-                                    "port": 1080
-                                }
-                            },
-                            "verify": {
-                                "as_addr": "http://192.168.1.254:8080/",
-                                "policy_ids": [
-                                    "default"
-                                ]
-                            }
+                    "socks5": {
+                        "proxy_listen": {
+                            "host": "0.0.0.0",
+                            "port": 1080
                         }
-                    ]
+                    },
+                    "verify": {
+                        "as_addr": "http://192.168.1.254:8080/",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
                 }
-                "#,
-        )
-        .boxed(),
-        AppType::HttpServer {
-            port: 30001,
-            expected_host_header: "example.com",
-            expected_path_and_query: "/foo/bar/www?type=1&case=1",
+            ]
         }
-        .boxed(),
-        ShellTask {
-            name: "curl_via_socks5".to_owned(),
-            node_type: NodeType::Client,
-            script: r#"
-                curl --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
-            "#
-            .to_owned(),
-            mode: ShellMode::ForegroundStop,
+        "#,
+    )
+}
 
+fn tng_client_password_auth() -> TngInstance {
+    TngInstance::TngClient(
+        r#"
+        {
+            "add_ingress": [
+                {
+                    "socks5": {
+                        "proxy_listen": {
+                            "host": "0.0.0.0",
+                            "port": 1080
+                        },
+                        "auth": {
+                            "username": "user",
+                            "password": "ppppppwd"
+                        }
+                    },
+                    "verify": {
+                        "as_addr": "http://192.168.1.254:8080/",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            ]
         }
+        "#,
+    )
+}
+
+fn tng_client_dst_filters() -> TngInstance {
+    TngInstance::TngClient(
+        r#"
+        {
+            "add_ingress": [
+                {
+                    "socks5": {
+                        "proxy_listen": {
+                            "host": "0.0.0.0",
+                            "port": 1080
+                        },
+                        "dst_filters": [
+                            {
+                                "ip": "192.168.1.1",
+                                "port": 30001
+                            }
+                        ]
+                    },
+                    "verify": {
+                        "as_addr": "http://192.168.1.254:8080/",
+                        "policy_ids": [
+                            "default"
+                        ]
+                    }
+                }
+            ]
+        }
+        "#,
+    )
+}
+
+fn http_server(port: u16) -> AppType {
+    AppType::HttpServer {
+        port,
+        expected_host_header: "example.com",
+        expected_path_and_query: "/foo/bar/www?type=1&case=1",
+    }
+}
+
+fn curl_via_socks5(script: &str) -> ShellTask {
+    ShellTask {
+        name: "curl_via_socks5".to_owned(),
+        node_type: NodeType::Client,
+        script: script.to_owned(),
+        mode: ShellMode::ForegroundStop,
+    }
+}
+
+fn assert_curl_body(command: &str) -> String {
+    format!(
+        r#"
+            body=$({command})
+            if [ "$body" != "Hello World HTTP!" ]; then
+                echo "unexpected curl response body: $body" >&2
+                exit 1
+            fi
+        "#
+    )
+}
+
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn socks5_no_auth() -> Result<()> {
+    run_test!(vec![
+        tng_server().boxed(),
+        tng_client_no_auth().boxed(),
+        http_server(30001).boxed(),
+        curl_via_socks5(&assert_curl_body(
+            r#"curl -sS --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1""#
+        ))
         .boxed(),
     ])
-    .await?;
+    .await
+}
 
-    // Test socks5 with password auth
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn socks5_password_auth() -> Result<()> {
     run_test!(vec![
-        tng_server.clone().boxed(),
-        TngInstance::TngClient(
-            r#"
-                {
-                    "add_ingress": [
-                        {
-                            "socks5": {
-                                "proxy_listen": {
-                                    "host": "0.0.0.0",
-                                    "port": 1080
-                                },
-                                "auth": {
-                                    "username": "user",
-                                    "password": "ppppppwd"
-                                }
-                            },
-                            "verify": {
-                                "as_addr": "http://192.168.1.254:8080/",
-                                "policy_ids": [
-                                    "default"
-                                ]
-                            }
-                        }
-                    ]
-                }
-                "#,
-        )
-        .boxed(),
-        AppType::HttpServer {
-            port: 30001,
-            expected_host_header: "example.com",
-            expected_path_and_query: "/foo/bar/www?type=1&case=1",
-        }
-        .boxed(),
-        ShellTask {
-            name: "curl_via_socks5".to_owned(),
-            node_type: NodeType::Client,
-            script: r#"
-                curl --socks5 user:ppppppwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
-            "#
-            .to_owned(),
-            mode: ShellMode::ForegroundStop,
-
-        }
+        tng_server().boxed(),
+        tng_client_password_auth().boxed(),
+        http_server(30001).boxed(),
+        curl_via_socks5(&assert_curl_body(
+            r#"curl -sS --socks5 user:ppppppwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1""#
+        ))
         .boxed(),
     ])
-    .await?;
+    .await
+}
 
-    // Test socks5 with wrong password
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn socks5_wrong_password_then_correct_password() -> Result<()> {
     run_test!(vec![
-        tng_server.clone().boxed(),
-        TngInstance::TngClient(
+        tng_server().boxed(),
+        tng_client_password_auth().boxed(),
+        http_server(30001).boxed(),
+        curl_via_socks5(&format!(
             r#"
-                {
-                    "add_ingress": [
-                        {
-                            "socks5": {
-                                "proxy_listen": {
-                                    "host": "0.0.0.0",
-                                    "port": 1080
-                                },
-                                "auth": {
-                                    "username": "user",
-                                    "password": "ppppppwd"
-                                }
-                            },
-                            "verify": {
-                                "as_addr": "http://192.168.1.254:8080/",
-                                "policy_ids": [
-                                    "default"
-                                ]
-                            }
-                        }
-                    ]
-                }
-                "#,
-        )
-        .boxed(),
-        AppType::HttpServer {
-            port: 30001,
-            expected_host_header: "example.com",
-            expected_path_and_query: "/foo/bar/www?type=1&case=1",
-        }
-        .boxed(),
-        ShellTask {
-            name: "curl_via_socks5".to_owned(),
-            node_type: NodeType::Client,
-            script: r#"
                 if curl --socks5 user:wrong_passwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1" ; then
                     echo "curl should fail due to wrong password"
                     exit 1
                 fi
 
-                # Let's try again with the correct password
-                curl --socks5 user:ppppppwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
-            "#
-            .to_owned(),
-            mode: ShellMode::ForegroundStop,
-
-
-        }
+                {}
+            "#,
+            assert_curl_body(
+                r#"curl -sS --socks5 user:ppppppwd@127.0.0.1:1080 --socks5-basic -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1""#
+            )
+        ))
         .boxed(),
     ])
-    .await?;
+    .await
+}
 
-    // Test socks5 with dst_filters
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn socks5_dst_filters() -> Result<()> {
     run_test!(vec![
-        tng_server.clone().boxed(),
-        TngInstance::TngClient(
+        tng_server().boxed(),
+        tng_client_dst_filters().boxed(),
+        http_server(30001).boxed(),
+        http_server(40001).boxed(),
+        curl_via_socks5(&format!(
             r#"
-                {
-                    "add_ingress": [
-                        {
-                            "socks5": {
-                                "proxy_listen": {
-                                    "host": "0.0.0.0",
-                                    "port": 1080
-                                },
-                                "dst_filters": [
-                                    {
-                                        "domain": "192.168.1.1",
-                                        "port": 30001
-                                    }
-                                ]
-                            },
-                            "verify": {
-                                "as_addr": "http://192.168.1.254:8080/",
-                                "policy_ids": [
-                                    "default"
-                                ]
-                            }
-                        }
-                    ]
-                }
-                "#,
-        )
-        .boxed(),
-        AppType::HttpServer {
-            port: 30001,
-            expected_host_header: "example.com",
-            expected_path_and_query: "/foo/bar/www?type=1&case=1",
-        }
-        .boxed(),
-        AppType::HttpServer {
-            port: 40001,
-            expected_host_header: "example.com",
-            expected_path_and_query: "/foo/bar/www?type=1&case=1",
-        }
-        .boxed(),
-        ShellTask {
-            name: "curl_via_socks5".to_owned(),
-            node_type: NodeType::Client,
-            script: r#"
-                curl --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1"
-                curl --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:40001/foo/bar/www?type=1&case=1"
-            "#
-            .to_owned(),
-            mode: ShellMode::ForegroundStop,
-
-        }
+                {}
+                {}
+            "#,
+            assert_curl_body(
+                r#"curl -sS --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:30001/foo/bar/www?type=1&case=1""#
+            ),
+            assert_curl_body(
+                r#"curl -sS --socks5 127.0.0.1:1080 -H "Host: example.com" "http://192.168.1.1:40001/foo/bar/www?type=1&case=1""#
+            )
+        ))
         .boxed(),
     ])
-    .await?;
-    Ok(())
+    .await
 }

--- a/tng-testsuite/tests/ohttp/ohttp.rs
+++ b/tng-testsuite/tests/ohttp/ohttp.rs
@@ -14,12 +14,14 @@ use tng_testsuite::{
 /// The `$1` placeholder should be replaced with the actual request payload.
 fn call_api_fn() -> &'static str {
     r#"call_api() {
-        curl -s -X POST http://192.168.1.1:30001 \
+        response=$(curl -sS -X POST http://192.168.1.1:30001 \
             -H "x-tng-ohttp-api: /tng/key-config" \
             -H "Content-Type: application/json" \
             -H "Accept: */*" \
             -H "User-Agent: tng/2.2.6" \
-            -d "$1"
+            -d "$1")
+        echo "$response" | jq -e '.hpke_key_config.encoded_key_config_list | length > 0' >/dev/null
+        printf '%s\n' "$response"
     }
 "#
 }
@@ -892,12 +894,13 @@ MC4CAQAwBQYDK2VuBCIEIOixlJE0Ykdc4ePwmaf2LLAea8Lfkfb+SARsKYmCBRpR
 
                     # Function to call the key config API
                     call_api() {{
-                        curl -X POST http://192.168.1.1:30001 \
+                        response=$(curl -sS -X POST http://192.168.1.1:30001 \
                             -H "x-tng-ohttp-api: /tng/key-config" \
                             -H "Content-Type: application/json" \
                             -H "Accept: */*" \
                             -H "User-Agent: tng/2.2.6" \
-                            -d '{{"attestation_request":{{"model":"background_check","challenge_token":"dummy token"}}}}' | jq -c '.hpke_key_config.encoded_key_config_list'
+                            -d '{{"attestation_request":{{"model":"background_check","challenge_token":"dummy token"}}}}')
+                        echo "$response" | jq -e -c '.hpke_key_config.encoded_key_config_list | select(length > 0)'
                     }}
 
                     # Wait a moment for server to fully start


### PR DESCRIPTION
## Summary

Split the SOCKS5 netfilter integration test into focused cases, fix the `dst_filters` IP matcher configuration, and assert expected curl response bodies instead of relying only on curl exit status.

Also validate OHTTP key-config curl responses with jq so malformed or unexpected bodies fail even when older curl versions exit successfully.

## Changes

- **`tng-testsuite/tests/netfilter/client_socks5_server_netfilter.rs`**: refactor the single `test()` into focused cases (`socks5_no_auth`, `socks5_password_auth`, `socks5_wrong_password_then_correct_password`, `socks5_dst_filters`); fix the `dst_filters` matcher to use the `ip` field instead of `domain` for an IP literal; assert the curl response body equals `Hello World HTTP!` rather than relying on exit status alone.
- **`tng-testsuite/tests/ohttp/ohttp.rs`**: wrap the key-config curl call and validate the response with `jq -e` so malformed/empty `hpke_key_config.encoded_key_config_list` fails the test regardless of curl exit code.