### PR TITLE
feat(netfilter-udp): implement ingress + egress TPROXY UDP tunnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,21 @@ The following failures are pre-existing environment issues, not caused by code c
   apt-get install protobuf-compiler
   ```
 
+### Cross-Platform / Cross-Compile Verification
+
+TNG is built for non-Linux targets in CI (macOS `aarch64`/`x86_64-apple-darwin`, Windows `x86_64-pc-windows-gnu`, and `wasm32-unknown-unknown`). Code that depends on Linux-only facilities — **netfilter / iptables / TPROXY / `SO_MARK` (`socket2::Socket::set_mark`) / raw `libc` recvmsg ancillary data (`IP_ORIGDSTADDR`)** — must be `#[cfg(target_os = "linux")]`-gated so the crate still compiles on macOS/Windows/wasm. The `netfilter`, `netfilter_udp`, and `utils/udp` (TPROXY) modules are already Linux-gated; when adding a new Linux-only mode, mirror that gating and use the runtime `#[cfg(not(target_os = "linux"))]` bail pattern (see `IngressMode::Netfilter`/`NetfilterUdp` arms in `tng/src/runtime.rs`) so enum `match`es stay exhaustive on every platform.
+
+Do **not** use plain `cargo check --target <non-linux>` to verify these — `aws-lc-sys` runs a C build script that `cargo check` cannot cross-compile (no target sysroot for clang). Use the Makefile cross-compile targets, which drive the C toolchain through `zig` via `cargo-zigbuild`:
+
+```bash
+make mac-cross-build        # cargo zigbuild --target aarch64-apple-darwin
+make windows-cross-build    # cargo zigbuild --target x86_64-pc-windows-gnu --release (runs install-windows-build-deps first)
+make wasm-build-debug       # wasm-pack build --dev --target web ./tng-wasm
+make wasm-build-release     # wasm-pack build --release --target web ./tng-wasm
+```
+
+Any change touching `cfg(target_os = ...)` gates, `socket2` usage, or the `netfilter_udp`/`utils/udp` modules should be verified with at least `make mac-cross-build` and `make windows-cross-build` before pushing — CI builds all of these on every PR.
+
 ## Running Tests with Service Dependencies
 
 Several integration tests require external services to be running. Before running `cargo test`, start the following in the background and wait for them to be ready:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5868,15 +5868,14 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+source = "git+https://github.com/inclavare-containers/quinn.git?rev=2995f83efe00cdce9bb833b922e69d08649b271b#2995f83efe00cdce9bb833b922e69d08649b271b"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7789,6 +7788,7 @@ dependencies = [
  "hyper-util 0.1.7",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+ "libc",
  "local-ip-address",
  "nix 0.30.1",
  "notify",
@@ -7798,6 +7798,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "parking_lot 0.12.3",
  "peekable 0.4.1",
  "pin-project",
  "pin-project-lite",
@@ -7912,6 +7913,7 @@ dependencies = [
  "scopeguard",
  "serde_json",
  "serial_test",
+ "socket2 0.5.10",
  "tempfile",
  "thirtyfour",
  "tng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,11 @@ git = "https://github.com/inclavare-containers/tokio-graceful.git"
 git = "https://github.com/inclavare-containers/hyper.git"
 rev = "6fde2c7c2e00b4fc1b9e31b827654230f488630f"
 
+[patch.crates-io.quinn-udp]
+# Forked quinn-udp with IP_ORIGDSTADDR + dst_addr in RecvMeta for TPROXY compatibility
+git = "https://github.com/inclavare-containers/quinn.git"
+rev = "2995f83efe00cdce9bb833b922e69d08649b271b"
+
 [patch.crates-io]
 hyper-util = {path = "./deps/hyper-util-shim"}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@
   - [Mode: netfilter (Transparent Proxy)](#mode-netfilter-transparent-proxy)
   - [Mode: hook (LD_PRELOAD)](#mode-ingress-hook-ld-preload)
   - [Mode: mapping_udp (UDP over QUIC)](#mode-mapping_udp-udp-over-quic-datagram-tunnel)
+  - [Mode: netfilter_udp (Transparent UDP Proxy)](#mode-netfilter_udp-transparent-udp-proxy)
     - [Per-Entry QUIC Configuration](#udp-over-quic-configuration)
 - [Egress (Tunnel Exit)](#egress-tunnel-exit)
   - [Common Fields](#common-fields)
@@ -24,6 +25,7 @@
   - [Mode: netfilter (Port Hijacking)](#mode-netfilter-port-hijacking)
   - [Mode: hook (LD_PRELOAD)](#egress-hook-ld-preload)
   - [Mode: mapping_udp (UDP over QUIC)](#mode-mapping_udp-udp-over-quic-datagram-tunnel)
+  - [Mode: netfilter_udp (Transparent UDP Proxy)](#mode-netfilter_udp-transparent-udp-proxy-1)
 - [Remote Attestation (Common Configuration)](#remote-attestation-common-configuration)
   - [Provider Selection](#provider-selection)
   - [Attester Configuration](#attester-configuration)
@@ -76,7 +78,7 @@ The `Ingress` object configures the tunnel's entry endpoints, controlling how tr
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` \| `mapping_udp` | None | Traffic inbound mode. Place the corresponding mode's key-value in the object based on the mode used |
+| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` \| `mapping_udp` \| `netfilter_udp` | None | Traffic inbound mode. Place the corresponding mode's key-value in the object based on the mode used |
 | `ohttp` | [OHttp](#ingress-side-configuration) | None | OHTTP protocol configuration (mutually exclusive with `rats_tls`) |
 | `rats_tls` | [RatsTlsArgs](#transport-layer-common-configuration) | None | RA-TLS transport configuration (mutually exclusive with `ohttp`) |
 | `no_ra` | boolean | `false` | Disable remote attestation (for debugging only; cannot coexist with `attest`/`verify`) |
@@ -362,6 +364,12 @@ flowchart TD
 
 > **Note:** This mode only captures TCP traffic and does not capture traffic destined for local addresses.
 
+**Capture matrix:**
+
+| Mode | Other host → local | Other host → other host | Local → local | Local → other host |
+|---|---|---|---|---|
+| netfilter ingress | ❌ | ❌ | ❌ | ✅ |
+
 > [!NOTE]
 > **Running in containers without `CAP_NET_ADMIN`:** The netfilter mode requires `CAP_NET_ADMIN` to create iptables rules. If your container lacks this capability, you can work around it using [pasta](https://passt.top), which bypasses the missing capability by creating a child network namespace and user namespace pair:
 >
@@ -596,6 +604,54 @@ Encapsulates raw UDP datagrams over a QUIC connection. The ingress side listens 
 
 ---
 
+### Mode: netfilter_udp (Transparent UDP Proxy)
+
+> **Requires:** Linux kernel with iptables TPROXY support. Only available with the `ingress-netfilter-udp` and `egress-netfilter-udp` feature flags.
+
+Intercepts raw UDP traffic transparently via iptables TPROXY, tunnels it over QUIC datagrams, and reconstructs the original UDP flow at the other end. No client-side code changes are needed — applications send UDP to the original destination address as usual.
+
+#### Ingress Side (`"netfilter_udp"`)
+
+The ingress side intercepts client UDP packets using iptables TPROXY in the mangle table PREROUTING chain. It extracts the original destination address via `IP_ORIGDSTADDR` socket option and establishes a QUIC datagram tunnel per `(client_src, original_dst)` session.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `capture_dst` | array or object [[CaptureDst](#netfilter-capture-destination)] | All | Destination filter: which UDP traffic to intercept (host/ipset/port/port_end combinations). If empty, captures all UDP traffic |
+| `listen_port` | integer | No (auto-assigned) | Local port for TPROXY to redirect intercepted packets to |
+| `so_mark` | integer | `565` | SO_MARK value to exclude TNG's own packets from interception |
+| `capture_cgroup` | array of string | None | Only capture traffic from these cgroup paths (cgroup v2 only) |
+| `nocapture_cgroup` | array of string | None | Exclude traffic from these cgroup paths (cgroup v2 only) |
+
+**Example:**
+
+```json
+{
+  "add_ingress": [
+    {
+      "netfilter_udp": {
+        "capture_dst": [
+          { "host": "10.0.0.1", "port": 5000 }
+        ],
+        "listen_port": 10001
+      },
+      "quic": { "max_datagram_size": 1200 },
+      "no_ra": true
+    }
+  ]
+}
+```
+
+> [!NOTE]
+> By default, ingress connects to the egress using `original_dst` — the client's original destination address extracted from TPROXY. Ensure clients target the egress machine's address so `original_dst` resolves correctly.
+
+**Capture matrix:**
+
+| Mode | Other host → local | Other host → other host | Local → local | Local → other host |
+|---|---|---|---|---|
+| netfilter ingress | ❌ | ❌ | ❌ | ✅ |
+
+---
+
 ## Egress (Tunnel Exit)
 
 The `Egress` object configures the tunnel's exit endpoints, controlling how traffic exits the tunnel.
@@ -606,7 +662,7 @@ The `Egress` object configures the tunnel's exit endpoints, controlling how traf
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `egress_mode` | `mapping` \| `netfilter` \| `hook` \| `mapping_udp` | None | Traffic outbound mode. Place the corresponding mode's key-value in the object based on the mode used |
+| `egress_mode` | `mapping` \| `netfilter` \| `hook` \| `mapping_udp` \| `netfilter_udp` | None | Traffic outbound mode. Place the corresponding mode's key-value in the object based on the mode used |
 | `direct_forward` | array [[DirectForwardRule](#direct_forward-rules)] | No | Direct forwarding (without decryption) rules |
 | `ohttp` | [OHttp](#egress-side-configuration) | None | OHTTP protocol configuration (mutually exclusive with `rats_tls`) |
 | `rats_tls` | [RatsTlsArgs](#transport-layer-common-configuration) | None | RA-TLS transport configuration (mutually exclusive with `ohttp`) |
@@ -760,7 +816,14 @@ flowchart TD
     E --No--> C
 ```
 
-> **Note:** This mode only captures TCP traffic and does not capture traffic destined for local addresses (unless `capture_local_traffic: true`).
+> **Note:** This mode only captures TCP traffic. By default (`capture_local_traffic: false`) it does not capture traffic whose **source IP is local** (i.e. traffic the machine itself originates, including loopback-to-self); set `capture_local_traffic: true` to capture such locally-originated traffic.
+
+**Capture matrix** (by `capture_local_traffic`):
+
+| `capture_local_traffic` | Other host → local | Other host → other host | Local → local | Local → other host |
+|---|---|---|---|---|
+| `false` (default) | ✅ | ✅ | ❌ | ❌ |
+| `true` | ✅ | ✅ | ✅ | ✅ |
 
 > [!NOTE]
 > **Running in containers without `CAP_NET_ADMIN`:** See the [Ingress netfilter note](#mode-netfilter-transparent-proxy) above for the same workaround using pasta.
@@ -962,6 +1025,52 @@ The egress side of `mapping_udp` accepts QUIC datagram connections from an ingre
         "idle_timeout_secs": 60
       },
       "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+---
+
+### Mode: netfilter_udp (Transparent UDP Proxy)
+
+The egress side accepts incoming QUIC datagram connections on a TPROXY-configured socket. For outbound UDP to backends, iptables TPROXY intercepts packets destined for the captured addresses, and `IP_ORIGDSTADDR` on the redirected packets reveals the original backend target so the payload can be forwarded correctly. See the [ingress netfilter_udp section](#mode-netfilter_udp-transparent-udp-proxy) for the full feature overview.
+
+> **Capture scope:** The egress only hooks the mangle `PREROUTING` chain, so it captures incoming UDP from remote hosts destined for the machine, and locally-generated UDP sent to a local address (loopback-to-self, only when `capture_local_traffic` is `true`). It does **not** capture locally-generated UDP destined for other hosts — such traffic traverses the `OUTPUT` chain, which the egress does not hook.
+
+**Capture matrix** (by `capture_local_traffic`):
+
+| `capture_local_traffic` | Other host → local | Other host → other host | Local → local | Local → other host |
+|---|---|---|---|---|
+| `false` (default) | ✅ | ✅ | ❌ | ❌ |
+| `true` | ✅ | ✅ | ✅ | ❌ |
+
+> `Local → other host` stays ❌ even with `capture_local_traffic: true` — the egress does not hook `OUTPUT`, so locally-generated outbound traffic never reaches the PREROUTING TPROXY rule.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `capture_dst` | array or object [[CaptureDst](#netfilter-capture-destination)] | All | Which UDP traffic to intercept on the egress machine |
+| `capture_local_traffic` | boolean | `false` | Whether to capture traffic whose source IP is the local machine (locally-originated traffic; enable when a local client on the gateway talks to a co-located backend) |
+| `listen_port` | integer | Yes | Local port for TPROXY to redirect QUIC UDP packets to |
+| `so_mark` | integer | `565` | SO_MARK value to exclude TNG's own packets |
+| `capture_cgroup` | array of string | None | Only capture traffic from these cgroup paths |
+| `nocapture_cgroup` | array of string | None | Exclude traffic from these cgroup paths |
+
+**Example:**
+
+```json
+{
+  "add_egress": [
+    {
+      "netfilter_udp": {
+        "capture_dst": [
+          { "host": "192.168.1.1", "port": 30001 }
+        ],
+        "capture_local_traffic": true,
+        "listen_port": 20001
+      },
+      "quic": { "max_datagram_size": 1200 },
+      "no_ra": true
     }
   ]
 }
@@ -2000,9 +2109,11 @@ Logs are appended to existing files.
 | ingress mapping | `ingress_type=mapping,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
 | ingress http_proxy | `ingress_type=http_proxy,ingress_id={id},ingress_proxy_listen={proxy_listen.host}:{proxy_listen.port}` |
 | ingress mapping_udp | `ingress_type=mapping_udp,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
+| ingress netfilter_udp | `ingress_type=netfilter_udp,ingress_id={id},ingress_listen_port={listen_port}` |
 | egress mapping | `egress_type=netfilter,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
 | egress netfilter | `egress_type=netfilter,egress_id={id},egress_listen_port={listen_port}` |
 | egress mapping_udp | `egress_type=mapping_udp,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
+| egress netfilter_udp | `egress_type=netfilter_udp,egress_id={id},egress_listen_port={listen_port}` |
 
 **Supported Exporters:**
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -16,6 +16,7 @@
   - [模式：netfilter（透明代理）](#netfilter透明代理)
   - [模式：hook（LD_PRELOAD）](#ingress-hook-ld_preload)
   - [模式：mapping_udp（UDP over QUIC）](#模式mapping_udpudp-over-quic-datagram-隧道)
+  - [模式：netfilter_udp（透明 UDP 代理）](#模式netfilter_udp透明-udp-代理)
     - [逐条目 QUIC 配置](#udp-over-quic-配置)
 - [Egress（隧道出口）](#egress隧道出口)
   - [通用字段](#egress通用字段)
@@ -24,6 +25,7 @@
   - [模式：netfilter（端口劫持）](#netfilter端口劫持)
   - [模式：hook（LD_PRELOAD）](#egress-hookld_preload)
   - [模式：mapping_udp（UDP over QUIC）](#模式mapping_udpudp-over-quic-datagram-隧道)
+  - [模式：netfilter_udp（透明 UDP 代理）](#模式netfilter_udp透明-udp-代理-1)
 - [远程证明（公共配置）](#远程证明公共配置)
   - [Provider 选择](#provider-选择)
   - [Attester 配置](#attester-配置)
@@ -76,7 +78,7 @@
 
 | 字段 | 类型 | 默认 | 说明 |
 |---|---|---|---|
-| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` \| `mapping_udp` | 无 | 流量入站方式。根据使用的模式，在对象中放置对应模式的键值 |
+| `ingress_mode` | `mapping` \| `http_proxy` \| `netfilter` \| `socks5` \| `hook` \| `mapping_udp` \| `netfilter_udp` | 无 | 流量入站方式。根据使用的模式，在对象中放置对应模式的键值 |
 | `ohttp` | [OHttp](#ingress-侧配置) | 无 | OHTTP 协议配置（与 `rats_tls` 互斥） |
 | `rats_tls` | [RatsTlsArgs](#ratstlsargs) | 无 | RA-TLS 传输配置（与 `ohttp` 互斥） |
 | `no_ra` | boolean | `false` | 禁用远程证明（调试用，不可与 `attest`/`verify` 共存） |
@@ -362,6 +364,12 @@ flowchart TD
 
 > **注意**：该模式仅捕获 TCP 流量，不捕获发往本机地址的流量。
 
+**捕获矩阵：**
+
+| 模式 | 其他主机→本机 | 其他主机→其他主机 | 本机→本机 | 本机→其他主机 |
+|---|---|---|---|---|
+| netfilter ingress | ❌ | ❌ | ❌ | ✅ |
+
 > [!NOTE]
 > **在无 `CAP_NET_ADMIN` 的容器中运行**：netfilter 模式需要 `CAP_NET_ADMIN` 来创建 iptables 规则。如果容器缺少此能力，可以通过 [pasta](https://passt.top) 来解决——它通过创建子 network namespace 和子 user namespace 的方式，在子 namespace 内获得 `CAP_NET_ADMIN`，从而绕过缺该能力的问题：
 >
@@ -596,6 +604,54 @@ flowchart TD
 
 ---
 
+### 模式：netfilter_udp（透明 UDP 代理）
+
+> **要求：** 支持 iptables TPROXY 的 Linux 内核。仅在启用 `ingress-netfilter-udp` 和 `egress-netfilter-udp` 特性时可用。
+
+通过 iptables TPROXY 透明劫持原始 UDP 流量，经 QUIC Datagram 隧道转发，并在对端重建原始 UDP 流。客户端代码无需任何修改——应用程序照常向原始目的地址发送 UDP。
+
+#### Ingress 侧（`"netfilter_udp"`）
+
+Ingress 侧通过 iptables TPROXY（mangle 表 PREROUTING 链）劫持客户端 UDP 包，利用 `IP_ORIGDSTADDR` socket 选项提取原始目的地址，并为每个 `(client_src, original_dst)` 会话建立 QUIC Datagram 隧道。
+
+| 字段 | 类型 | 默认值 | 描述 |
+|---|---|---|---|
+| `capture_dst` | 数组或对象 [[CaptureDst](#netfilter-捕获目的地址)] | 全部 | 目的地址过滤：劫持哪些 UDP 流量（host/ipset/port/port_end 组合）。为空时劫持所有 UDP |
+| `listen_port` | 整数 | 否（自动分配） | TPROXY 重定向劫持包到的本地端口 |
+| `so_mark` | 整数 | `565` | SO_MARK 值，用于排除 TNG 自身发出的包 |
+| `capture_cgroup` | 字符串数组 | 无 | 仅劫持这些 cgroup 路径的流量（仅 cgroup v2） |
+| `nocapture_cgroup` | 字符串数组 | 无 | 排除这些 cgroup 路径的流量（仅 cgroup v2） |
+
+**示例：**
+
+```json
+{
+  "add_ingress": [
+    {
+      "netfilter_udp": {
+        "capture_dst": [
+          { "host": "10.0.0.1", "port": 5000 }
+        ],
+        "listen_port": 10001
+      },
+      "quic": { "max_datagram_size": 1200 },
+      "no_ra": true
+    }
+  ]
+}
+```
+
+> [!NOTE]
+> 默认情况下 ingress 使用 `original_dst`（从 TPROXY 提取的客户端原始目的地址）连接 egress。请确保客户端目标地址为 egress 机器的地址，以保证 `original_dst` 正确解析。
+
+**捕获矩阵：**
+
+| 模式 | 其他主机→本机 | 其他主机→其他主机 | 本机→本机 | 本机→其他主机 |
+|---|---|---|---|---|
+| netfilter ingress | ❌ | ❌ | ❌ | ✅ |
+
+---
+
 ## Egress（隧道出口）
 
 `Egress` 对象配置隧道的出口端点，控制流量如何从隧道流出。
@@ -606,7 +662,7 @@ flowchart TD
 
 | 字段 | 类型 | 默认 | 说明 |
 |---|---|---|---|
-| `egress_mode` | `mapping` \| `netfilter` \| `hook` \| `mapping_udp` | 无 | 流量出站方式。根据使用的模式，在对象中放置对应模式的键值 |
+| `egress_mode` | `mapping` \| `netfilter` \| `hook` \| `mapping_udp` \| `netfilter_udp` | 无 | 流量出站方式。根据使用的模式，在对象中放置对应模式的键值 |
 | `direct_forward` | array [[DirectForwardRule](#direct_forward-规则)] | 否 | 直接转发（不解密）规则 |
 | `ohttp` | [OHttp](#egress-侧配置) | 无 | OHTTP 协议配置（与 `rats_tls` 互斥） |
 | `rats_tls` | [RatsTlsArgs](#ratstlsargs) | 无 | RA-TLS 传输配置（与 `ohttp` 互斥） |
@@ -760,7 +816,14 @@ flowchart TD
     E --否--> C
 ```
 
-> **注意**：该模式仅捕获 TCP 流量，不捕获发往本机地址的流量（除非 `capture_local_traffic: true`）。
+> **注意**：该模式仅捕获 TCP 流量。默认（`capture_local_traffic: false`）不捕获**源 IP 为本机**的流量（即本机自身发出的流量，含 loopback-to-self）；需设 `capture_local_traffic: true` 才会捕获这类本机发出的流量。
+
+**捕获矩阵**（按 `capture_local_traffic` 区分）：
+
+| `capture_local_traffic` | 其他主机→本机 | 其他主机→其他主机 | 本机→本机 | 本机→其他主机 |
+|---|---|---|---|---|
+| `false`（默认） | ✅ | ✅ | ❌ | ❌ |
+| `true` | ✅ | ✅ | ✅ | ✅ |
 
 > [!NOTE]
 > **在无 `CAP_NET_ADMIN` 的容器中运行**：同上，参考 [Ingress netfilter 章节](#netfilter透明代理)中的 pasta 方案。
@@ -962,6 +1025,52 @@ tng exec --config-file=/etc/tng.json -- vllm serve --host 0.0.0.0 --port 8080
         "idle_timeout_secs": 60
       },
       "attest": { "no_ra": true }
+    }
+  ]
+}
+```
+
+---
+
+### 模式：netfilter_udp（透明 UDP 代理）
+
+Egress 侧在配置了 TPROXY 的 socket 上接收来自 ingress 的 QUIC Datagram 连接。对于发往后端的 UDP 出站流量，iptables TPROXY 劫持发往捕获地址的包，通过 `IP_ORIGDSTADDR` 从重定向包中提取原始后端目标地址，从而正确转发 UDP 载荷。完整的特性概览见 [ingress netfilter_udp 章节](#模式netfilter_udp透明-udp-代理)。
+
+> **捕获范围：** egress 仅 hook mangle `PREROUTING` 链，因此能捕获远程主机发往本机的 UDP，以及本机生成、发往本机地址的 UDP（回环到自身，仅在 `capture_local_traffic` 为 `true` 时）。它**不能**捕获本机生成、发往其他主机的 UDP——这类流量走 `OUTPUT` 链，而 egress 未 hook 该链。
+
+**捕获矩阵**（按 `capture_local_traffic` 区分）：
+
+| `capture_local_traffic` | 其他主机→本机 | 其他主机→其他主机 | 本机→本机 | 本机→其他主机 |
+|---|---|---|---|---|
+| `false`（默认） | ✅ | ✅ | ❌ | ❌ |
+| `true` | ✅ | ✅ | ✅ | ❌ |
+
+> 即使 `capture_local_traffic: true`，`本机→其他主机` 仍为 ❌——egress 未 hook `OUTPUT`，本机发出的出站流量不会到达 PREROUTING 的 TPROXY 规则。
+
+| 字段 | 类型 | 默认值 | 描述 |
+|---|---|---|---|
+| `capture_dst` | 数组或对象 [[CaptureDst](#netfilter-捕获目的地址)] | 全部 | 在 egress 机器上劫持哪些 UDP 流量 |
+| `capture_local_traffic` | 布尔值 | `false` | 是否捕获源 IP 为本机的流量（本机自身发出的流量；当网关本机上的客户端访问同机后端时需开启） |
+| `listen_port` | 整数 | 必填 | TPROXY 重定向 QUIC UDP 包到的本地端口 |
+| `so_mark` | 整数 | `565` | SO_MARK 值，用于排除 TNG 自身发出的包 |
+| `capture_cgroup` | 字符串数组 | 无 | 仅劫持这些 cgroup 路径的流量 |
+| `nocapture_cgroup` | 字符串数组 | 无 | 排除这些 cgroup 路径的流量 |
+
+**示例：**
+
+```json
+{
+  "add_egress": [
+    {
+      "netfilter_udp": {
+        "capture_dst": [
+          { "host": "192.168.1.1", "port": 30001 }
+        ],
+        "capture_local_traffic": true,
+        "listen_port": 20001
+      },
+      "quic": { "max_datagram_size": 1200 },
+      "no_ra": true
     }
   ]
 }
@@ -1990,9 +2099,11 @@ RUST_LOG=debug tng --log-file tng-debug.log launch --config-file config.json
 | ingress mapping | `ingress_type=mapping,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
 | ingress http_proxy | `ingress_type=http_proxy,ingress_id={id},ingress_proxy_listen={proxy_listen.host}:{proxy_listen.port}` |
 | ingress mapping_udp | `ingress_type=mapping_udp,ingress_id={id},ingress_in={in.host}:{in.port},ingress_out={out.host}:{out.port}` |
+| ingress netfilter_udp | `ingress_type=netfilter_udp,ingress_id={id},ingress_listen_port={listen_port}` |
 | egress mapping | `egress_type=netfilter,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
 | egress netfilter | `egress_type=netfilter,egress_id={id},egress_listen_port={listen_port}` |
 | egress mapping_udp | `egress_type=mapping_udp,egress_id={id},egress_in={in.host}:{in.port},egress_out={out.host}:{out.port}` |
+| egress netfilter_udp | `egress_type=netfilter_udp,egress_id={id},egress_listen_port={listen_port}` |
 
 **支持的 Exporter：**
 

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -32,6 +32,7 @@ rustls = {workspace = true, default-features = false, features = ["logging", "st
 rustls-pemfile = {workspace = true}
 scopeguard = {workspace = true}
 serde_json = {workspace = true}
+socket2 = {workspace = true}
 thirtyfour = {workspace = true, optional = true}
 tng = {path = "../tng", optional = true}
 tokio = {workspace = true, default-features = true, features = ["rt-multi-thread", "sync", "process", "signal", "macros"]}
@@ -152,6 +153,10 @@ path = "tests/http/mapping_port_range.rs"
 [[test]]
 name = "mapping_udp"
 path = "tests/mapping_udp.rs"
+
+[[test]]
+name = "netfilter_udp"
+path = "tests/netfilter_udp.rs"
 
 [[test]]
 name = "mapping_multi_rule"

--- a/tng-testsuite/src/lib.rs
+++ b/tng-testsuite/src/lib.rs
@@ -132,24 +132,47 @@ pub async fn run_test(name: &str, tasks: Vec<Box<dyn Task>>) -> Result<()> {
                 });
             }
 
-            let mut first_error = None;
+            let mut first_error: Option<anyhow::Error> = None;
 
-            loop {
-                match sub_tasks.next().await {
-                    Some((task_name, res)) => {
-                        if let Err(e) =
-                            res.with_context(|| format!("Error in the {task_name} task"))
-                        {
-                            tracing::error!("[{name}] Error in task {task_name}: {e:?}");
-                            if first_error.is_none() {
-                                first_error = Some(e);
-                            }
-                        }
-                    }
-                    None => {
-                        break;
+            // Verifier client tasks terminate on their own (a UDP/TCP client
+            // finishes its rounds, or times out and bails); the service tasks
+            // (TngServer, TngClient, UdpServer, ...) only exit once `token` is
+            // cancelled. A verifier cancels the token itself on completion via
+            // `token.drop_guard()`; we also cancel below once the first task
+            // finishes, so a crashed service (which carries no drop_guard) still
+            // tears the rest down.
+            //
+            // We then drain the remaining tasks with a BOUNDED grace. A
+            // service's teardown — notably the netfilter `IptablesGuard::drop`
+            // revoke script — must not block the suite forever: if it hangs,
+            // we log and force-end so the test reports its real result instead
+            // of hanging indefinitely.
+            if let Some((task_name, res)) = sub_tasks.next().await {
+                if let Err(e) = res.with_context(|| format!("Error in the {task_name} task")) {
+                    tracing::error!("[{name}] Error in task {task_name}: {e:?}");
+                    if first_error.is_none() {
+                        first_error = Some(e);
                     }
                 }
+            }
+            token.cancel();
+
+            let teardown_grace = Duration::from_secs(15);
+            let drain = async {
+                while let Some((task_name, res)) = sub_tasks.next().await {
+                    if let Err(e) = res.with_context(|| format!("Error in the {task_name} task")) {
+                        tracing::error!("[{name}] Error in task {task_name}: {e:?}");
+                        if first_error.is_none() {
+                            first_error = Some(e);
+                        }
+                    }
+                }
+            };
+            if tokio::time::timeout(teardown_grace, drain).await.is_err() {
+                tracing::error!(
+                    "[{name}] Teardown grace ({teardown_grace:?}) exceeded while waiting for \
+                     service tasks to shut down; forcing test end",
+                );
             }
 
             if let Some(e) = first_error {

--- a/tng-testsuite/src/lib.rs
+++ b/tng-testsuite/src/lib.rs
@@ -134,45 +134,37 @@ pub async fn run_test(name: &str, tasks: Vec<Box<dyn Task>>) -> Result<()> {
 
             let mut first_error: Option<anyhow::Error> = None;
 
-            // Verifier client tasks terminate on their own (a UDP/TCP client
-            // finishes its rounds, or times out and bails); the service tasks
-            // (TngServer, TngClient, UdpServer, ...) only exit once `token` is
-            // cancelled. A verifier cancels the token itself on completion via
-            // `token.drop_guard()`; we also cancel below once the first task
-            // finishes, so a crashed service (which carries no drop_guard) still
-            // tears the rest down.
+            // Wait for all tasks to finish. The verifier (e.g. app_client) cancels
+            // the token itself on completion via its `token.drop_guard()`, which
+            // makes the service tasks (TngServer, TngClient, ...) wind down so the
+            // loop drains to completion.
             //
-            // We then drain the remaining tasks with a BOUNDED grace. A
-            // service's teardown — notably the netfilter `IptablesGuard::drop`
-            // revoke script — must not block the suite forever: if it hangs,
-            // we log and force-end so the test reports its real result instead
-            // of hanging indefinitely.
-            if let Some((task_name, res)) = sub_tasks.next().await {
-                if let Err(e) = res.with_context(|| format!("Error in the {task_name} task")) {
-                    tracing::error!("[{name}] Error in task {task_name}: {e:?}");
-                    if first_error.is_none() {
-                        first_error = Some(e);
-                    }
-                }
-            }
-            token.cancel();
-
-            let teardown_grace = Duration::from_secs(15);
-            let drain = async {
-                while let Some((task_name, res)) = sub_tasks.next().await {
-                    if let Err(e) = res.with_context(|| format!("Error in the {task_name} task")) {
-                        tracing::error!("[{name}] Error in task {task_name}: {e:?}");
-                        if first_error.is_none() {
-                            first_error = Some(e);
+            // We deliberately do NOT cancel on the FIRST task completion: a
+            // short-lived `BackgroundContinue` setup task (such as `prepare_ipset`)
+            // finishes within milliseconds, and cancelling then would tear the
+            // tunnel down before the verifier ever runs — which is what broke the
+            // ipset netfilter tests. Only a task that actually errors (a crashed
+            // service with no drop_guard) cancels the token here so the rest
+            // still tear down.
+            loop {
+                match sub_tasks.next().await {
+                    Some((task_name, res)) => {
+                        if let Err(e) =
+                            res.with_context(|| format!("Error in the {task_name} task"))
+                        {
+                            tracing::error!("[{name}] Error in task {task_name}: {e:?}");
+                            if first_error.is_none() {
+                                first_error = Some(e);
+                            }
+                            // A crashed service carries no drop_guard, so cancel
+                            // the token to let the remaining tasks tear down.
+                            token.cancel();
                         }
                     }
+                    None => {
+                        break;
+                    }
                 }
-            };
-            if tokio::time::timeout(teardown_grace, drain).await.is_err() {
-                tracing::error!(
-                    "[{name}] Teardown grace ({teardown_grace:?}) exceeded while waiting for \
-                     service tasks to shut down; forcing test end",
-                );
             }
 
             if let Some(e) = first_error {

--- a/tng-testsuite/src/task/app/udp_server.rs
+++ b/tng-testsuite/src/task/app/udp_server.rs
@@ -6,8 +6,14 @@ pub async fn launch_udp_server(
     token: CancellationToken,
     port: u16,
 ) -> Result<JoinHandle<Result<()>>> {
-    let addr = format!("0.0.0.0:{port}");
-    let socket = UdpSocket::bind(&addr).await?;
+    // Bind plainly (no SO_REUSEADDR) so this server behaves like a real
+    // backend that did not set SO_REUSEADDR. The netfilter_udp egress replies
+    // via a SOCK_RAW + IP_HDRINCL socket (no bind), so it never competes for
+    // this port — the test must pass without any SO_REUSEADDR workaround.
+    let addr: std::net::SocketAddr = format!("0.0.0.0:{port}").parse()?;
+    let socket = UdpSocket::bind(addr)
+        .await
+        .with_context(|| format!("Failed to bind UDP server socket on {addr}"))?;
     tracing::info!("UDP server listening on {addr}");
 
     Ok(tokio::task::spawn(async move {
@@ -20,7 +26,7 @@ pub async fn launch_udp_server(
                 }
                 result = socket.recv_from(&mut buf) => {
                     let (n, src_addr) = result?;
-                    tracing::info!("UDP server received {} bytes from {}", n, src_addr);
+                    tracing::info!("UDP server received {} bytes from {}, echo back now", n, src_addr);
                     socket
                         .send_to(&buf[..n], src_addr)
                         .await

--- a/tng-testsuite/tests/mapping_udp.rs
+++ b/tng-testsuite/tests/mapping_udp.rs
@@ -604,3 +604,74 @@ async fn test_mapping_udp_short_idle_timeout() -> Result<()> {
 
     Ok(())
 }
+
+/// Egress `mapping_udp` with a **domain** `out.host` — exercises domain-backend
+/// resolution in `forward_connection` (egress `MappingUdpEgress` produces an
+/// `EndpointAddr::Domain` backend endpoint, which must be resolved to an IPv4
+/// address instead of bailing). The egress backend is `localhost` (resolves to
+/// `127.0.0.1`, where the UdpServer listens).
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_mapping_udp_basic_with_domain_backend() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20031
+                        },
+                        "out": {
+                            "host": "localhost",
+                            "port": 30031
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10031
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 20031
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30031 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10031,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng-testsuite/tests/netfilter_udp.rs
+++ b/tng-testsuite/tests/netfilter_udp.rs
@@ -1,0 +1,483 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, tng::TngInstance, Task as _},
+};
+
+/// Common topology for the egress-only tests below:
+///   Client node (192.168.1.253): TNG Client (ingress mapping_udp) + UdpClient
+///   Server node (192.168.1.1):   TNG Server (egress netfilter_udp) + UdpServer
+///
+/// Data flow:
+///   UdpClient → 127.0.0.1:1000x (ingress mapping_udp, client node)
+///     → QUIC datagram tunnel → 192.168.1.1:3000x (egress capture_dst, server node)
+///     → egress TPROXY intercepts, orig_dst = 192.168.1.1:3000x
+///     → egress forwards UDP → 192.168.1.1:3000x (UdpServer, server node)
+///
+/// The QUIC tunnel targets the capture_dst port (the real backend), so the
+/// egress derives the backend address directly from IP_ORIGDSTADDR — no
+/// `backend` override and no fixed `listen_port` are needed (the listener
+/// picks a free, non-overlapping port at random).
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_udp_basic() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 30001 }
+                        ],
+                        "capture_local_traffic": true
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10001
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 30001
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30001 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10001,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Egress netfilter_udp with port range capture
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_udp_port_range() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 30010, "port_end": 30020 }
+                        ],
+                        "capture_local_traffic": true
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10010
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 30015
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30015 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10010,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Egress netfilter_udp with custom max_datagram_size
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_udp_datagram_size() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 30041 }
+                        ],
+                        "capture_local_traffic": true
+                    },
+                    "quic": {
+                        "max_datagram_size": 1400
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10041
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 30041
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1400
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30041 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10041,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Egress netfilter_udp without explicit capture_dst (capture all UDP)
+///
+/// Uses the default `capture_local_traffic: false`. With the `! --src-type
+/// LOCAL` filter, the co-located backend's forward/reply traffic (source IP is
+/// local) is exempted from the catch-all TPROXY rule, while the remote
+/// client's QUIC tunnel packets are still captured. Setting
+/// `capture_local_traffic: true` here would re-capture the backend's reply
+/// into the QUIC listener (silently dropped), breaking the round-trip — see
+/// the warn emitted by the egress when that combo is configured.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_egress_netfilter_udp_capture_all() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "netfilter_udp": {},
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "port": 10051
+                        },
+                        "out": {
+                            "host": "192.168.1.1",
+                            "port": 30051
+                        },
+                        "idle_timeout_secs": 30
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30051 }.boxed(),
+        AppType::UdpClient {
+            host: "127.0.0.1",
+            port: 10051,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Mixed direction: ingress netfilter_udp (client) + egress mapping_udp (server).
+///
+///   Client node (192.168.1.253): TNG Client (ingress netfilter_udp) + UdpClient
+///   Server node (192.168.1.1):   TNG Server (egress mapping_udp) + UdpServer
+///
+/// Data flow:
+///   UdpClient → 192.168.1.1:20071 (captured by ingress TPROXY on the client)
+///     → ingress orig_dst = 192.168.1.1:20071
+///     → ingress QUIC tunnel (SO_MARK bypasses the client's own OUTPUT capture)
+///       → 192.168.1.1:20071 (egress mapping_udp `in` listener, server node)
+///     → egress forwards UDP → 127.0.0.1:30071 (UdpServer, server node)
+///
+/// Unlike the egress-netfilter topology, the egress side is a fixed mapping
+/// listener: the QUIC tunnel targets the egress `in` port, which the ingress
+/// derives from the captured original destination. So `capture_dst` must
+/// exactly name the egress `in` address (host + port).
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ingress_netfilter_egress_mapping_basic() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20071
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30071
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 20071 }
+                        ]
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30071 }.boxed(),
+        AppType::UdpClient {
+            host: "192.168.1.1",
+            port: 20071,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Mixed direction with an ingress port-range capture. The ingress captures a
+/// range of destination ports; the egress mapping_udp `in` port must fall inside
+/// that range so the captured original destination routes to the egress listener.
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_ingress_netfilter_egress_mapping_port_range() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "mapping_udp": {
+                        "in": {
+                            "host": "0.0.0.0",
+                            "port": 20085
+                        },
+                        "out": {
+                            "host": "127.0.0.1",
+                            "port": 30085
+                        }
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 20080, "port_end": 20090 }
+                        ]
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30085 }.boxed(),
+        AppType::UdpClient {
+            host: "192.168.1.1",
+            port: 20085,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}
+
+/// Full ingress+egress netfilter_udp on a single machine (both sides TPROXY).
+///
+///   Client node (192.168.1.253): TNG Client (ingress netfilter_udp) + UdpClient
+///   Server node (192.168.1.1):   TNG Server (egress netfilter_udp) + UdpServer
+///
+/// Data flow:
+///   UdpClient → 192.168.1.1:30061 (captured by ingress TPROXY on the client)
+///     → ingress orig_dst = 192.168.1.1:30061
+///     → ingress QUIC tunnel (SO_MARK bypasses the client's own OUTPUT capture)
+///       → 192.168.1.1:30061 (captured by egress TPROXY on the server)
+///     → egress orig_dst = 192.168.1.1:30061
+///     → egress forwards UDP → 192.168.1.1:30061 (UdpServer, server node)
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_netfilter_udp_full_path() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+        {
+            "add_egress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 30061 }
+                        ],
+                        "capture_local_traffic": true
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        TngInstance::TngClient(
+            r#"
+        {
+            "add_ingress": [
+                {
+                    "netfilter_udp": {
+                        "capture_dst": [
+                            { "host": "192.168.1.1", "port": 30061 }
+                        ]
+                    },
+                    "quic": {
+                        "max_datagram_size": 1200
+                    },
+                    "no_ra": true
+                }
+            ]
+        }
+        "#,
+        )
+        .boxed(),
+        AppType::UdpServer { port: 30061 }.boxed(),
+        AppType::UdpClient {
+            host: "192.168.1.1",
+            port: 30061,
+        }
+        .boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng/Cargo.toml
+++ b/tng/Cargo.toml
@@ -40,7 +40,9 @@ hyper = {workspace = true}
 hyper-util = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
+libc = "0.2"
 local-ip-address = "0.6"
+parking_lot = "0.12"
 nix = {workspace = true, features = ["process", "signal", "socket", "net"]}
 ohttp = {git = "https://github.com/inclavare-containers/ohttp.git", rev = "7d45814b747eb3944b234956edc1e56e2bf9cb2f"}
 opentelemetry = {workspace = true, optional = true}
@@ -164,18 +166,20 @@ default = [
 ]
 
 __egress-common = ["hyper/server", "dep:async-tungstenite", "dep:serf", "dep:peekable", "dep:uuid", "dep:pkcs8"]
-egress-all = ["egress-mapping", "egress-netfilter", "egress-mapping-udp"]
+egress-all = ["egress-mapping", "egress-netfilter", "egress-mapping-udp", "egress-netfilter-udp"]
 egress-mapping = ["__egress-common"]
 egress-netfilter = ["__egress-common", "dep:which"]
 egress-mapping-udp = ["__egress-common"]
+egress-netfilter-udp = ["__egress-common", "dep:which"]
 
 __ingress-common = ["dep:async-tungstenite"]
-ingress-all = ["ingress-http-proxy", "ingress-mapping", "ingress-netfilter", "ingress-socks5", "ingress-mapping-udp"]
+ingress-all = ["ingress-http-proxy", "ingress-mapping", "ingress-netfilter", "ingress-socks5", "ingress-mapping-udp", "ingress-netfilter-udp"]
 ingress-http-proxy = ["__ingress-common", "hyper/client"]
 ingress-mapping = ["__ingress-common"]
 ingress-netfilter = ["__ingress-common", "dep:which"]
 ingress-socks5 = ["__ingress-common", "dep:fast-socks5"]
 ingress-mapping-udp = ["__ingress-common"]
+ingress-netfilter-udp = ["__ingress-common", "dep:which"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 

--- a/tng/src/config/egress.rs
+++ b/tng/src/config/egress.rs
@@ -111,6 +111,53 @@ pub struct EgressMappingUdpArgs {
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct EgressNetfilterUdpArgs {
+    #[serde_as(as = "OneOrMany<_, PreferMany>")]
+    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capture_dst: Vec<EgressNetfilterCaptureDstArgs>,
+
+    #[serde(default = "bool::default")]
+    pub capture_local_traffic: bool,
+
+    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capture_cgroup: Vec<String>,
+
+    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub nocapture_cgroup: Vec<String>,
+
+    /// The local port the TPROXY interception socket (QUIC listener) binds to.
+    ///
+    /// Optional: when omitted, a free port is picked randomly. This is the
+    /// iptables interception machine's receive port — it receives packets
+    /// redirected by the TPROXY rule. **It must not overlap any `capture_dst`
+    /// port**; otherwise the listener would intercept its own traffic and
+    /// recurse. Letting it default to a random port avoids this by construction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_port: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub so_mark: Option<u32>,
+
+    /// Idle timeout in seconds for the UDP session.
+    ///
+    /// This is a bidirectional timeout — both directions must be idle for the
+    /// timeout to trigger. Any activity in either direction resets the timer.
+    ///
+    /// On the egress side, if no datagram is sent from QUIC AND no response
+    /// datagram is received from the backend for this duration, the UDP socket
+    /// is closed and the corresponding QUIC connection is terminated.
+    ///
+    /// Similar to NAT UDP session timeout. Defaults to 30s if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EgressNetfilterArgs {
     #[serde_as(as = "OneOrMany<_, PreferMany>")]
     #[serde(default = "Vec::new")]
@@ -206,6 +253,22 @@ pub enum EgressNetfilterCaptureDst {
     },
 }
 
+impl EgressNetfilterCaptureDst {
+    /// Return the (start, end) port range matched by this rule, inclusive.
+    /// Returns `None` for host/ipset-only rules that match all ports.
+    pub fn port_range(&self) -> Option<(u16, u16)> {
+        match self {
+            EgressNetfilterCaptureDst::HostOnly { .. }
+            | EgressNetfilterCaptureDst::IpSetOnly { .. } => None,
+            EgressNetfilterCaptureDst::PortOnly { port, port_end }
+            | EgressNetfilterCaptureDst::HostAndPort { port, port_end, .. }
+            | EgressNetfilterCaptureDst::IpSetAndPort { port, port_end, .. } => {
+                Some((*port, port_end.unwrap_or(*port)))
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub enum EgressMode {
@@ -221,6 +284,10 @@ pub enum EgressMode {
     #[cfg(feature = "egress-mapping-udp")]
     #[serde(rename = "mapping_udp")]
     MappingUdp(EgressMappingUdpArgs),
+
+    #[cfg(feature = "egress-netfilter-udp")]
+    #[serde(rename = "netfilter_udp")]
+    NetfilterUdp(EgressNetfilterUdpArgs),
 }
 
 impl EgressMode {
@@ -231,6 +298,8 @@ impl EgressMode {
             EgressMode::Hook(_) => EgressAccessMode::Hook,
             #[cfg(feature = "egress-mapping-udp")]
             EgressMode::MappingUdp(_) => EgressAccessMode::MappingUdp,
+            #[cfg(feature = "egress-netfilter-udp")]
+            EgressMode::NetfilterUdp(_) => EgressAccessMode::NetfilterUdp,
         }
     }
 }
@@ -828,6 +897,33 @@ mod tests {
             serde_json::to_value(config2)?
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_egress_netfilter_udp() -> Result<()> {
+        let config: TngConfig = serde_json::from_value(json!(
+            {
+                "add_egress": [
+                    {
+                        "netfilter_udp": {
+                            "capture_dst": [
+                                { "port": 30001 },
+                                { "host": "10.0.0.0/24", "port": 443 }
+                            ],
+                            "listen_port": 50001
+                        },
+                        "no_ra": true
+                    }
+                ]
+            }
+        ))?;
+        let json = serde_json::to_string_pretty(&config)?;
+        let config2: TngConfig = serde_json::from_str(&json)?;
+        assert_eq!(
+            serde_json::to_value(config)?,
+            serde_json::to_value(config2)?
+        );
         Ok(())
     }
 }

--- a/tng/src/config/ingress.rs
+++ b/tng/src/config/ingress.rs
@@ -75,6 +75,10 @@ pub enum IngressMode {
     #[cfg(feature = "ingress-mapping-udp")]
     #[serde(rename = "mapping_udp")]
     MappingUdp(IngressMappingUdpArgs),
+
+    #[cfg(feature = "ingress-netfilter-udp")]
+    #[serde(rename = "netfilter_udp")]
+    NetfilterUdp(IngressNetfilterUdpArgs),
 }
 
 impl IngressMode {
@@ -87,6 +91,8 @@ impl IngressMode {
             IngressMode::Hook(_) => IngressAccessMode::Hook,
             #[cfg(feature = "ingress-mapping-udp")]
             IngressMode::MappingUdp(_) => IngressAccessMode::MappingUdp,
+            #[cfg(feature = "ingress-netfilter-udp")]
+            IngressMode::NetfilterUdp(_) => IngressAccessMode::NetfilterUdp,
         }
     }
 }
@@ -141,6 +147,51 @@ pub struct IngressMappingUdpArgs {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IngressNetfilterUdpArgs {
+    #[serde_as(as = "OneOrMany<_, PreferMany>")]
+    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capture_dst: Vec<IngressNetfilterCaptureDstArgs>,
+
+    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capture_cgroup: Vec<String>,
+
+    #[serde(default = "Vec::new")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub nocapture_cgroup: Vec<String>,
+
+    /// The local port the TPROXY interception socket (QUIC client tunnel
+    /// listener) binds to.
+    ///
+    /// Optional: when omitted, a free port is picked randomly. This is the
+    /// iptables interception machine's receive port — it receives packets
+    /// redirected by the TPROXY rule. **It must not overlap any
+    /// `capture_dst` port**; otherwise the listener would intercept its own
+    /// traffic and recurse. Letting it default to a random port avoids this
+    /// by construction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_port: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub so_mark: Option<u32>,
+
+    /// Idle timeout in seconds for the UDP session.
+    ///
+    /// This is a bidirectional timeout — both directions must be idle for the
+    /// timeout to trigger. Any activity in either direction resets the timer.
+    ///
+    /// On the ingress side, if no new datagram is received from the client AND
+    /// no response datagram is received from the QUIC connection for this
+    /// duration, the QUIC connection is closed and the entry is removed.
+    ///
+    /// Similar to NAT UDP session timeout. Defaults to 30s if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IngressHttpProxyArgs {
     pub proxy_listen: Endpoint,
 
@@ -168,6 +219,15 @@ pub struct IngressNetfilterArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub nocapture_cgroup: Vec<String>,
 
+    /// The local port the TPROXY interception socket (QUIC client tunnel
+    /// listener) binds to.
+    ///
+    /// Optional: when omitted, a free port is picked randomly. This is the
+    /// iptables interception machine's receive port — it receives packets
+    /// redirected by the TPROXY rule. **It must not overlap any
+    /// `capture_dst` port**; otherwise the listener would intercept its own
+    /// traffic and recurse. Letting it default to a random port avoids this
+    /// by construction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub listen_port: Option<u16>,
 
@@ -293,6 +353,22 @@ pub enum IngressNetfilterCaptureDst {
         port: u16,
         port_end: Option<u16>,
     },
+}
+
+impl IngressNetfilterCaptureDst {
+    /// Return the (start, end) port range matched by this rule, inclusive.
+    /// Returns `None` for host/ipset-only rules that match all ports.
+    pub fn port_range(&self) -> Option<(u16, u16)> {
+        match self {
+            IngressNetfilterCaptureDst::HostOnly { .. }
+            | IngressNetfilterCaptureDst::IpSetOnly { .. } => None,
+            IngressNetfilterCaptureDst::PortOnly { port, port_end }
+            | IngressNetfilterCaptureDst::HostAndPort { port, port_end, .. }
+            | IngressNetfilterCaptureDst::IpSetAndPort { port, port_end, .. } => {
+                Some((*port, port_end.unwrap_or(*port)))
+            }
+        }
+    }
 }
 
 #[serde_as]
@@ -1147,6 +1223,45 @@ mod tests {
         // Some(false) is not skipped (only None is), but stays false:
         let args2: super::OHttpArgs = serde_json::from_value(json!({"tls": false}))?;
         assert_eq!(args2.tls, Some(false));
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_ingress_netfilter_udp() -> Result<()> {
+        let config: TngConfig = serde_json::from_value(json!(
+            {
+                "add_ingress": [
+                    {
+                        "netfilter_udp": {
+                            "capture_dst": [
+                                { "port": 30001 },
+                                { "host": "10.0.0.0/24", "port": 443 }
+                            ],
+                            "listen_port": 50000
+                        },
+                        "no_ra": true
+                    }
+                ]
+            }
+        ))?;
+        let json = serde_json::to_string_pretty(&config)?;
+        let config2: TngConfig = serde_json::from_str(&json)?;
+        assert_eq!(
+            serde_json::to_value(config)?,
+            serde_json::to_value(config2)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize_ingress_netfilter_udp_capture_all() -> Result<()> {
+        let _config: TngConfig = serde_json::from_value(json!(
+            {
+                "add_ingress": [
+                    { "netfilter_udp": {}, "no_ra": true }
+                ]
+            }
+        ))?;
         Ok(())
     }
 }

--- a/tng/src/runtime.rs
+++ b/tng/src/runtime.rs
@@ -174,8 +174,25 @@ impl TngRuntime {
                         use crate::tunnel::ingress::datagram_flow::DatagramIngressFlow;
                         use crate::tunnel::ingress::mapping_udp::MappingUdpIngress;
 
-                        let mut ingress = MappingUdpIngress::new(id, mapping_udp_args).await?;
-                        ingress.set_max_datagram_size(add_ingress.common.quic.as_ref().and_then(|q| q.max_datagram_size));
+                        let ingress = MappingUdpIngress::new(id, mapping_udp_args).await?;
+
+                        Arc::new(
+                            DatagramIngressFlow::new(
+                                ingress,
+                                &add_ingress.common,
+                                &service_metrics_creator,
+                                runtime.clone(),
+                            )
+                            .await?,
+                        ) as Arc<_>
+                    }
+                    #[cfg(all(feature = "ingress-netfilter-udp", target_os = "linux"))]
+                    IngressMode::NetfilterUdp(netfilter_udp_args) => {
+                        use crate::tunnel::ingress::datagram_flow::DatagramIngressFlow;
+                        use crate::tunnel::ingress::netfilter_udp::NetfilterUdpIngress;
+
+                        let ingress =
+                            NetfilterUdpIngress::new(id, netfilter_udp_args).await?;
 
                         Arc::new(
                             DatagramIngressFlow::new(
@@ -246,8 +263,29 @@ impl TngRuntime {
                         use crate::tunnel::egress::datagram_flow::DatagramEgressFlow;
                         use crate::tunnel::egress::mapping_udp::MappingUdpEgress;
 
-                        let mut egress = MappingUdpEgress::new(id, mapping_udp_args).await?;
-                        egress.set_max_datagram_size(add_egress.common.quic.as_ref().and_then(|q| q.max_datagram_size));
+                        let egress = MappingUdpEgress::new(id, mapping_udp_args).await?;
+
+                        Arc::new(
+                            DatagramEgressFlow::new(
+                                egress,
+                                &add_egress.common,
+                                &service_metrics_creator,
+                                runtime.clone(),
+                            )
+                            .await?,
+                        ) as Arc<_>
+                    }
+                    #[cfg(all(feature = "egress-netfilter-udp", target_os = "linux"))]
+                    EgressMode::NetfilterUdp(netfilter_udp_args) => {
+                        use crate::tunnel::egress::datagram_flow::DatagramEgressFlow;
+                        use crate::tunnel::egress::netfilter_udp::NetfilterUdpEgress;
+
+                        let egress = NetfilterUdpEgress::new(
+                            id,
+                            netfilter_udp_args,
+                            &add_egress.common,
+                            runtime.clone(),
+                        ).await?;
 
                         Arc::new(
                             DatagramEgressFlow::new(

--- a/tng/src/runtime.rs
+++ b/tng/src/runtime.rs
@@ -186,23 +186,34 @@ impl TngRuntime {
                             .await?,
                         ) as Arc<_>
                     }
-                    #[cfg(all(feature = "ingress-netfilter-udp", target_os = "linux"))]
+                    #[cfg(feature = "ingress-netfilter-udp")]
                     IngressMode::NetfilterUdp(netfilter_udp_args) => {
-                        use crate::tunnel::ingress::datagram_flow::DatagramIngressFlow;
-                        use crate::tunnel::ingress::netfilter_udp::NetfilterUdpIngress;
+                        #[cfg(not(target_os = "linux"))]
+                        {
+                            let _ = netfilter_udp_args;
+                            anyhow::bail!(
+                                "Using ingress with 'netfilter_udp' type is not supported on OS other than Linux"
+                            );
+                        }
 
-                        let ingress =
-                            NetfilterUdpIngress::new(id, netfilter_udp_args).await?;
+                        #[cfg(target_os = "linux")]
+                        {
+                            use crate::tunnel::ingress::datagram_flow::DatagramIngressFlow;
+                            use crate::tunnel::ingress::netfilter_udp::NetfilterUdpIngress;
 
-                        Arc::new(
-                            DatagramIngressFlow::new(
-                                ingress,
-                                &add_ingress.common,
-                                &service_metrics_creator,
-                                runtime.clone(),
-                            )
-                            .await?,
-                        ) as Arc<_>
+                            let ingress =
+                                NetfilterUdpIngress::new(id, netfilter_udp_args).await?;
+
+                            Arc::new(
+                                DatagramIngressFlow::new(
+                                    ingress,
+                                    &add_ingress.common,
+                                    &service_metrics_creator,
+                                    runtime.clone(),
+                                )
+                                .await?,
+                            ) as Arc<_>
+                        }
                     }
                 })
             }.instrument(span.clone()).await?;
@@ -275,27 +286,39 @@ impl TngRuntime {
                             .await?,
                         ) as Arc<_>
                     }
-                    #[cfg(all(feature = "egress-netfilter-udp", target_os = "linux"))]
+                    #[cfg(feature = "egress-netfilter-udp")]
                     EgressMode::NetfilterUdp(netfilter_udp_args) => {
-                        use crate::tunnel::egress::datagram_flow::DatagramEgressFlow;
-                        use crate::tunnel::egress::netfilter_udp::NetfilterUdpEgress;
+                        #[cfg(not(target_os = "linux"))]
+                        {
+                            let _ = netfilter_udp_args;
+                            anyhow::bail!(
+                                "Using egress with 'netfilter_udp' type is not supported on OS other than Linux"
+                            );
+                        }
 
-                        let egress = NetfilterUdpEgress::new(
-                            id,
-                            netfilter_udp_args,
-                            &add_egress.common,
-                            runtime.clone(),
-                        ).await?;
+                        #[cfg(target_os = "linux")]
+                        {
+                            use crate::tunnel::egress::datagram_flow::DatagramEgressFlow;
+                            use crate::tunnel::egress::netfilter_udp::NetfilterUdpEgress;
 
-                        Arc::new(
-                            DatagramEgressFlow::new(
-                                egress,
+                            let egress = NetfilterUdpEgress::new(
+                                id,
+                                netfilter_udp_args,
                                 &add_egress.common,
-                                &service_metrics_creator,
                                 runtime.clone(),
                             )
-                            .await?,
-                        ) as Arc<_>
+                            .await?;
+
+                            Arc::new(
+                                DatagramEgressFlow::new(
+                                    egress,
+                                    &add_egress.common,
+                                    &service_metrics_creator,
+                                    runtime.clone(),
+                                )
+                                .await?,
+                            ) as Arc<_>
+                        }
                     }
                 })
             }.instrument(span.clone()).await?;

--- a/tng/src/tunnel/access_log.rs
+++ b/tng/src/tunnel/access_log.rs
@@ -10,6 +10,7 @@ pub enum IngressAccessMode {
     HttpProxy,
     Hook,
     MappingUdp,
+    NetfilterUdp,
 }
 
 impl Display for IngressAccessMode {
@@ -21,6 +22,7 @@ impl Display for IngressAccessMode {
             IngressAccessMode::HttpProxy => write!(f, "http_proxy"),
             IngressAccessMode::Hook => write!(f, "hook"),
             IngressAccessMode::MappingUdp => write!(f, "mapping_udp"),
+            IngressAccessMode::NetfilterUdp => write!(f, "netfilter_udp"),
         }
     }
 }
@@ -32,6 +34,7 @@ pub enum EgressAccessMode {
     Netfilter,
     Hook,
     MappingUdp,
+    NetfilterUdp,
 }
 
 impl Display for EgressAccessMode {
@@ -41,6 +44,7 @@ impl Display for EgressAccessMode {
             EgressAccessMode::Netfilter => write!(f, "netfilter"),
             EgressAccessMode::Hook => write!(f, "hook"),
             EgressAccessMode::MappingUdp => write!(f, "mapping_udp"),
+            EgressAccessMode::NetfilterUdp => write!(f, "netfilter_udp"),
         }
     }
 }

--- a/tng/src/tunnel/egress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/egress/datagram_flow/mod.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use web_time_compat::{Duration, Instant, InstantExt};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use indexmap::IndexMap;
@@ -15,12 +15,13 @@ use crate::config::egress::CommonArgs as EgressCommonArgs;
 use crate::error::TngError;
 use crate::service::RegistedService;
 use crate::status::{StatusProvider, StatusQueryResult};
-use crate::tunnel::access_log::{AccessAccepted, EgressAccessMode};
+use crate::tunnel::access_log::AccessAccepted;
 use crate::tunnel::endpoint::{EndpointAddr, TngEndpoint};
 use crate::tunnel::service_metrics::ServiceMetrics;
 use crate::tunnel::service_metrics::ServiceMetricsCreator;
 use crate::tunnel::utils::runtime::TokioRuntime;
 use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+use crate::tunnel::utils::socket::resolve_ipv4_addr;
 
 /// Trait for a single QUIC connection on the egress side.
 ///
@@ -43,14 +44,22 @@ pub(super) trait EgressDatagramConnection: Send + Sync {
 
 /// Trait for the QUIC listener on the egress side.
 ///
-/// Accepts incoming QUIC connections and yields `EgressDatagramConnection` objects.
+/// Accepts incoming QUIC connections and yields `AcceptedConnection` objects.
 #[async_trait]
 pub(super) trait EgressDatagramListener: Send + Sync {
     /// Get the local address the listener is bound to.
     fn local_addr(&self) -> Result<SocketAddr>;
 
-    /// Accept the next QUIC connection.
-    async fn accept(&self) -> Result<Arc<dyn EgressDatagramConnection>>;
+    /// Accept the next QUIC connection, returning the connection paired with
+    /// its original destination address (from IP_ORIGDSTADDR for netfilter_udp,
+    /// or the fixed backend endpoint for mapping_udp).
+    async fn accept(&self) -> Result<AcceptedConnection>;
+}
+
+/// An accepted QUIC connection paired with its backend address.
+pub(super) struct AcceptedConnection {
+    pub connection: Arc<dyn EgressDatagramConnection>,
+    pub backend_addr: TngEndpoint,
 }
 
 /// Trait for egress datagram listeners.
@@ -63,17 +72,26 @@ pub(super) trait EgressDatagramTrait: Send + Sync {
     /// Return the metric attributes of this egress.
     fn metric_attributes(&self) -> IndexMap<String, String>;
 
-    /// The backend endpoint this egress forwards to.
-    fn backend_endpoint(&self) -> TngEndpoint;
+    /// Return the access log mode for this egress.
+    fn access_mode(&self) -> crate::tunnel::access_log::EgressAccessMode;
 
     /// The idle timeout in seconds for connections.
     fn idle_timeout_secs(&self) -> u64;
 
+    /// The SO_MARK value to set on backend UDP sockets (to bypass TPROXY rules).
+    /// Returns `None` if no mark is needed (e.g., no TPROXY in use).
+    fn so_mark(&self) -> Option<u32> {
+        None
+    }
+
     /// Bind the QUIC listener. The Flow provides the TLS config generator
     /// so RA context is managed centrally (same pattern as ingress).
+    /// `max_datagram_size` is the top-level `quic.max_datagram_size` (the Flow
+    /// owns it so RA context is managed centrally).
     async fn bind_listener(
         &self,
         tls_gen: &TlsConfigGenerator,
+        max_datagram_size: Option<usize>,
     ) -> Result<Arc<dyn EgressDatagramListener>>;
 }
 
@@ -82,6 +100,9 @@ pub struct DatagramEgressFlow {
     tls_gen: TlsConfigGenerator,
     metrics: ServiceMetrics,
     runtime: TokioRuntime,
+    /// Top-level `quic.max_datagram_size`, captured in `new()` from the common
+    /// args and passed to `bind_listener`.
+    max_datagram_size: Option<usize>,
 }
 
 impl DatagramEgressFlow {
@@ -100,11 +121,14 @@ impl DatagramEgressFlow {
             Arc::new(crate::tunnel::ra_context::RaContext::from_ra_args(&ra_args).await?);
         let tls_gen = TlsConfigGenerator::new(ra_context, runtime.clone()).await?;
 
+        let max_datagram_size = common_args.quic.as_ref().and_then(|q| q.max_datagram_size);
+
         Ok(Self {
             egress: Box::new(egress),
             tls_gen,
             metrics,
             runtime,
+            max_datagram_size,
         })
     }
 }
@@ -112,18 +136,28 @@ impl DatagramEgressFlow {
 #[async_trait::async_trait]
 impl RegistedService for DatagramEgressFlow {
     async fn serve(&self, ready: Sender<()>) -> Result<()> {
-        let listener = self.egress.bind_listener(&self.tls_gen).await?;
+        let listener = self
+            .egress
+            .bind_listener(&self.tls_gen, self.max_datagram_size)
+            .await?;
         let actual_addr = listener.local_addr()?;
-        tracing::info!("UDP mapping egress QUIC listener on {}", actual_addr);
+        let access_mode = self.egress.access_mode();
+        tracing::info!(
+            "UDP {} egress QUIC listener on {}",
+            access_mode,
+            actual_addr
+        );
 
         ready.send(()).await?;
 
-        let backend_ep = self.egress.backend_endpoint();
         let idle_timeout_secs = self.egress.idle_timeout_secs();
         let listener_addr = actual_addr;
 
         loop {
-            let connection = listener.accept().await?;
+            let AcceptedConnection {
+                connection,
+                backend_addr: backend_ep,
+            } = listener.accept().await?;
             let remote = connection.remote_address();
 
             tracing::info!(
@@ -131,8 +165,7 @@ impl RegistedService for DatagramEgressFlow {
                 "Accepted QUIC connection from ingress"
             );
 
-            let access_accepted =
-                AccessAccepted::new_egress(remote, listener_addr, EgressAccessMode::MappingUdp);
+            let access_accepted = AccessAccepted::new_egress(remote, listener_addr, access_mode);
             let access_routed = access_accepted.into_routed(
                 &backend_ep,
                 true, // from_trusted_tunnel
@@ -145,16 +178,17 @@ impl RegistedService for DatagramEgressFlow {
             let active_cx = metrics.new_cx();
             let runtime_spawn = self.runtime.clone();
             let runtime_for_task = self.runtime.clone();
-            let backend_ep_clone = backend_ep.clone();
             let idle_timeout = idle_timeout_secs;
             let connection_clone = connection.clone();
+            let so_mark = self.egress.so_mark();
 
             runtime_spawn.spawn_supervised_task(async move {
                 if let Err(e) = Self::forward_connection(
                     connection_clone,
-                    &backend_ep_clone,
+                    &backend_ep,
                     idle_timeout,
                     &runtime_for_task,
+                    so_mark,
                 )
                 .await
                 {
@@ -175,23 +209,37 @@ impl DatagramEgressFlow {
         backend_ep: &TngEndpoint,
         idle_timeout_secs: u64,
         runtime: &TokioRuntime,
+        so_mark: Option<u32>,
     ) -> Result<()> {
-        let backend_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
-        // Connect without formatting a "host:port" string: both `(Ipv4Addr, u16)`
-        // and `(&str, u16)` implement `ToSocketAddrs` directly.
-        match backend_ep.addr() {
-            EndpointAddr::Ipv4(ip) => {
-                backend_socket.connect((*ip, backend_ep.port())).await?;
-            }
-            EndpointAddr::Domain(d) => {
-                backend_socket
-                    .connect((d.as_str(), backend_ep.port()))
-                    .await?;
-            }
+        let backend_addr = match backend_ep.addr() {
+            EndpointAddr::Ipv4(ip) => SocketAddr::new(std::net::IpAddr::V4(*ip), backend_ep.port()),
+            EndpointAddr::Domain(d) => resolve_ipv4_addr(d, backend_ep.port())
+                .await
+                .with_context(|| format!("resolve egress backend domain {d}"))?,
+        };
+
+        // Create a UDP socket with socket2 crate so that we can set the SO_MARK option
+        let std_socket = socket2::Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )?;
+        std_socket.set_nonblocking(true)?;
+        if let Some(mark) = so_mark {
+            std_socket.set_mark(mark)?;
         }
+        const ANY: SocketAddr =
+            SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), 0);
+        std_socket.bind(&ANY.into())?;
+        let backend_socket = Arc::new(UdpSocket::from_std(std_socket.into())?);
+        backend_socket.connect(backend_addr).await?;
 
         let idle_timeout = Duration::from_secs(idle_timeout_secs);
         let last_activity = Arc::new(Mutex::new(Instant::get()));
+        // Idle-timeout probe cadence: when neither direction has moved for this
+        // long, the `sleep` arm in each forward task fires and checks whether
+        // the session has been idle past `idle_timeout`. 5s is coarse but fine
+        // — the timeout itself is ~30s.
         let check_interval = Duration::from_secs(5);
 
         let conn_clone = connection.clone();
@@ -207,13 +255,18 @@ impl DatagramEgressFlow {
                     datagram_result = conn_clone.read_datagram() => {
                         match datagram_result {
                             Ok(payload) => {
-                                let _ = backend_socket_a.send(&payload).await;
+                                tracing::debug!(len = payload.len(), "egress A: forward QUIC->backend");
+                                if let Err(e) = backend_socket_a.send(&payload).await {
+                                    tracing::warn!(error = %e, "egress A: backend_socket send failed");
+                                }
                                 *last_act_a.lock().await = Instant::get();
                             }
-                            Err(_) => break,
+                            Err(e) => { tracing::debug!(error=%e, "egress A: read_datagram ended"); break; }
                         }
                     }
                     _ = sleep(check_interval) => {
+                        // Idle-timeout probe: if neither direction has moved
+                        // for `timeout_a`, tear down the connection.
                         let last = *last_act_a.lock().await;
                         if last.elapsed() >= timeout_a {
                             break;
@@ -238,6 +291,7 @@ impl DatagramEgressFlow {
                     recv_result = backend_socket_b.recv(&mut recv_buf) => {
                         match recv_result {
                             Ok(n) => {
+                                tracing::debug!(len = n, "egress B: recv backend->QUIC");
                                 let payload = Bytes::copy_from_slice(&recv_buf[..n]);
                                 if let Err(e) = connection_send.send_datagram(payload) {
                                     tracing::warn!(error = %e, "Failed to send datagram to QUIC");
@@ -245,10 +299,11 @@ impl DatagramEgressFlow {
                                 }
                                 *last_act_b.lock().await = Instant::get();
                             }
-                            Err(_) => break,
+                            Err(e) => { tracing::debug!(error=%e, "egress B: recv ended"); break; }
                         }
                     }
                     _ = sleep(check_interval) => {
+                        // Idle-timeout probe (same as task A).
                         let last = *last_act_b.lock().await;
                         if last.elapsed() >= timeout_b {
                             break;

--- a/tng/src/tunnel/egress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/egress/datagram_flow/mod.rs
@@ -211,6 +211,12 @@ impl DatagramEgressFlow {
         runtime: &TokioRuntime,
         so_mark: Option<u32>,
     ) -> Result<()> {
+        // SO_MARK is Linux-only; `so_mark` is only `Some` for netfilter_udp
+        // egress (Linux-only). On other platforms it is always `None`, so
+        // consume it to avoid an unused-variable warning there.
+        #[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+        let _ = so_mark;
+
         let backend_addr = match backend_ep.addr() {
             EndpointAddr::Ipv4(ip) => SocketAddr::new(std::net::IpAddr::V4(*ip), backend_ep.port()),
             EndpointAddr::Domain(d) => resolve_ipv4_addr(d, backend_ep.port())
@@ -225,6 +231,7 @@ impl DatagramEgressFlow {
             Some(socket2::Protocol::UDP),
         )?;
         std_socket.set_nonblocking(true)?;
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         if let Some(mark) = so_mark {
             std_socket.set_mark(mark)?;
         }

--- a/tng/src/tunnel/egress/mapping_udp.rs
+++ b/tng/src/tunnel/egress/mapping_udp.rs
@@ -9,7 +9,7 @@ use quinn::crypto::rustls::QuicServerConfig;
 
 use crate::config::egress::EgressMappingUdpArgs;
 use crate::tunnel::egress::datagram_flow::{
-    EgressDatagramConnection, EgressDatagramListener, EgressDatagramTrait,
+    AcceptedConnection, EgressDatagramConnection, EgressDatagramListener, EgressDatagramTrait,
 };
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::utils::rustls::config::alpn::Alpn;
@@ -61,6 +61,7 @@ impl EgressDatagramConnection for QuicEgressConnection {
 struct QuicEgressListener {
     endpoint: quinn::Endpoint,
     max_datagram_size: Option<usize>,
+    backend_ep: TngEndpoint,
 }
 
 #[async_trait]
@@ -71,7 +72,9 @@ impl EgressDatagramListener for QuicEgressListener {
             .context("Failed to get QUIC local address")
     }
 
-    async fn accept(&self) -> Result<Arc<dyn EgressDatagramConnection>> {
+    async fn accept(&self) -> Result<AcceptedConnection> {
+        use super::datagram_flow::AcceptedConnection;
+
         let connecting = self
             .endpoint
             .accept()
@@ -80,10 +83,14 @@ impl EgressDatagramListener for QuicEgressListener {
         let connection = connecting
             .await
             .context("QUIC connection handshake failed")?;
-        Ok(Arc::new(QuicEgressConnection {
-            inner: connection,
-            max_datagram_size: self.max_datagram_size,
-        }))
+
+        Ok(AcceptedConnection {
+            connection: Arc::new(QuicEgressConnection {
+                inner: connection,
+                max_datagram_size: self.max_datagram_size,
+            }),
+            backend_addr: self.backend_ep.clone(),
+        })
     }
 }
 
@@ -97,7 +104,6 @@ pub struct MappingUdpEgress {
     pub listen_port: u16,
     pub backend_addr: String,
     pub backend_port: u16,
-    pub max_datagram_size: Option<usize>,
     pub idle_timeout_secs: u64,
 }
 
@@ -121,14 +127,8 @@ impl MappingUdpEgress {
                 .to_owned(),
             backend_port: mapping_args.out.port,
 
-            max_datagram_size: None,
             idle_timeout_secs: mapping_args.idle_timeout_secs.unwrap_or(30),
         })
-    }
-
-    /// Set max_datagram_size from top-level quic config.
-    pub fn set_max_datagram_size(&mut self, size: Option<usize>) {
-        self.max_datagram_size = size;
     }
 
     pub fn metric_attributes(&self) -> IndexMap<String, String> {
@@ -154,8 +154,8 @@ impl EgressDatagramTrait for MappingUdpEgress {
         self.metric_attributes()
     }
 
-    fn backend_endpoint(&self) -> TngEndpoint {
-        TngEndpoint::new(self.backend_addr.clone(), self.backend_port)
+    fn access_mode(&self) -> crate::tunnel::access_log::EgressAccessMode {
+        crate::tunnel::access_log::EgressAccessMode::MappingUdp
     }
 
     fn idle_timeout_secs(&self) -> u64 {
@@ -165,6 +165,7 @@ impl EgressDatagramTrait for MappingUdpEgress {
     async fn bind_listener(
         &self,
         tls_gen: &TlsConfigGenerator,
+        max_datagram_size: Option<usize>,
     ) -> Result<Arc<dyn EgressDatagramListener>> {
         let listen_addr: SocketAddr =
             format!("{}:{}", self.listen_addr, self.listen_port).parse()?;
@@ -180,7 +181,8 @@ impl EgressDatagramTrait for MappingUdpEgress {
 
         Ok(Arc::new(QuicEgressListener {
             endpoint,
-            max_datagram_size: self.max_datagram_size,
+            max_datagram_size,
+            backend_ep: TngEndpoint::new(self.backend_addr.clone(), self.backend_port),
         }))
     }
 }

--- a/tng/src/tunnel/egress/mod.rs
+++ b/tng/src/tunnel/egress/mod.rs
@@ -10,5 +10,8 @@ pub mod mapping_udp;
 #[cfg(all(feature = "egress-netfilter", target_os = "linux"))]
 pub mod netfilter;
 
+#[cfg(all(feature = "egress-netfilter-udp", target_os = "linux"))]
+pub mod netfilter_udp;
+
 #[cfg(feature = "egress-mapping-udp")]
 pub(crate) mod datagram_flow;

--- a/tng/src/tunnel/egress/netfilter_udp/iptables.rs
+++ b/tng/src/tunnel/egress/netfilter_udp/iptables.rs
@@ -1,0 +1,223 @@
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+
+use crate::{
+    config::egress::EgressNetfilterCaptureDst,
+    tunnel::utils::iptables::{
+        format_dport, IptablesRuleGenerator, NETFILTER_UDP_EGRESS_FW_MARK_BASE,
+        NETFILTER_UDP_EGRESS_ROUTE_TABLE_BASE,
+    },
+};
+
+use super::NetfilterUdpEgress;
+
+fn is_cgroup_v2() -> bool {
+    Path::new("/sys/fs/cgroup/cgroup.controllers").exists()
+}
+
+#[async_trait]
+impl IptablesRuleGenerator for NetfilterUdpEgress {
+    async fn gen_script(&self) -> Result<(String, String)> {
+        which::which("iptables")
+            .context("The external tool \"iptables\" is not found, please install it")?;
+        which::which("ip").context("The external tool \"ip\" is not found, please install it")?;
+
+        let id = self.id;
+        let fw_mark = NETFILTER_UDP_EGRESS_FW_MARK_BASE + id as u32;
+        let route_table = NETFILTER_UDP_EGRESS_ROUTE_TABLE_BASE + id as u32;
+        let listen_port = self.listen_port;
+
+        if self.capture_dst.is_empty() {
+            tracing::info!("capture_dst is empty, will capture all UDP traffic");
+
+            if self.capture_local_traffic {
+                tracing::warn!(
+                    "netfilter_udp egress: capture_dst is empty and \
+                     capture_local_traffic is true — the backend's reply packets \
+                     may not be delivered to the downstream client; please specify \
+                     concrete capture rules instead of capture-all"
+                );
+            }
+        }
+
+        let mut invoke_script = "".to_owned();
+        let mut revoke_script = "".to_owned();
+
+        let clean_up = format!(
+            "\
+            iptables -t mangle -D PREROUTING -p udp -j TNG_EGRESS_UDP_{id} 2>/dev/null || true ; \
+            iptables -t mangle -F TNG_EGRESS_UDP_{id} 2>/dev/null || true ; \
+            iptables -t mangle -X TNG_EGRESS_UDP_{id} 2>/dev/null || true ; \
+            iptables -t mangle -F TNG_EGRESS_UDP_{id}_CGROUP 2>/dev/null || true ; \
+            iptables -t mangle -X TNG_EGRESS_UDP_{id}_CGROUP 2>/dev/null || true ; \
+            ip route flush table {route_table} 2>/dev/null || true ; \
+            ip rule del table {route_table} 2>/dev/null || true ; \
+            "
+        );
+
+        invoke_script += &clean_up;
+        invoke_script += &format!("iptables -t mangle -N TNG_EGRESS_UDP_{id} ; ");
+
+        // Bypass our own backend-forward traffic. The egress forwards each
+        // QUIC datagram to the backend via a connected UDP socket carrying
+        // SO_MARK = so_mark. When the backend address equals a capture_dst
+        // host that is local to this node (the common case: capture_dst is one
+        // of this machine's own IPs), that locally-generated forward packet is
+        // looped back through `lo` and re-traverses PREROUTING — so without an
+        // escape it would be TPROXY'd right back into our own QUIC listener
+        // and never reach the real backend. This `--mark so_mark -j RETURN`
+        // rule (placed first in the chain) lets the marked forward fall through
+        // to normal local delivery.
+        //
+        // This does NOT exempt the ingress's QUIC tunnel packets: those carry
+        // the *ingress* side's so_mark on the client node, but a packet mark
+        // (skb->mark) is per-skb and is NOT propagated across the bridge/wire
+        // — the server receives the ingress tunnel with mark 0, so it does not
+        // match here and is still intercepted. (Mirrors the TCP `netfilter`
+        // egress and the ingress `out1_chain` escape rule.)
+        invoke_script += &format!(
+            "iptables -t mangle -A TNG_EGRESS_UDP_{id} -m mark --mark {} -j RETURN ;",
+            self.so_mark
+        );
+
+        // Handle cgroup filtering
+        if !self.capture_cgroup.is_empty() {
+            if !is_cgroup_v2() {
+                bail!("It seems that you are not running in cgroup v2, but `capture_cgroup` and `nocapture_cgroup` are supported on cgroup v2 only")
+            }
+
+            invoke_script += &format!("iptables -t mangle -N TNG_EGRESS_UDP_{id}_CGROUP ; ");
+
+            for cgroup in &self.nocapture_cgroup {
+                invoke_script += &format!(
+                    "iptables -t mangle -A TNG_EGRESS_UDP_{id}_CGROUP -m cgroup --path {cgroup} -j RETURN ;"
+                );
+            }
+
+            Self::append_capture_rules(
+                &mut invoke_script,
+                &format!("TNG_EGRESS_UDP_{id}_CGROUP"),
+                &self.capture_dst,
+                &self.capture_local_traffic,
+                listen_port,
+                fw_mark,
+            );
+
+            for cgroup in &self.capture_cgroup {
+                invoke_script += &format!(
+                    "iptables -t mangle -A TNG_EGRESS_UDP_{id} -m cgroup --path {cgroup} -j TNG_EGRESS_UDP_{id}_CGROUP ;"
+                );
+            }
+            invoke_script += "iptables -t mangle -A TNG_EGRESS_UDP_{id} -j RETURN ; ";
+        } else {
+            for cgroup in &self.nocapture_cgroup {
+                invoke_script += &format!(
+                    "iptables -t mangle -A TNG_EGRESS_UDP_{id} -m cgroup --path {cgroup} -j RETURN ;"
+                );
+            }
+
+            Self::append_capture_rules(
+                &mut invoke_script,
+                &format!("TNG_EGRESS_UDP_{id}"),
+                &self.capture_dst,
+                &self.capture_local_traffic,
+                listen_port,
+                fw_mark,
+            );
+        }
+
+        // Add routing rules for TPROXY
+        invoke_script += &format!(
+            "ip route add local default dev lo table {route_table} ; \
+             ip rule add fwmark {fw_mark}/0xffffff table {route_table} ; "
+        );
+
+        // NOTE: unlike the TCP `netfilter` egress, the UDP egress hooks only
+        // PREROUTING (not OUTPUT) because TPROXY is a PREROUTING-only target.
+        // There is intentionally NO trailing catch-all `-p udp -j TPROXY` here:
+        // `append_capture_rules` already emits a catch-all when `capture_dst`
+        // is empty. Adding another unconditional one would also TPROXY the
+        // backend's *reply* (UdpServer -> our backend socket, destined to an
+        // ephemeral port that no specific capture rule matches), sinking the
+        // echo before it reaches the backend socket and breaking the
+        // round-trip. The TCP egress avoids this via conntrack (nat REDIRECT
+        // only applies to the first packet of a connection); UDP has no such
+        // established-connection bypass, so we must not over-capture.
+
+        // Insert into PREROUTING chain
+        invoke_script +=
+            &format!("iptables -t mangle -I PREROUTING 1 -p udp -j TNG_EGRESS_UDP_{id} ; ");
+
+        revoke_script += &clean_up;
+
+        Ok((invoke_script, revoke_script))
+    }
+}
+
+impl NetfilterUdpEgress {
+    fn append_capture_rules(
+        script: &mut String,
+        chain: &str,
+        capture_dst: &[EgressNetfilterCaptureDst],
+        capture_local_traffic: &bool,
+        listen_port: u16,
+        fw_mark: u32,
+    ) {
+        let src_check = if !*capture_local_traffic {
+            "-m addrtype ! --src-type LOCAL "
+        } else {
+            ""
+        };
+
+        if capture_dst.is_empty() {
+            *script += &format!(
+                "iptables -t mangle -A {chain} -p udp {src_check}-j TPROXY --on-ip 0.0.0.0 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ; ",
+            );
+        } else {
+            for cap in capture_dst {
+                match cap {
+                    EgressNetfilterCaptureDst::HostOnly { host } => {
+                        *script += &format!(
+                            "iptables -t mangle -A {chain} -p udp {src_check}--dst {}/{} -j TPROXY --on-ip 0.0.0.0 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ; ",
+                            host.first_address(), host.network_length()
+                        );
+                    }
+                    EgressNetfilterCaptureDst::IpSetOnly { ipset } => {
+                        *script += &format!(
+                            "iptables -t mangle -A {chain} -p udp {src_check}-m set --match-set {ipset} dst -j TPROXY --on-ip 0.0.0.0 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ; "
+                        );
+                    }
+                    EgressNetfilterCaptureDst::PortOnly { port, port_end } => {
+                        let dport = format_dport(*port, port_end.as_ref());
+                        *script += &format!(
+                            "iptables -t mangle -A {chain} -p udp {src_check}--dport {dport} -j TPROXY --on-ip 0.0.0.0 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ; "
+                        );
+                    }
+                    EgressNetfilterCaptureDst::HostAndPort {
+                        host,
+                        port,
+                        port_end,
+                    } => {
+                        let dport = format_dport(*port, port_end.as_ref());
+                        *script += &format!(
+                            "iptables -t mangle -A {chain} -p udp {src_check}--dst {}/{} --dport {dport} -j TPROXY --on-ip 0.0.0.0 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ; ",
+                            host.first_address(), host.network_length()
+                        );
+                    }
+                    EgressNetfilterCaptureDst::IpSetAndPort {
+                        ipset,
+                        port,
+                        port_end,
+                    } => {
+                        let dport = format_dport(*port, port_end.as_ref());
+                        *script += &format!(
+                            "iptables -t mangle -A {chain} -p udp {src_check}--dport {dport} -m set --match-set {ipset} dst -j TPROXY --on-ip 0.0.0.0 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ; "
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tng/src/tunnel/egress/netfilter_udp/mod.rs
+++ b/tng/src/tunnel/egress/netfilter_udp/mod.rs
@@ -1,0 +1,370 @@
+mod iptables;
+mod quinn_tproxy_bridge;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use indexmap::IndexMap;
+
+use crate::config::egress::{CommonArgs, EgressNetfilterCaptureDst, EgressNetfilterUdpArgs};
+use crate::tunnel::egress::datagram_flow::{
+    AcceptedConnection, EgressDatagramConnection, EgressDatagramListener, EgressDatagramTrait,
+};
+use crate::tunnel::endpoint::TngEndpoint;
+use crate::tunnel::utils::iptables::IptablesExecutor;
+use crate::tunnel::utils::runtime::TokioRuntime;
+use crate::tunnel::utils::rustls::config::alpn::Alpn;
+use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+use crate::tunnel::utils::socket::TCP_CONNECT_SO_MARK_DEFAULT;
+
+use self::quinn_tproxy_bridge::QuinnTproxyBridgeSocket;
+
+/// A hack to bridge quinn's `AsyncUdpSocket` interface with the netfilter_udp
+/// business requirement of replying from the spoofed `orig_dst`.
+///
+/// quinn hands us a `Transmit` whose `destination` is the downstream's address
+/// but gives no way to recover the original destination that TPROXY captured for
+/// that downstream's packets. So at `poll_recv` time — when we *do* have both the
+/// downstream address and the `IP_ORIGDSTADDR` (`orig_dst`) — we record the
+/// downstream → `orig_dst` correspondence here, and at `try_send` time we look
+/// it up to spoof the reply's IPv4 source as `orig_dst:port` (so the
+/// downstream's connected QUIC socket accepts the reply). It is also queried at
+/// `accept` time to derive the backend address to forward to.
+///
+/// ("downstream" = the tunnel-facing peer — the ingress QUIC client — never the
+/// upstream backend. The earlier `peer` wording was dropped because in this code
+/// "peer" ambiguously meant either side.)
+#[derive(Default)]
+pub struct DownstreamOrigDstMap {
+    /// downstream address → its TPROXY-captured original destination.
+    ///
+    /// A synchronous (`parking_lot`) `Mutex` — not `tokio::sync::Mutex` — because
+    /// the map is read/written from quinn's *synchronous* trait methods
+    /// `AsyncUdpSocket::poll_recv` (`insert`) and `try_send` (`get`), which
+    /// cannot `.await` an async lock. The critical section is a single
+    /// `HashMap` `insert`/`get` with effectively no contention (one
+    /// downstream peer at a time), so the uncontended fast-path — a CAS, no
+    /// futex/syscall, sub-microsecond — is well within tokio's tolerance for
+    /// short synchronous work; only long/blocking operations need
+    /// `spawn_blocking`/`block_in_place`. `tokio::sync::Mutex` is additionally
+    /// unsuitable because its guard cannot be held across the `Poll` return.
+    map: parking_lot::Mutex<HashMap<SocketAddr, SocketAddr>>,
+}
+
+impl DownstreamOrigDstMap {
+    /// Record that `downstream`'s TPROXY-captured original destination is
+    /// `orig_dst`.
+    pub fn insert(&self, downstream: SocketAddr, orig_dst: SocketAddr) {
+        self.map.lock().insert(downstream, orig_dst);
+    }
+
+    /// Look up the original destination recorded for `downstream`.
+    pub fn get(&self, downstream: &SocketAddr) -> Option<SocketAddr> {
+        self.map.lock().get(downstream).copied()
+    }
+
+    #[allow(dead_code)]
+    pub fn remove(&self, downstream: &SocketAddr) {
+        self.map.lock().remove(downstream);
+    }
+}
+
+/// One accepted QUIC connection on the egress, wrapped as an
+/// [`EgressDatagramConnection`] for the flow's per-connection forwarding.
+struct NetfilterUdpQuicConnection {
+    /// The underlying quinn connection (downstream / tunnel side).
+    connection: quinn::Connection,
+}
+
+#[async_trait]
+impl EgressDatagramConnection for NetfilterUdpQuicConnection {
+    fn remote_address(&self) -> SocketAddr {
+        self.connection.remote_address()
+    }
+
+    async fn read_datagram(&self) -> Result<Bytes> {
+        self.connection
+            .read_datagram()
+            .await
+            .context("QUIC datagram read failed")
+    }
+
+    fn send_datagram(&self, payload: Bytes) -> Result<()> {
+        self.connection
+            .send_datagram(payload)
+            .context("QUIC datagram send failed")
+    }
+
+    fn close(&self, error_code: u32, reason: &[u8]) {
+        self.connection.close(error_code.into(), reason);
+    }
+}
+
+/// Default idle-timeout for a netfilter_udp egress session when the
+/// `idle_timeout_secs` config field is unset.
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 30;
+
+/// UDP netfilter egress configuration (parsed from [`EgressNetfilterUdpArgs`]).
+///
+/// The actual QUIC accept loop + per-connection forwarding is owned by
+/// `DatagramEgressFlow`; this struct holds parsed config and provides the
+/// listener via `bind_listener`.
+pub struct NetfilterUdpEgress {
+    /// Instance index within the egress list; added to the per-mode fwmark /
+    /// routing-table bases so concurrent instances get disjoint iptables state.
+    pub id: usize,
+    /// The TPROXY interception socket's receive port (the QUIC listener port).
+    pub listen_port: u16,
+    /// SO_MARK set on TNG's own backend-forward UDP sockets so they bypass the
+    /// local mangle TPROXY capture (the `--mark so_mark -j RETURN` escape).
+    pub so_mark: u32,
+    /// Destination rules defining which UDP traffic TPROXY intercepts.
+    pub capture_dst: Vec<EgressNetfilterCaptureDst>,
+    /// Whether to also intercept locally-generated traffic (`--src-type LOCAL`).
+    pub capture_local_traffic: bool,
+    /// cgroup v2 paths to capture (allowlist); empty = capture all matched.
+    pub capture_cgroup: Vec<String>,
+    /// cgroup v2 paths to exclude from capture (denylist).
+    pub nocapture_cgroup: Vec<String>,
+    /// Idle timeout (seconds) for a backend UDP session; idle in both
+    /// directions closes it. Defaults to [`DEFAULT_IDLE_TIMEOUT_SECS`].
+    pub idle_timeout_secs: u64,
+    /// Downstream → `orig_dst` correspondence (see [`DownstreamOrigDstMap`]),
+    /// shared between the egress config and the quinn bridge socket so
+    /// `poll_recv` can record and `try_send` / `accept` can look it up.
+    pub downstream_orig_dst_map: Arc<DownstreamOrigDstMap>,
+}
+
+/// Pick a free port that does not fall inside any `capture_dst` port range,
+/// re-rolling (up to a bounded number of attempts) when the random pick
+/// collides with a captured range. Host/ipset-only rules (no port) are
+/// ignored — they match all ports and cannot be avoided by picking a port.
+fn pick_port_avoiding(capture_dst: &[EgressNetfilterCaptureDst]) -> Result<u16> {
+    for _ in 0..64 {
+        let p = portpicker::pick_unused_port().context("Failed to pick a free port")?;
+        let mut collided = false;
+        for cap in capture_dst {
+            if let Some((start, end)) = cap.port_range() {
+                if (start..=end).contains(&p) {
+                    collided = true;
+                    break;
+                }
+            }
+        }
+        if !collided {
+            return Ok(p);
+        }
+    }
+    anyhow::bail!("Failed to pick a free port outside `capture_dst` ranges after 64 attempts")
+}
+
+impl NetfilterUdpEgress {
+    pub async fn new(
+        id: usize,
+        args: &EgressNetfilterUdpArgs,
+        _common_args: &CommonArgs,
+        _runtime: TokioRuntime,
+    ) -> Result<Self> {
+        let capture_dst: Vec<EgressNetfilterCaptureDst> = args
+            .capture_dst
+            .iter()
+            .map(Clone::clone)
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>>>()?;
+
+        // `listen_port` is the TPROXY interception socket's receive port (the
+        // QUIC listener). It is optional: when unset, a free port is picked
+        // randomly — just like the TCP `netfilter` egress. It MUST NOT overlap
+        // any `capture_dst` port, otherwise the listener would intercept its
+        // own traffic and recurse. When the port is auto-picked, we re-roll
+        // until it lands outside every `capture_dst` port range.
+        let listen_port = match args.listen_port {
+            Some(p) => {
+                for cap in &capture_dst {
+                    if let Some((start, end)) = cap.port_range() {
+                        if (start..=end).contains(&p) {
+                            anyhow::bail!(
+                                "netfilter_udp egress `listen_port` ({}) must not overlap a \
+                                 `capture_dst` port range ({}-{}); the TPROXY listener would \
+                                 intercept its own traffic",
+                                p,
+                                start,
+                                end
+                            );
+                        }
+                    }
+                }
+                p
+            }
+            None => pick_port_avoiding(&capture_dst)?,
+        };
+
+        let so_mark = args.so_mark.unwrap_or(TCP_CONNECT_SO_MARK_DEFAULT);
+        let idle_timeout_secs = args.idle_timeout_secs.unwrap_or(DEFAULT_IDLE_TIMEOUT_SECS);
+
+        Ok(Self {
+            id,
+            listen_port,
+            so_mark,
+            capture_dst,
+            capture_local_traffic: args.capture_local_traffic,
+            capture_cgroup: args.capture_cgroup.clone(),
+            nocapture_cgroup: args.nocapture_cgroup.clone(),
+            idle_timeout_secs,
+            downstream_orig_dst_map: Arc::new(DownstreamOrigDstMap::default()),
+        })
+    }
+}
+
+#[async_trait]
+impl EgressDatagramTrait for NetfilterUdpEgress {
+    fn metric_attributes(&self) -> IndexMap<String, String> {
+        [
+            ("egress_type".to_owned(), "netfilter_udp".to_owned()),
+            ("egress_id".to_owned(), self.id.to_string()),
+            (
+                "egress_listen_port".to_owned(),
+                self.listen_port.to_string(),
+            ),
+        ]
+        .into()
+    }
+
+    fn access_mode(&self) -> crate::tunnel::access_log::EgressAccessMode {
+        crate::tunnel::access_log::EgressAccessMode::NetfilterUdp
+    }
+
+    fn so_mark(&self) -> Option<u32> {
+        Some(self.so_mark)
+    }
+
+    fn idle_timeout_secs(&self) -> u64 {
+        self.idle_timeout_secs
+    }
+
+    async fn bind_listener(
+        &self,
+        tls_gen: &TlsConfigGenerator,
+        max_datagram_size: Option<usize>,
+    ) -> Result<Arc<dyn EgressDatagramListener>> {
+        use crate::tunnel::utils::iptables::IptablesGuard;
+
+        let tls_config = tls_gen
+            .get_blocking_one_time_rustls_server_config(Alpn::RatsQuic)
+            .await?;
+
+        let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(
+            quinn::crypto::rustls::QuicServerConfig::try_from(tls_config.0)?,
+        ));
+        let mut transport_config = quinn::TransportConfig::default();
+        transport_config.max_concurrent_bidi_streams(0u32.into());
+        transport_config.max_concurrent_uni_streams(0u32.into());
+        if let Some(size) = max_datagram_size {
+            transport_config.datagram_receive_buffer_size(Some(size));
+            transport_config.datagram_send_buffer_size(size);
+        }
+        server_config.transport_config(Arc::new(transport_config));
+
+        // Wrap the downstream TPROXY socket as quinn's `AsyncUdpSocket`;
+        // `QuinnTproxyBridgeSocket::new` creates the TPROXY interception
+        // socket (bound to `0.0.0.0:listen_port`) and wraps it for tokio
+        // readiness + the cached `SOCK_RAW` reply socket.
+        let bind_addr: std::net::SocketAddr = format!("0.0.0.0:{}", self.listen_port).parse()?;
+        let netfilter_socket =
+            QuinnTproxyBridgeSocket::new(bind_addr, Arc::clone(&self.downstream_orig_dst_map))?;
+
+        // Create quinn endpoint with our custom socket
+        let endpoint = quinn::Endpoint::new_with_abstract_socket(
+            quinn::EndpointConfig::default(),
+            Some(server_config),
+            Arc::new(netfilter_socket),
+            Arc::new(quinn::TokioRuntime),
+        )?;
+
+        // Setup iptables
+        let iptables_guard: IptablesGuard = IptablesExecutor::setup(self).await?;
+
+        // The QUIC listener itself is logged by `DatagramEgressFlow::serve`
+        // (shared with the mapping_udp egress); here we only log the TPROXY
+        // interception setup.
+        tracing::info!(
+            "netfilter_udp egress TPROXY on 0.0.0.0:{}",
+            self.listen_port
+        );
+
+        Ok(Arc::new(NetfilterUdpQuicListener {
+            endpoint,
+            downstream_orig_dst_map: Arc::clone(&self.downstream_orig_dst_map),
+            _iptables_guard: iptables_guard,
+        }))
+    }
+}
+
+/// The egress's QUIC listener (`quinn::Endpoint`) exposed as an
+/// [`EgressDatagramListener`]. Accepts the ingress's QUIC connections and
+/// derives each connection's backend address from the `orig_dst` TPROXY
+/// recorded for that downstream. Holds the iptables guard so the TPROXY rules
+/// are revoked when the listener (and thus the flow) is dropped.
+struct NetfilterUdpQuicListener {
+    /// The quinn QUIC endpoint (downstream / tunnel-facing listener).
+    endpoint: quinn::Endpoint,
+    /// Downstream → `orig_dst` correspondence; queried at `accept` time to
+    /// derive the backend address to forward to (and, in the bridge socket, at
+    /// `try_send` time to spoof the reply source).
+    downstream_orig_dst_map: Arc<DownstreamOrigDstMap>,
+    /// Revokes the TPROXY iptables rules on drop (when the flow stops).
+    _iptables_guard: crate::tunnel::utils::iptables::IptablesGuard,
+}
+
+#[async_trait]
+impl EgressDatagramListener for NetfilterUdpQuicListener {
+    fn local_addr(&self) -> Result<SocketAddr> {
+        self.endpoint
+            .local_addr()
+            .context("get netfilter_udp egress listener local addr")
+    }
+
+    async fn accept(&self) -> Result<AcceptedConnection> {
+        let connecting = self
+            .endpoint
+            .accept()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("QUIC endpoint closed"))?;
+        let connection = connecting
+            .await
+            .context("QUIC connection handshake failed")?;
+
+        let downstream = connection.remote_address();
+
+        // Derive the backend address from the IP_ORIGDSTADDR that TPROXY
+        // interception recorded for this downstream when its QUIC packets were
+        // redirected to the listener. This is the original destination the
+        // client intended to reach — i.e. the real backend service.
+        let orig_dst = self
+            .downstream_orig_dst_map
+            .get(&downstream)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no orig_dst mapping for downstream {} — the packet may have arrived \
+                     before TPROXY interception populated the map, or the connection \
+                     was established via a different path",
+                    downstream
+                )
+            })?;
+        let backend_addr = TngEndpoint::new(orig_dst.ip().to_string(), orig_dst.port());
+
+        tracing::debug!(
+            %downstream, %backend_addr,
+            "Accepted QUIC connection on netfilter_udp egress"
+        );
+
+        Ok(AcceptedConnection {
+            connection: Arc::new(NetfilterUdpQuicConnection { connection }),
+            backend_addr,
+        })
+    }
+}

--- a/tng/src/tunnel/egress/netfilter_udp/quinn_tproxy_bridge.rs
+++ b/tng/src/tunnel/egress/netfilter_udp/quinn_tproxy_bridge.rs
@@ -1,0 +1,212 @@
+//! Bridge between quinn and the netfilter `TPROXY` interception socket.
+//!
+//! [`QuinnTproxyBridgeSocket`] implements quinn's `AsyncUdpSocket` trait over a
+//! TPROXY-configured UDP socket so quinn can run its QUIC endpoint directly on
+//! the intercepted traffic. It is the egress's **downstream** (tunnel-facing)
+//! socket — the one the remote ingress QUIC client connects to — *not* the
+//! upstream (backend-facing) socket (backend-bound forwarding lives in
+//! `datagram_flow`).
+//!
+//! The bridge does two TPROXY-specific things quinn's default UDP socket
+//! cannot:
+//!   - **receive**: `recvmsg` with `IP_ORIGDSTADDR` to recover the original
+//!     destination (`orig_dst` = the backend the client dialed) of each
+//!     TPROXY-redirected packet;
+//!   - **send**: reply toward the ingress (downstream) with the IPv4 source
+//!     spoofed to `orig_dst:port` via a `SOCK_RAW` + `IP_HDRINCL` socket, so
+//!     the downstream's connected QUIC socket accepts the reply (quinn rejects
+//!     replies from any other source port).
+
+use std::io::{self, IoSliceMut};
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use quinn::{AsyncUdpSocket, UdpPoller};
+
+use crate::tunnel::utils::udp::tproxy_recv::TproxyRecvSocket;
+use crate::tunnel::utils::udp::tproxy_send::RawUdpSender;
+
+use super::DownstreamOrigDstMap;
+
+/// The egress's downstream (tunnel-facing) QUIC listener, exposed to quinn as
+/// a custom `AsyncUdpSocket` and bridged onto a netfilter `TPROXY`
+/// interception socket.
+///
+/// The egress is the *server* end of the encrypted QUIC tunnel; this is its
+/// **downstream** (tunnel-facing) socket — the one the remote ingress QUIC
+/// client connects to. It is *not* the **upstream** (backend-facing) socket:
+/// backend-bound forwarding uses a separate normal UDP socket in
+/// `datagram_flow`. Do not conflate the two.
+///
+/// It is a TPROXY interception socket. iptables marks the ingress's QUIC
+/// packets — which are addressed to the *backend* `orig_dst:port` the client
+/// dialed — and routes them here via policy routing. We `recvmsg` them to
+/// recover that original destination (`IP_ORIGDSTADDR`), which is the real
+/// backend (upstream) address to forward to, and we send QUIC replies back
+/// toward the ingress (downstream) with the IPv4 source spoofed to
+/// `orig_dst:port` so the downstream's connected QUIC socket accepts them
+/// (quinn rejects replies from any other source port).
+pub(crate) struct QuinnTproxyBridgeSocket {
+    /// The downstream (tunnel-facing) TPROXY/QUIC listener socket, wrapped as a
+    /// [`TproxyRecvSocket`] (`AsyncFd` + `clear_ready`). quinn drives receive
+    /// readiness through it and reads `local_addr` from it. It is **not** used
+    /// for the actual send syscall — replies go out through
+    /// `downstream_reply_sender`; the only data this socket carries is the
+    /// *receive* path, which `TproxyRecvSocket::poll_recv` drives via `recvmsg`
+    /// to extract `IP_ORIGDSTADDR` (tokio's `UdpSocket` does not expose
+    /// `recvmsg` with ancillary data). (Wrapped in `Arc` so the `UdpPoller` can
+    /// share it.)
+    downstream_recv: Arc<TproxyRecvSocket>,
+    /// The downstream (tunnel-facing) reply socket — a `SOCK_RAW` +
+    /// `IP_HDRINCL` socket that sends QUIC replies back toward the ingress
+    /// (downstream) with the IPv4 source spoofed to `orig_dst:port` — no
+    /// `bind`, so a co-located backend on that port need not set
+    /// `SO_REUSEADDR`. Cached once: quinn calls `try_send` per packet.
+    downstream_reply_sender: RawUdpSender,
+    /// Downstream → `orig_dst` correspondence, populated by `poll_recv` and
+    /// read by `try_send` to look up the spoofed source (`orig_dst:port`) for
+    /// each downstream reply. See [`DownstreamOrigDstMap`] for why this map
+    /// exists (a quinn-interface ↔ business-requirement bridge).
+    downstream_orig_dst_map: Arc<DownstreamOrigDstMap>,
+}
+
+impl QuinnTproxyBridgeSocket {
+    pub(crate) fn new(
+        bind_addr: SocketAddr,
+        downstream_orig_dst_map: Arc<DownstreamOrigDstMap>,
+    ) -> anyhow::Result<Self> {
+        // Create the downstream TPROXY interception socket (IP_TRANSPARENT +
+        // IP_RECVORIGDSTADDR, bound, nonblocking) and register it with tokio's
+        // I/O driver, all inside `TproxyRecvSocket::new`. The `IP_TRANSPARENT`
+        // serves the *receive* side (accepting TPROXY-redirected packets
+        // addressed to the backend `orig_dst:port`) — it is unrelated to the
+        // `SOCK_RAW` `downstream_reply_sender` created below for the *send*
+        // (reply) side.
+        let downstream_recv = Arc::new(TproxyRecvSocket::new(bind_addr)?);
+
+        // No SO_MARK on the egress reply socket: its destination is the ingress
+        // (downstream) (never a `capture_dst`), so it is never re-captured, and marking
+        // it with the TPROXY fwmark would risk routing it back into the local
+        // TPROXY table.
+        let downstream_reply_sender = RawUdpSender::new(None)?;
+
+        Ok(Self {
+            downstream_recv,
+            downstream_orig_dst_map,
+            downstream_reply_sender,
+        })
+    }
+}
+
+impl std::fmt::Debug for QuinnTproxyBridgeSocket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuinnTproxyBridgeSocket")
+            .field("downstream_recv_addr", &self.downstream_recv.local_addr())
+            .finish()
+    }
+}
+
+/// `UdpPoller` implementation for [`QuinnTproxyBridgeSocket`].
+struct QuinnTproxyBridgePoller {
+    downstream_recv: Arc<TproxyRecvSocket>,
+}
+
+impl std::fmt::Debug for QuinnTproxyBridgePoller {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QuinnTproxyBridgePoller").finish()
+    }
+}
+
+impl UdpPoller for QuinnTproxyBridgePoller {
+    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Proxy write-readiness for the quinn `UdpPoller` — see
+        // `TproxyRecvSocket::poll_write_ready`. (The actual reply send goes
+        // through the separate `SOCK_RAW` reply socket.)
+        self.downstream_recv.poll_write_ready(cx)
+    }
+}
+
+impl AsyncUdpSocket for QuinnTproxyBridgeSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        Box::pin(QuinnTproxyBridgePoller {
+            downstream_recv: Arc::clone(&self.downstream_recv),
+        })
+    }
+
+    fn try_send(&self, transmit: &quinn::udp::Transmit<'_>) -> io::Result<()> {
+        // Reply from orig_dst (the address the ingress QUIC client dialed) so
+        // quinn accepts the response: it rejects replies from a port other than
+        // the one it dialed (verified — a reply from the TPROXY listen port
+        // never completes the handshake). We send via the cached `SOCK_RAW` +
+        // `IP_HDRINCL` socket (`downstream_reply_sender`), which hand-builds
+        // the IPv4+UDP header with the spoofed source. Unlike the previous
+        // `IP_TRANSPARENT` + `bind(orig_dst:port)` approach, this never binds,
+        // so a co-located backend on `orig_dst:port` need not set
+        // `SO_REUSEADDR` — that topology is now supported.
+        let orig_dst = self
+            .downstream_orig_dst_map
+            .get(&transmit.destination)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "no orig_dst mapping for downstream {} — the packet may have arrived before TPROXY interception populated the map, or the connection was established via a different path",
+                        transmit.destination
+                    ),
+                )
+            })?;
+
+        self.downstream_reply_sender
+            .send(transmit.contents, orig_dst, transmit.destination)
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [quinn::udp::RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        // Defensive: this impl fills exactly one slot (`bufs[0]` / `meta[0`]);
+        // reject empty / mismatched slices with an error instead of panicking on
+        // the index. (quinn normally passes equal-length non-empty slices.)
+        if bufs.is_empty() || meta.is_empty() {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "poll_recv called with empty bufs/meta",
+            )));
+        }
+
+        // Drive the receive via `TproxyRecvSocket::poll_recv` (shared with the
+        // ingress), which polls `AsyncFd` read-readiness and `recvmsg`s with
+        // `clear_ready()` on `WouldBlock`.
+        let buf: &mut [u8] = &mut bufs[0];
+        let packet = std::task::ready!(self.downstream_recv.poll_recv(cx, buf))?;
+        let downstream_addr = packet.peer;
+        let orig_dst = packet.orig_dst;
+
+        // Record the downstream → orig_dst mapping for later use in try_send
+        // (reply source spoofing) and accept (backend addr).
+        self.downstream_orig_dst_map
+            .insert(downstream_addr, orig_dst);
+
+        // Populate RecvMeta with the original destination
+        meta[0] = quinn::udp::RecvMeta {
+            addr: downstream_addr,
+            len: packet.len,
+            stride: packet.len,
+            ecn: None,
+            dst_ip: Some(orig_dst.ip()),
+            dst_addr: Some(orig_dst),
+        };
+
+        // One datagram read into `bufs[0]` / `meta[0]`; quinn's `poll_recv`
+        // contract returns the number of packets filled.
+        Poll::Ready(Ok(1))
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.downstream_recv.local_addr())
+    }
+}

--- a/tng/src/tunnel/ingress/datagram_flow/mod.rs
+++ b/tng/src/tunnel/ingress/datagram_flow/mod.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use indexmap::IndexMap;
-use tokio::net::UdpSocket;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
@@ -20,8 +19,37 @@ use crate::tunnel::access_log::{AccessAccepted, AccessEstablished, IngressAccess
 use crate::tunnel::endpoint::TngEndpoint;
 use crate::tunnel::service_metrics::ServiceMetrics;
 use crate::tunnel::service_metrics::ServiceMetricsCreator;
+use crate::tunnel::udp::quic_tunnel::QuicDatagramTunnelClient;
 use crate::tunnel::utils::runtime::TokioRuntime;
 use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+
+/// QUIC-backed tunnel wrapper shared by all ingress datagram modes
+/// (mapping_udp, netfilter_udp).
+///
+/// The Flow owns the UDP socket and session map; the tunnel handles
+/// communication with the egress endpoint.
+pub(super) struct QuicIngressTunnel {
+    inner: QuicDatagramTunnelClient,
+}
+
+impl QuicIngressTunnel {
+    pub(super) fn new(inner: QuicDatagramTunnelClient) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl IngressDatagramTunnel for QuicIngressTunnel {
+    fn send_datagram(&self, payload: Bytes) -> Result<()> {
+        self.inner.send_datagram(payload)
+    }
+    async fn read_datagram(&self) -> Result<Bytes> {
+        self.inner.receive_datagram().await
+    }
+    fn close(&self, error_code: u32, reason: &[u8]) {
+        self.inner.connection.close(error_code.into(), reason);
+    }
+}
 
 /// Trait for QUIC tunnel operations on the ingress side.
 ///
@@ -40,33 +68,71 @@ pub(super) trait IngressDatagramTunnel: Send + Sync {
     fn close(&self, error_code: u32, reason: &[u8]);
 }
 
-/// Trait for ingress datagram listeners.
+/// Trait for an ingress datagram listener — owns the client-side UDP socket
+/// and provides datagram I/O. Mirrors `EgressDatagramListener` on the egress
+/// side: the Flow calls `bind_listener()` once, then drives `recv_datagram`
+/// and `send_to_client` on the returned listener.
+#[async_trait]
+pub(super) trait IngressDatagramListener: Send + Sync {
+    /// Get the local address the listener is bound to.
+    fn local_addr(&self) -> Result<SocketAddr>;
+
+    /// Receive a datagram from a client, returning
+    /// `(bytes_read, client_source, original_destination)`.
+    ///
+    /// For `mapping_udp`: uses `udp_socket.recv_from()`, `original_dst` =
+    /// the resolved egress endpoint. For `netfilter_udp`: uses `AsyncFd +
+    /// recvmsg` to extract `IP_ORIGDSTADDR`.
+    async fn recv_datagram(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr, SocketAddr)>;
+
+    /// Send a datagram back to a client.
+    ///
+    /// `original_dst` is the destination the client dialed; `netfilter_udp`
+    /// spoofs the reply source from it (via an `IP_TRANSPARENT` socket bound to
+    /// `original_dst`), `mapping_udp` ignores it and sends from the listener.
+    async fn send_to_client(
+        &self,
+        data: &Bytes,
+        client_addr: SocketAddr,
+        original_dst: SocketAddr,
+    ) -> Result<()>;
+}
+
+/// Trait for ingress datagram configurations.
 ///
-/// Implemented by protocol-specific ingress configurations (e.g. mapping_udp).
-/// The Flow manages the UDP socket, session map, idle cleanup, and TLS config;
-/// this trait only provides the ability to create QUIC tunnels to egress.
+/// Implemented by protocol-specific ingress configurations (e.g. mapping_udp,
+/// netfilter_udp). The Flow manages the session map, idle cleanup, and TLS
+/// config; this trait provides listener binding and QUIC tunnel creation.
 #[async_trait]
 pub(super) trait IngressDatagramTrait: Send + Sync {
     /// Return the metric attributes of this ingress.
     fn metric_attributes(&self) -> IndexMap<String, String>;
 
-    /// The UDP listen address for this ingress.
-    fn listen_endpoint(&self) -> (String, u16);
-
-    /// The egress endpoint this ingress forwards to.
-    fn egress_endpoint(&self) -> TngEndpoint;
+    /// Return the access-log mode of this ingress.
+    fn access_mode(&self) -> IngressAccessMode;
 
     /// The idle timeout in seconds for client sessions.
     fn idle_timeout_secs(&self) -> u64;
 
     /// Create a new QUIC tunnel to the egress endpoint for the given client.
-    /// The Flow provides the TLS config generator so RA context is managed centrally.
+    /// `original_dst` is the original destination address (from IP_ORIGDSTADDR
+    /// for netfilter_udp, or the fixed egress endpoint for mapping_udp).
+    /// `max_datagram_size` is the top-level `quic.max_datagram_size` (the Flow
+    /// owns it so RA context is managed centrally). The Flow provides the TLS
+    /// config generator so RA context is managed centrally.
     async fn create_tunnel(
         &self,
         client_addr: SocketAddr,
+        original_dst: SocketAddr,
+        max_datagram_size: Option<usize>,
         tls_gen: &TlsConfigGenerator,
         runtime: TokioRuntime,
     ) -> Result<Arc<dyn IngressDatagramTunnel>>;
+
+    /// Bind the client-side UDP listener and return it. The listener owns the
+    /// socket (a plain `UdpSocket` for mapping_udp; a TPROXY socket with the
+    /// iptables guard for netfilter_udp).
+    async fn bind_listener(&self) -> Result<Arc<dyn IngressDatagramListener>>;
 }
 
 /// Per-client QUIC session on ingress.
@@ -79,10 +145,13 @@ struct ClientSession {
 }
 
 pub struct DatagramIngressFlow {
-    ingress: Box<dyn IngressDatagramTrait>,
+    ingress: Arc<dyn IngressDatagramTrait>,
     tls_gen: TlsConfigGenerator,
     metrics: ServiceMetrics,
     runtime: TokioRuntime,
+    /// Top-level `quic.max_datagram_size`, captured in `new()` from the common
+    /// args and passed to `create_tunnel` per session.
+    max_datagram_size: Option<usize>,
 }
 
 impl DatagramIngressFlow {
@@ -101,11 +170,14 @@ impl DatagramIngressFlow {
             Arc::new(crate::tunnel::ra_context::RaContext::from_ra_args(&ra_args).await?);
         let tls_gen = TlsConfigGenerator::new(ra_context, runtime.clone()).await?;
 
+        let max_datagram_size = common_args.quic.as_ref().and_then(|q| q.max_datagram_size);
+
         Ok(Self {
-            ingress: Box::new(ingress),
+            ingress: Arc::new(ingress),
             tls_gen,
             metrics,
             runtime,
+            max_datagram_size,
         })
     }
 }
@@ -113,20 +185,23 @@ impl DatagramIngressFlow {
 #[async_trait::async_trait]
 impl RegistedService for DatagramIngressFlow {
     async fn serve(&self, ready: Sender<()>) -> Result<()> {
-        let (listen_addr, listen_port) = self.ingress.listen_endpoint();
-        let listen_str = format!("{}:{}", listen_addr, listen_port);
-        let udp_socket = Arc::new(UdpSocket::bind(&listen_str).await?);
-        let listener_addr = udp_socket.local_addr()?;
-        tracing::info!("UDP mapping ingress listening on {}", listen_str);
+        let listener = self.ingress.bind_listener().await?;
+        let listener_addr = listener.local_addr()?;
+        let access_mode = self.ingress.access_mode();
+        tracing::info!("UDP {} ingress listening on {}", access_mode, listener_addr);
 
         ready.send(()).await?;
 
         let idle_timeout_secs = self.ingress.idle_timeout_secs();
-        let egress_ep = self.ingress.egress_endpoint();
+        // Idle-timeout probe cadence: the `sleep` arms below fire every 5s to
+        // check whether a session has been idle past `idle_timeout_secs` (both
+        // the per-session forward task and the periodic map sweep). 5s is coarse
+        // but fine — the timeout itself is ~30s.
         let check_interval = Duration::from_secs(5);
 
         // client_addr -> ClientSession
-        let client_map: Arc<Mutex<HashMap<SocketAddr, ClientSession>>> =
+        // Key is (client_src, original_dst) — for mapping_udp, original_dst is fixed.
+        let client_map: Arc<Mutex<HashMap<(SocketAddr, SocketAddr), ClientSession>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
         let mut buf = vec![0u8; 65535];
@@ -134,32 +209,41 @@ impl RegistedService for DatagramIngressFlow {
         loop {
             tokio::select! {
                 // Direction A: Client -> QUIC
-                recv_result = udp_socket.recv_from(&mut buf) => {
-                    let (n, client_src) = recv_result?;
+                recv_result = listener.recv_datagram(&mut buf) => {
+                    let (n, client_src, original_dst) = recv_result?;
                     let payload = Bytes::copy_from_slice(&buf[..n]);
 
+                    let session_key = (client_src, original_dst);
+
                     let mut map = client_map.lock().await;
-                    let session = match map.get(&client_src) {
+                    let session = match map.get(&session_key) {
                         Some(s) => s,
                         None => {
                             tracing::info!(
-                                %client_src,
-                                egress = %egress_ep,
+                                %client_src, %original_dst,
                                 "Creating QUIC connection for new client"
                             );
 
                             let tunnel = self.ingress
-                                .create_tunnel(client_src, &self.tls_gen, self.runtime.clone())
+                                .create_tunnel(client_src, original_dst, self.max_datagram_size, &self.tls_gen, self.runtime.clone())
                                 .await?;
 
                             let access_accepted = AccessAccepted::new_ingress(
                                 client_src,
                                 listener_addr,
-                                IngressAccessMode::MappingUdp,
+                                access_mode,
+                            );
+                            // For the access log only: derive the upstream
+                            // remote from `original_dst`. For mapping_udp this
+                            // is the resolved egress endpoint; for netfilter_udp
+                            // it is the per-packet captured destination.
+                            let backend_ep = TngEndpoint::new(
+                                original_dst.ip().to_string(),
+                                original_dst.port(),
                             );
                             let access_routed = access_accepted.into_routed(
-                                &egress_ep,
-                                true, // to_trusted_tunnel
+                                &backend_ep,
+                                true,
                             );
                             let access_established =
                                 access_routed.into_established(None, false);
@@ -170,10 +254,15 @@ impl RegistedService for DatagramIngressFlow {
                             let active_cx = metrics.new_cx();
 
                             // Spawn QUIC -> Client forwarding task
-                            let udp_socket_clone = udp_socket.clone();
+                            let listener = Arc::clone(&listener);
                             let last_activity_clone = last_activity.clone();
                             let idle_timeout = Duration::from_secs(idle_timeout_secs);
-                            let client_src_for_task = client_src;
+                            let client_src_for_task = session_key.0;
+                            // The reply must come from the destination the client
+                            // dialed (`original_dst`); the listener's
+                            // `send_to_client` uses it (netfilter spoofs the
+                            // source, mapping ignores it).
+                            let original_dst_for_task = session_key.1;
                             let runtime_clone = self.runtime.clone();
                             let tunnel_clone = tunnel.clone();
 
@@ -184,8 +273,8 @@ impl RegistedService for DatagramIngressFlow {
                                         datagram_result = tunnel_clone.read_datagram() => {
                                             match datagram_result {
                                                 Ok(datagram) => {
-                                                    if let Err(e) = udp_socket_clone
-                                                        .send_to(&datagram, client_src_for_task)
+                                                    if let Err(e) = listener
+                                                        .send_to_client(&datagram, client_src_for_task, original_dst_for_task)
                                                         .await
                                                     {
                                                         tracing::warn!(
@@ -219,7 +308,7 @@ impl RegistedService for DatagramIngressFlow {
                                 }
                             });
 
-                            map.entry(client_src).or_insert(ClientSession {
+                            map.entry(session_key).or_insert(ClientSession {
                                 tunnel,
                                 last_activity,
                                 access_established,
@@ -231,7 +320,7 @@ impl RegistedService for DatagramIngressFlow {
                     *session.last_activity.lock().await = Instant::get();
                     if let Err(e) = session.tunnel.send_datagram(payload) {
                         tracing::warn!(
-                            %client_src,
+                            %client_src, %original_dst,
                             error = %e,
                             "Failed to send datagram to QUIC"
                         );
@@ -242,13 +331,13 @@ impl RegistedService for DatagramIngressFlow {
                     let mut map = client_map.lock().await;
                     let idle_timeout = Duration::from_secs(idle_timeout_secs);
 
-                    map.retain(|addr, session| {
+                    map.retain(|(client_addr, _orig_dst), session| {
                         let last = session.last_activity.try_lock();
                         match last {
                             Ok(guard) => {
                                 if guard.elapsed() >= idle_timeout {
                                     tracing::debug!(
-                                        %addr,
+                                        %client_addr,
                                         "Idle timeout - removing client session"
                                     );
                                     session.tunnel.close(0, b"idle");

--- a/tng/src/tunnel/ingress/mapping_udp.rs
+++ b/tng/src/tunnel/ingress/mapping_udp.rs
@@ -5,34 +5,19 @@ use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use indexmap::IndexMap;
+use tokio::net::UdpSocket;
 
 use crate::config::ingress::IngressMappingUdpArgs;
-use crate::tunnel::endpoint::TngEndpoint;
-use crate::tunnel::ingress::datagram_flow::{IngressDatagramTrait, IngressDatagramTunnel};
+use crate::tunnel::access_log::IngressAccessMode;
+use crate::tunnel::endpoint::EndpointAddr;
+use crate::tunnel::ingress::datagram_flow::{
+    IngressDatagramListener, IngressDatagramTrait, IngressDatagramTunnel, QuicIngressTunnel,
+};
 use crate::tunnel::udp::quic_tunnel::QuicDatagramTunnelClient;
 use crate::tunnel::utils::runtime::TokioRuntime;
 use crate::tunnel::utils::rustls::config::alpn::Alpn;
 use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
-
-/// QUIC-backed tunnel implementing `IngressDatagramTunnel`.
-struct QuicIngressTunnel {
-    inner: QuicDatagramTunnelClient,
-}
-
-#[async_trait]
-impl IngressDatagramTunnel for QuicIngressTunnel {
-    fn send_datagram(&self, payload: Bytes) -> Result<()> {
-        self.inner.send_datagram(payload)
-    }
-
-    async fn read_datagram(&self) -> Result<Bytes> {
-        self.inner.receive_datagram().await
-    }
-
-    fn close(&self, error_code: u32, reason: &[u8]) {
-        self.inner.connection.close(error_code.into(), reason);
-    }
-}
+use crate::tunnel::utils::socket::resolve_ipv4_addr;
 
 /// UDP mapping ingress configuration.
 ///
@@ -44,7 +29,6 @@ pub struct MappingUdpIngress {
     pub listen_port: u16,
     pub egress_addr: String,
     pub egress_port: u16,
-    pub max_datagram_size: Option<usize>,
     pub idle_timeout_secs: u64,
 }
 
@@ -74,14 +58,8 @@ impl MappingUdpIngress {
             listen_port,
             egress_addr,
             egress_port,
-            max_datagram_size: None,
             idle_timeout_secs,
         })
-    }
-
-    /// Set max_datagram_size from top-level quic config.
-    pub fn set_max_datagram_size(&mut self, size: Option<usize>) {
-        self.max_datagram_size = size;
     }
 
     pub fn metric_attributes(&self) -> IndexMap<String, String> {
@@ -99,6 +77,53 @@ impl MappingUdpIngress {
         ]
         .into()
     }
+
+    /// The fixed original destination a captured client packet is mapped to.
+    /// Mirrors the former `recv_datagram` logic: an IPv4 egress endpoint yields
+    /// its address; a domain endpoint is resolved to its first IPv4 address
+    /// (the netfilter_udp/datagram_flow path is IPv4-only, so non-IPv4 results
+    /// are skipped and a v6-only domain errors out).
+    async fn fixed_original_dst(&self) -> Result<SocketAddr> {
+        let original_dst = match EndpointAddr::from_host(&self.egress_addr) {
+            EndpointAddr::Ipv4(ip) => SocketAddr::new(std::net::IpAddr::V4(ip), self.egress_port),
+            EndpointAddr::Domain(d) => resolve_ipv4_addr(&d, self.egress_port)
+                .await
+                .with_context(|| format!("resolve mapping_udp egress domain {d}"))?,
+        };
+        Ok(original_dst)
+    }
+}
+
+/// Plain UDP listener for mapping_udp — owns a bound `UdpSocket` and the fixed
+/// original destination. All client datagram I/O goes through the flow, which
+/// calls `recv_datagram` / `send_to_client` here.
+struct MappingUdpListener {
+    socket: Arc<UdpSocket>,
+    original_dst: SocketAddr,
+}
+
+#[async_trait]
+impl IngressDatagramListener for MappingUdpListener {
+    fn local_addr(&self) -> Result<SocketAddr> {
+        self.socket
+            .local_addr()
+            .context("get mapping listener local addr")
+    }
+
+    async fn recv_datagram(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr, SocketAddr)> {
+        let (n, client_src) = self.socket.recv_from(buf).await?;
+        Ok((n, client_src, self.original_dst))
+    }
+
+    async fn send_to_client(
+        &self,
+        data: &Bytes,
+        client_addr: SocketAddr,
+        _original_dst: SocketAddr,
+    ) -> Result<()> {
+        self.socket.send_to(data, client_addr).await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -107,12 +132,8 @@ impl IngressDatagramTrait for MappingUdpIngress {
         self.metric_attributes()
     }
 
-    fn listen_endpoint(&self) -> (String, u16) {
-        (self.listen_addr.clone(), self.listen_port)
-    }
-
-    fn egress_endpoint(&self) -> TngEndpoint {
-        TngEndpoint::new(self.egress_addr.clone(), self.egress_port)
+    fn access_mode(&self) -> IngressAccessMode {
+        IngressAccessMode::MappingUdp
     }
 
     fn idle_timeout_secs(&self) -> u64 {
@@ -122,6 +143,8 @@ impl IngressDatagramTrait for MappingUdpIngress {
     async fn create_tunnel(
         &self,
         _client_addr: SocketAddr,
+        _original_dst: SocketAddr,
+        max_datagram_size: Option<usize>,
         tls_gen: &TlsConfigGenerator,
         _runtime: TokioRuntime,
     ) -> Result<Arc<dyn IngressDatagramTunnel>> {
@@ -139,11 +162,27 @@ impl IngressDatagramTrait for MappingUdpIngress {
         let quic_tunnel = QuicDatagramTunnelClient::connect(
             &egress_endpoint,
             Alpn::RatsQuic,
-            self.max_datagram_size,
+            max_datagram_size,
             tls_config,
+            // mapping_udp installs no iptables OUTPUT capture rule, so no
+            // SO_MARK is needed on the QUIC client socket.
+            None,
         )
         .await?;
 
-        Ok(Arc::new(QuicIngressTunnel { inner: quic_tunnel }))
+        Ok(Arc::new(QuicIngressTunnel::new(quic_tunnel)))
+    }
+
+    async fn bind_listener(&self) -> Result<Arc<dyn IngressDatagramListener>> {
+        let listen_str = format!("{}:{}", self.listen_addr, self.listen_port);
+        let socket = UdpSocket::bind(&listen_str)
+            .await
+            .with_context(|| format!("Failed to bind mapping_udp listener on {listen_str}"))?;
+        tracing::info!("UDP mapping ingress listening on {}", listen_str);
+
+        Ok(Arc::new(MappingUdpListener {
+            socket: Arc::new(socket),
+            original_dst: self.fixed_original_dst().await?,
+        }))
     }
 }

--- a/tng/src/tunnel/ingress/mod.rs
+++ b/tng/src/tunnel/ingress/mod.rs
@@ -15,6 +15,8 @@ pub mod mapping;
 pub mod mapping_udp;
 #[cfg(all(feature = "ingress-netfilter", target_os = "linux"))]
 pub mod netfilter;
+#[cfg(all(feature = "ingress-netfilter-udp", target_os = "linux"))]
+pub mod netfilter_udp;
 #[cfg(feature = "ingress-socks5")]
 pub mod socks5;
 

--- a/tng/src/tunnel/ingress/netfilter/iptables.rs
+++ b/tng/src/tunnel/ingress/netfilter/iptables.rs
@@ -2,16 +2,16 @@ use std::path::Path;
 
 use crate::{
     config::ingress::IngressNetfilterCaptureDst,
-    tunnel::utils::iptables::{format_dport, IptablesRuleGenerator},
+    tunnel::utils::iptables::{
+        format_dport, IptablesRuleGenerator, NETFILTER_TCP_INGRESS_FW_MARK_BASE,
+        NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE,
+    },
 };
 
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 
 use super::NetfilterIngress;
-
-const IPTABLES_FW_MARK_BASE: u32 = 566;
-const IP_ROUTE_TABLE_NUM_BASE: u32 = 239;
 
 fn is_cgroup_v2() -> bool {
     // https://rootlesscontaine.rs/getting-started/common/cgroup2/#checking-whether-cgroup-v2-is-already-enabled
@@ -29,8 +29,8 @@ impl IptablesRuleGenerator for NetfilterIngress {
         let id = self.id;
         // Use per-instance fw_mark and route_table to avoid conflicts
         // when multiple ingress netfilter instances run concurrently.
-        let fw_mark = IPTABLES_FW_MARK_BASE + id as u32;
-        let route_table = IP_ROUTE_TABLE_NUM_BASE + id as u32;
+        let fw_mark = NETFILTER_TCP_INGRESS_FW_MARK_BASE + id as u32;
+        let route_table = NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE + id as u32;
         let listen_port = self.listen_port;
 
         if self.capture_dst.is_empty() {

--- a/tng/src/tunnel/ingress/netfilter_udp/iptables.rs
+++ b/tng/src/tunnel/ingress/netfilter_udp/iptables.rs
@@ -1,0 +1,174 @@
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+
+use crate::{
+    config::ingress::IngressNetfilterCaptureDst,
+    tunnel::utils::iptables::{
+        format_dport, IptablesRuleGenerator, NETFILTER_UDP_INGRESS_FW_MARK_BASE,
+        NETFILTER_UDP_INGRESS_ROUTE_TABLE_BASE,
+    },
+};
+
+use super::NetfilterUdpIngress;
+
+fn is_cgroup_v2() -> bool {
+    std::path::Path::new("/sys/fs/cgroup/cgroup.controllers").exists()
+}
+
+#[async_trait]
+impl IptablesRuleGenerator for NetfilterUdpIngress {
+    async fn gen_script(&self) -> Result<(String, String)> {
+        which::which("iptables")
+            .context("The external tool \"iptables\" is not found, please install it")?;
+        which::which("ip").context("The external tool \"ip\" is not found, please install it")?;
+
+        let id = self.id;
+        let fw_mark = NETFILTER_UDP_INGRESS_FW_MARK_BASE + id as u32;
+        let route_table = NETFILTER_UDP_INGRESS_ROUTE_TABLE_BASE + id as u32;
+        let listen_port = self.listen_port;
+
+        if self.capture_dst.is_empty() {
+            tracing::info!("capture_dst is empty, will capture all UDP traffic")
+        }
+
+        let mut invoke_script = "".to_owned();
+        let mut revoke_script = "".to_owned();
+
+        // Short chain names that still fit iptables nftables' 28-char limit
+        // (e.g. `TNG_INGRESS_UDP_255_OUT1` is 24 chars). Each netfilter_udp
+        // ingress instance owns its own chain set keyed by `id`.
+        let pre_chain = format!("TNG_INGRESS_UDP_{id}_PRE");
+        let out1_chain = format!("TNG_INGRESS_UDP_{id}_OUT1");
+        let out2_chain = format!("TNG_INGRESS_UDP_{id}_OUT2");
+
+        let clean_up = format!(
+            "\
+            iptables -t mangle -D PREROUTING -p udp -j {pre_chain} 2>/dev/null || true ; \
+            iptables -t mangle -D OUTPUT -p udp -j {out1_chain} 2>/dev/null || true ; \
+            iptables -t mangle -F {pre_chain} 2>/dev/null || true ; \
+            iptables -t mangle -X {pre_chain} 2>/dev/null || true ; \
+            iptables -t mangle -F {out1_chain} 2>/dev/null || true ; \
+            iptables -t mangle -X {out1_chain} 2>/dev/null || true ; \
+            iptables -t mangle -F {out2_chain} 2>/dev/null || true ; \
+            iptables -t mangle -X {out2_chain} 2>/dev/null || true ; \
+            ip route flush table {route_table} 2>/dev/null || true ; \
+            ip rule del table {route_table} 2>/dev/null || true ; \
+            "
+        );
+
+        invoke_script += &clean_up;
+        invoke_script += &format!("iptables -t mangle -N {pre_chain} ; ");
+
+        // Skip: local dst, non-unicast dst, non-local src
+        invoke_script += &format!(
+            "\
+            iptables -t mangle -A {pre_chain} -m addrtype --dst-type LOCAL -j RETURN ; \
+            iptables -t mangle -A {pre_chain} -m addrtype ! --dst-type UNICAST -j RETURN ; \
+            iptables -t mangle -A {pre_chain} -m addrtype ! --src-type LOCAL -j RETURN ; \
+            "
+        );
+
+        invoke_script += &format!(
+            "iptables -t mangle -A {pre_chain} -p udp -j TPROXY --on-ip 127.0.0.1 --on-port {listen_port} --tproxy-mark {fw_mark}/0xffffff ;"
+        );
+        invoke_script += &format!("iptables -t mangle -I PREROUTING 1 -p udp -j {pre_chain} ;");
+
+        // OUTPUT chain (local process traffic)
+        invoke_script += &format!(
+            "\
+            ip route add local default dev lo table {route_table} ; \
+            ip rule add fwmark {fw_mark}/0xffffff table {route_table} ; \
+            iptables -t mangle -N {out1_chain} ; \
+            iptables -t mangle -N {out2_chain} ; \
+            "
+        );
+
+        invoke_script += &format!(
+            "\
+            iptables -t mangle -A {out1_chain} -m addrtype --dst-type LOCAL -j RETURN ; \
+            iptables -t mangle -A {out1_chain} -m addrtype ! --dst-type UNICAST -j RETURN ; \
+            iptables -t mangle -A {out1_chain} -m addrtype ! --src-type LOCAL -j RETURN ; \
+            iptables -t mangle -A {out1_chain} -p udp -m mark --mark {} -j RETURN ; \
+            ",
+            self.so_mark
+        );
+
+        // cgroup handling
+        if (!is_cgroup_v2())
+            && (!self.capture_cgroup.is_empty() || !self.nocapture_cgroup.is_empty())
+        {
+            bail!("It seems that you are not running in cgroup v2, but `capture_cgroup` and `nocapture_cgroup` are supported on cgroup v2 only")
+        } else {
+            if self.capture_cgroup.is_empty() {
+                invoke_script += &format!("iptables -t mangle -A {out1_chain} -j {out2_chain} ;");
+            } else {
+                for cgroup in &self.capture_cgroup {
+                    invoke_script += &format!(
+                        "iptables -t mangle -A {out1_chain} -m cgroup --path {cgroup} -j {out2_chain} ;"
+                    );
+                }
+            }
+            for cgroup in &self.nocapture_cgroup {
+                invoke_script += &format!(
+                    "iptables -t mangle -A {out2_chain} -m cgroup --path {cgroup} -j RETURN ;"
+                );
+            }
+        }
+
+        // capture_dst rules
+        if self.capture_dst.is_empty() {
+            invoke_script += &format!(
+                "iptables -t mangle -A {out2_chain} -p udp -j MARK --set-mark {fw_mark}/0xffffff ;"
+            );
+        } else {
+            for cap in &self.capture_dst {
+                match cap {
+                    IngressNetfilterCaptureDst::HostOnly { host } => {
+                        invoke_script += &format!(
+                            "iptables -t mangle -A {out2_chain} -p udp --dst {}/{} -j MARK --set-mark {fw_mark}/0xffffff ;",
+                            host.first_address(), host.network_length()
+                        );
+                    }
+                    IngressNetfilterCaptureDst::IpSetOnly { ipset } => {
+                        invoke_script += &format!(
+                            "iptables -t mangle -A {out2_chain} -p udp -m set --match-set {ipset} dst -j MARK --set-mark {fw_mark}/0xffffff ;"
+                        );
+                    }
+                    IngressNetfilterCaptureDst::PortOnly { port, port_end } => {
+                        let dport = format_dport(*port, port_end.as_ref());
+                        invoke_script += &format!(
+                            "iptables -t mangle -A {out2_chain} -p udp --dport {dport} -j MARK --set-mark {fw_mark}/0xffffff ;"
+                        );
+                    }
+                    IngressNetfilterCaptureDst::HostAndPort {
+                        host,
+                        port,
+                        port_end,
+                    } => {
+                        let dport = format_dport(*port, port_end.as_ref());
+                        invoke_script += &format!(
+                            "iptables -t mangle -A {out2_chain} -p udp --dst {}/{} --dport {dport} -j MARK --set-mark {fw_mark}/0xffffff ;",
+                            host.first_address(), host.network_length()
+                        );
+                    }
+                    IngressNetfilterCaptureDst::IpSetAndPort {
+                        ipset,
+                        port,
+                        port_end,
+                    } => {
+                        let dport = format_dport(*port, port_end.as_ref());
+                        invoke_script += &format!(
+                            "iptables -t mangle -A {out2_chain} -p udp --dport {dport} -m set --match-set {ipset} dst -j MARK --set-mark {fw_mark}/0xffffff ;"
+                        );
+                    }
+                }
+            }
+        }
+
+        invoke_script += &format!("iptables -t mangle -I OUTPUT 1 -p udp -j {out1_chain} ;");
+
+        revoke_script += &clean_up;
+
+        Ok((invoke_script, revoke_script))
+    }
+}

--- a/tng/src/tunnel/ingress/netfilter_udp/mod.rs
+++ b/tng/src/tunnel/ingress/netfilter_udp/mod.rs
@@ -1,0 +1,264 @@
+mod iptables;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use indexmap::IndexMap;
+
+use crate::config::ingress::{IngressNetfilterCaptureDst, IngressNetfilterUdpArgs};
+use crate::tunnel::access_log::IngressAccessMode;
+use crate::tunnel::ingress::datagram_flow::{
+    IngressDatagramListener, IngressDatagramTrait, IngressDatagramTunnel, QuicIngressTunnel,
+};
+use crate::tunnel::udp::quic_tunnel::QuicDatagramTunnelClient;
+use crate::tunnel::utils::iptables::{IptablesExecutor, IptablesGuard};
+use crate::tunnel::utils::runtime::TokioRuntime;
+use crate::tunnel::utils::rustls::config::alpn::Alpn;
+use crate::tunnel::utils::rustls::config::TlsConfigGenerator;
+use crate::tunnel::utils::socket::TCP_CONNECT_SO_MARK_DEFAULT;
+use crate::tunnel::utils::udp::tproxy_recv::TproxyRecvSocket;
+use crate::tunnel::utils::udp::tproxy_send::RawUdpSender;
+
+/// Default idle-timeout for a netfilter_udp ingress session when the
+/// `idle_timeout_secs` config field is unset.
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 30;
+
+/// UDP netfilter ingress configuration.
+///
+/// Intercepts UDP packets via iptables TPROXY, extracts the original
+/// destination via IP_ORIGDSTADDR, and establishes per-(client, dst)
+/// QUIC datagram tunnels to egress. The forwarding loop, session map, and
+/// idle cleanup are owned by `DatagramIngressFlow`; this struct only holds
+/// parsed config and provides the listener + tunnel creation.
+pub struct NetfilterUdpIngress {
+    pub id: usize,
+    pub listen_port: u16,
+    pub so_mark: u32,
+    pub capture_dst: Vec<IngressNetfilterCaptureDst>,
+    pub capture_cgroup: Vec<String>,
+    pub nocapture_cgroup: Vec<String>,
+    pub idle_timeout_secs: u64,
+}
+
+/// Pick a free port that does not fall inside any `capture_dst` port range,
+/// re-rolling (up to a bounded number of attempts) when the random pick
+/// collides with a captured range. Host/ipset-only rules (no port) are
+/// ignored — they match all ports and cannot be avoided by picking a port.
+fn pick_port_avoiding(capture_dst: &[IngressNetfilterCaptureDst]) -> Result<u16> {
+    for _ in 0..64 {
+        let p = portpicker::pick_unused_port().context("Failed to pick a free port")?;
+        let mut collided = false;
+        for cap in capture_dst {
+            if let Some((start, end)) = cap.port_range() {
+                if (start..=end).contains(&p) {
+                    collided = true;
+                    break;
+                }
+            }
+        }
+        if !collided {
+            return Ok(p);
+        }
+    }
+    anyhow::bail!("Failed to pick a free port outside `capture_dst` ranges after 64 attempts")
+}
+
+impl NetfilterUdpIngress {
+    pub async fn new(id: usize, args: &IngressNetfilterUdpArgs) -> Result<Self> {
+        let so_mark = args.so_mark.unwrap_or(TCP_CONNECT_SO_MARK_DEFAULT);
+        let capture_dst: Vec<IngressNetfilterCaptureDst> = args
+            .capture_dst
+            .iter()
+            .map(Clone::clone)
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>>>()?;
+
+        // `listen_port` is the TPROXY interception socket's receive port. It is
+        // optional: when unset, a free port is picked randomly — just like the
+        // TCP `netfilter` ingress. It MUST NOT overlap any `capture_dst` port,
+        // otherwise the listener would intercept its own traffic and recurse.
+        // When the port is auto-picked, we re-roll until it lands outside
+        // every `capture_dst` port range.
+        let listen_port = match args.listen_port {
+            Some(p) => {
+                for cap in &capture_dst {
+                    if let Some((start, end)) = cap.port_range() {
+                        if (start..=end).contains(&p) {
+                            anyhow::bail!(
+                                "netfilter_udp ingress `listen_port` ({}) must not overlap a \
+                                 `capture_dst` port range ({}-{}); the TPROXY listener would \
+                                 intercept its own traffic",
+                                p,
+                                start,
+                                end
+                            );
+                        }
+                    }
+                }
+                p
+            }
+            None => pick_port_avoiding(&capture_dst)?,
+        };
+
+        let idle_timeout_secs = args.idle_timeout_secs.unwrap_or(DEFAULT_IDLE_TIMEOUT_SECS);
+
+        Ok(Self {
+            id,
+            listen_port,
+            so_mark,
+            capture_dst,
+            capture_cgroup: args.capture_cgroup.clone(),
+            nocapture_cgroup: args.nocapture_cgroup.clone(),
+            idle_timeout_secs,
+        })
+    }
+}
+
+/// TPROXY listener for netfilter_udp — owns the TPROXY interception socket
+/// (wrapped in [`TproxyRecvSocket`], which drives `AsyncFd` readiness +
+/// `clear_ready()` and `recvmsg`) and the cached `SOCK_RAW` reply socket, plus
+/// the iptables guard whose drop revokes the TPROXY rules on shutdown.
+///
+/// Reads via raw `recvmsg` to obtain `IP_ORIGDSTADDR`. Because tokio's own
+/// `UdpSocket::readable()` readiness flag is only cleared by tokio's own
+/// `recv`/`try_recv` (not raw `recvmsg`), the receive path wraps the socket in
+/// `AsyncFd` and manually `clear_ready()`s on `WouldBlock` — otherwise the
+/// readiness flag is never cleared and the loop busy-spins forever. That logic
+/// lives inside [`TproxyRecvSocket`].
+struct NetfilterUdpTproxyListener {
+    /// The downstream (client-facing) TPROXY interception socket, wrapped for
+    /// tokio readiness and `recvmsg` (`IP_ORIGDSTADDR` extraction).
+    downstream_recv: TproxyRecvSocket,
+    /// The downstream (client-facing) reply socket — a cached `SOCK_RAW` +
+    /// `IP_HDRINCL` socket that sends replies back to the client with the IPv4
+    /// source spoofed to `orig_dst:port` (no `bind`, so a co-located backend on
+    /// that port need not set `SO_REUSEADDR`). `so_mark` is baked in at
+    /// creation so the reply bypasses this node's own mangle `OUTPUT` capture.
+    downstream_reply_sender: RawUdpSender,
+    local_addr: SocketAddr,
+    _iptables_guard: IptablesGuard,
+}
+
+#[async_trait]
+impl IngressDatagramListener for NetfilterUdpTproxyListener {
+    fn local_addr(&self) -> Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+
+    async fn recv_datagram(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr, SocketAddr)> {
+        let packet = self.downstream_recv.recv(buf).await?;
+        Ok((packet.len, packet.peer, packet.orig_dst))
+    }
+
+    async fn send_to_client(
+        &self,
+        data: &Bytes,
+        client_addr: SocketAddr,
+        original_dst: SocketAddr,
+    ) -> Result<()> {
+        // Reply from the original destination the client dialed (spoofed via
+        // the cached `SOCK_RAW` + `IP_HDRINCL` socket), not from the TPROXY
+        // listener socket (bound 127.0.0.1:listen_port) — a connected client
+        // socket only accepts replies from the peer it dialed (original_dst).
+        self.downstream_reply_sender
+            .send(data.as_ref(), original_dst, client_addr)
+            .context("netfilter_udp reply send failed")?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl IngressDatagramTrait for NetfilterUdpIngress {
+    fn metric_attributes(&self) -> IndexMap<String, String> {
+        [
+            ("ingress_type".to_owned(), "netfilter_udp".to_owned()),
+            ("ingress_id".to_owned(), self.id.to_string()),
+            (
+                "ingress_listen_port".to_owned(),
+                self.listen_port.to_string(),
+            ),
+        ]
+        .into()
+    }
+
+    fn access_mode(&self) -> IngressAccessMode {
+        IngressAccessMode::NetfilterUdp
+    }
+
+    fn idle_timeout_secs(&self) -> u64 {
+        self.idle_timeout_secs
+    }
+
+    async fn create_tunnel(
+        &self,
+        _client_addr: SocketAddr,
+        original_dst: SocketAddr,
+        max_datagram_size: Option<usize>,
+        tls_gen: &TlsConfigGenerator,
+        _runtime: TokioRuntime,
+    ) -> Result<Arc<dyn IngressDatagramTunnel>> {
+        let tls_config = tls_gen
+            .get_blocking_one_time_rustls_client_config(Alpn::RatsQuic)
+            .await?;
+
+        let ep = match original_dst.ip() {
+            std::net::IpAddr::V4(ip) => crate::config::Endpoint {
+                host: Some(ip.to_string()),
+                port: original_dst.port(),
+            },
+            std::net::IpAddr::V6(_) => {
+                anyhow::bail!("IPv6 original destination not supported for netfilter_udp");
+            }
+        };
+
+        let quic_tunnel = QuicDatagramTunnelClient::connect(
+            &ep,
+            Alpn::RatsQuic,
+            max_datagram_size,
+            tls_config,
+            // SO_MARK so the ingress's own QUIC handshake packets bypass the
+            // local OUTPUT capture rule (the `--mark {so_mark} -j RETURN`
+            // escape hatch). Without this, the QUIC connection to the egress
+            // (which is exactly a capture_dst) would be swallowed locally.
+            Some(self.so_mark),
+        )
+        .await?;
+
+        Ok(Arc::new(QuicIngressTunnel::new(quic_tunnel)))
+    }
+
+    async fn bind_listener(&self) -> Result<Arc<dyn IngressDatagramListener>> {
+        // 1. Create the TPROXY interception socket (IP_TRANSPARENT +
+        // IP_RECVORIGDSTADDR, bound 127.0.0.1:listen_port, nonblocking) and
+        // wrap it in `TproxyRecvSocket` (`AsyncFd` readiness + `recvmsg` +
+        // `clear_ready()` — see `NetfilterUdpTproxyListener::recv_datagram`).
+        let bind_addr: std::net::SocketAddr = format!("127.0.0.1:{}", self.listen_port).parse()?;
+        let downstream_recv = TproxyRecvSocket::new(bind_addr)?;
+        let local_addr = downstream_recv.local_addr();
+
+        // Cached SOCK_RAW + IP_HDRINCL reply socket with `so_mark` baked in so
+        // replies (spoofed from `orig_dst:port`) bypass this node's own mangle
+        // OUTPUT capture (the `--mark {so_mark} -j RETURN` escape).
+        let downstream_reply_sender = RawUdpSender::new(Some(self.so_mark))?;
+
+        // 2. Iptables setup — the guard is held by the listener and revoked on
+        // drop (when the flow's `serve` returns / the listener is dropped).
+        let _iptables_guard = IptablesExecutor::setup(self).await?;
+
+        tracing::info!(
+            "netfilter_udp ingress listening on {} (TPROXY on 127.0.0.1:{})",
+            local_addr,
+            self.listen_port
+        );
+
+        Ok(Arc::new(NetfilterUdpTproxyListener {
+            downstream_recv,
+            downstream_reply_sender,
+            local_addr,
+            _iptables_guard,
+        }))
+    }
+}

--- a/tng/src/tunnel/udp/quic_tunnel.rs
+++ b/tng/src/tunnel/udp/quic_tunnel.rs
@@ -61,6 +61,17 @@ impl QuicDatagramTunnelClient {
                     Some(socket2::Protocol::UDP),
                 )
                 .context("Failed to create QUIC client socket")?;
+                // SO_MARK is Linux-only. `so_mark = Some(_)` is only ever passed
+                // by netfilter_udp ingress, which is itself Linux-only, so this
+                // branch is unreachable on non-Linux — consume `mark` to keep
+                // the binding used without actually setting the option.
+                #[cfg(not(any(
+                    target_os = "android",
+                    target_os = "fuchsia",
+                    target_os = "linux"
+                )))]
+                let _ = mark;
+                #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
                 std_socket.set_mark(mark).with_context(|| {
                     format!("Failed to set SO_MARK={mark} on QUIC client socket")
                 })?;

--- a/tng/src/tunnel/udp/quic_tunnel.rs
+++ b/tng/src/tunnel/udp/quic_tunnel.rs
@@ -30,18 +30,61 @@ pub struct QuicDatagramTunnelClient {
 
 impl QuicDatagramTunnelClient {
     /// Connect to egress QUIC endpoint with RA-based TLS config.
+    /// Connect to egress QUIC endpoint with RA-based TLS config.
+    ///
+    /// When `so_mark` is `Some(mark)`, the underlying UDP socket is created
+    /// with `SO_MARK` set so that its outgoing packets carry the given mark.
+    /// This is required by `netfilter_udp` ingress: the ingress installs an
+    /// iptables OUTPUT rule that captures packets matching `capture_dst`, plus
+    /// an escape-hatch `--mark {so_mark} -j RETURN`. Without `SO_MARK` the
+    /// ingress's own QUIC handshake packets (destined to the egress, which is
+    /// exactly a `capture_dst`) would be captured and fed back into the local
+    /// TPROXY socket — the QUIC connection could never leave the host.
+    /// `mapping_udp` ingress passes `None` since it installs no such rules.
     pub async fn connect(
         target: &Endpoint,
         _alpn: Alpn,
         max_datagram_size: Option<usize>,
         tls_config: BlockingOnetimeTlsClientConfig,
+        so_mark: Option<u32>,
     ) -> Result<Self> {
-        let listen_addr: SocketAddr = "0.0.0.0:0".parse()?;
-
-        let mut endpoint = quinn::Endpoint::client(listen_addr)?;
         let quinn_config =
             quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls_config.0)?));
-        endpoint.set_default_client_config(quinn_config);
+
+        let endpoint = match so_mark {
+            Some(mark) => {
+                // Build a UDP socket with SO_MARK so egress-bound QUIC packets
+                // bypass the local netfilter_udp OUTPUT capture rule.
+                let std_socket = socket2::Socket::new(
+                    socket2::Domain::IPV4,
+                    socket2::Type::DGRAM,
+                    Some(socket2::Protocol::UDP),
+                )
+                .context("Failed to create QUIC client socket")?;
+                std_socket.set_mark(mark).with_context(|| {
+                    format!("Failed to set SO_MARK={mark} on QUIC client socket")
+                })?;
+                std_socket.set_nonblocking(true)?;
+                const ANY: SocketAddr =
+                    SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), 0);
+                std_socket.bind(&ANY.into())?;
+                let std_socket: std::net::UdpSocket = std_socket.into();
+                let mut endpoint = quinn::Endpoint::new(
+                    quinn::EndpointConfig::default(),
+                    None,
+                    std_socket,
+                    Arc::new(quinn::TokioRuntime),
+                )?;
+                endpoint.set_default_client_config(quinn_config);
+                endpoint
+            }
+            None => {
+                let listen_addr: SocketAddr = "0.0.0.0:0".parse()?;
+                let mut endpoint = quinn::Endpoint::client(listen_addr)?;
+                endpoint.set_default_client_config(quinn_config);
+                endpoint
+            }
+        };
 
         let server_name = target
             .host

--- a/tng/src/tunnel/utils/iptables.rs
+++ b/tng/src/tunnel/utils/iptables.rs
@@ -21,6 +21,38 @@ pub fn format_dport(port: u16, port_end: Option<&u16>) -> String {
     }
 }
 
+/// Policy-routing fwmark and routing-table number bases for netfilter TPROXY
+/// rules.
+///
+/// Each netfilter mode owns a **disjoint** fwmark range and a disjoint policy
+/// routing table, so that a single TNG instance running several of them
+/// concurrently in the same network namespace does not collide. The per-mode
+/// `id` (the index of the instance within its own `add_ingress` / `add_egress`
+/// list — a *separate* enumeration per side and per protocol) is added to the
+/// mode's base. The ranges are spaced 1024 apart, far beyond any realistic
+/// instance count per mode.
+///
+/// | mode        | fwmark base | table base |
+/// |-------------|-------------|------------|
+/// | TCP ingress | 566         | 239        |
+/// | UDP ingress | 1566        | 1239       |
+/// | UDP egress  | 2566        | 2239       |
+///
+/// These are kernel-internal marks/tables, not user-facing config. The
+/// `so_mark` SO_MARK socket option (default 565) used to let TNG's own tunnel
+/// sockets escape capture is a separate value; it is just numerically
+/// adjacent to the TCP-ingress base.
+pub const NETFILTER_TCP_INGRESS_FW_MARK_BASE: u32 = 566;
+pub const NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE: u32 = 239;
+
+pub const NETFILTER_UDP_INGRESS_FW_MARK_BASE: u32 = NETFILTER_TCP_INGRESS_FW_MARK_BASE + 1024;
+pub const NETFILTER_UDP_INGRESS_ROUTE_TABLE_BASE: u32 =
+    NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE + 1024;
+
+pub const NETFILTER_UDP_EGRESS_FW_MARK_BASE: u32 = NETFILTER_TCP_INGRESS_FW_MARK_BASE + 2 * 1024;
+pub const NETFILTER_UDP_EGRESS_ROUTE_TABLE_BASE: u32 =
+    NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE + 2 * 1024;
+
 pub struct IptablesExecutor {}
 
 pub struct IptablesGuard {
@@ -119,7 +151,11 @@ impl Drop for IptablesGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::format_dport;
+    use super::{
+        format_dport, NETFILTER_TCP_INGRESS_FW_MARK_BASE, NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE,
+        NETFILTER_UDP_EGRESS_FW_MARK_BASE, NETFILTER_UDP_EGRESS_ROUTE_TABLE_BASE,
+        NETFILTER_UDP_INGRESS_FW_MARK_BASE, NETFILTER_UDP_INGRESS_ROUTE_TABLE_BASE,
+    };
 
     #[test]
     fn test_format_dport_single_port() {
@@ -132,5 +168,72 @@ mod tests {
         assert_eq!(format_dport(30000, Some(&30031)), "30000:30031");
         assert_eq!(format_dport(80, Some(&80)), "80:80");
         assert_eq!(format_dport(1, Some(&65535)), "1:65535");
+    }
+
+    /// The three netfilter modes must use disjoint fwmark and routing-table
+    /// ranges so that a single TNG instance running several of them in the
+    /// same network namespace (each `id` enumerated separately per side) does
+    /// not collide on the fwmark or policy routing table. `id` values are
+    /// small in practice; assert disjointness over a generous id span.
+    #[test]
+    fn test_netfilter_fwmark_and_table_ranges_are_disjoint() {
+        const ID_SPAN: u32 = 256;
+
+        let ranges: [((u32, u32), (u32, u32)); 3] = [
+            (
+                (
+                    NETFILTER_TCP_INGRESS_FW_MARK_BASE,
+                    NETFILTER_TCP_INGRESS_FW_MARK_BASE + ID_SPAN,
+                ),
+                (
+                    NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE,
+                    NETFILTER_TCP_INGRESS_ROUTE_TABLE_BASE + ID_SPAN,
+                ),
+            ),
+            (
+                (
+                    NETFILTER_UDP_INGRESS_FW_MARK_BASE,
+                    NETFILTER_UDP_INGRESS_FW_MARK_BASE + ID_SPAN,
+                ),
+                (
+                    NETFILTER_UDP_INGRESS_ROUTE_TABLE_BASE,
+                    NETFILTER_UDP_INGRESS_ROUTE_TABLE_BASE + ID_SPAN,
+                ),
+            ),
+            (
+                (
+                    NETFILTER_UDP_EGRESS_FW_MARK_BASE,
+                    NETFILTER_UDP_EGRESS_FW_MARK_BASE + ID_SPAN,
+                ),
+                (
+                    NETFILTER_UDP_EGRESS_ROUTE_TABLE_BASE,
+                    NETFILTER_UDP_EGRESS_ROUTE_TABLE_BASE + ID_SPAN,
+                ),
+            ),
+        ];
+
+        // fwmark ranges are pairwise disjoint
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                let (a_start, a_end) = ranges[i].0;
+                let (b_start, b_end) = ranges[j].0;
+                assert!(
+                    a_end <= b_start || b_end <= a_start,
+                    "fwmark ranges overlap: [{a_start},{a_end}) vs [{b_start},{b_end})"
+                );
+            }
+        }
+
+        // routing-table ranges are pairwise disjoint
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                let (a_start, a_end) = ranges[i].1;
+                let (b_start, b_end) = ranges[j].1;
+                assert!(
+                    a_end <= b_start || b_end <= a_start,
+                    "route-table ranges overlap: [{a_start},{a_end}) vs [{b_start},{b_end})"
+                );
+            }
+        }
     }
 }

--- a/tng/src/tunnel/utils/mod.rs
+++ b/tng/src/tunnel/utils/mod.rs
@@ -16,6 +16,8 @@ pub mod runtime;
 pub mod rustls;
 pub mod socket;
 pub mod tokio;
+#[cfg(target_os = "linux")]
+pub mod udp;
 
 #[cfg(not(wasm))]
 pub mod file_watcher;

--- a/tng/src/tunnel/utils/socket.rs
+++ b/tng/src/tunnel/utils/socket.rs
@@ -171,3 +171,43 @@ where
 
     last_result.unwrap_or_else(|| Err(anyhow::anyhow!("No address resolved")))
 }
+
+/// Resolve a `host:port` to the first IPv4 `SocketAddr`.
+///
+/// The netfilter_udp / TPROXY / datagram_flow UDP paths are IPv4-only
+/// (iptables, raw-socket spoofing, TPROXY recv, and the backend DGRAM socket
+/// all force IPv4), so IPv6 results are skipped and a v6-only host errors out.
+/// Mirrors the IPv4-only behavior of `tcp_connect` (which also forces
+/// `socket2::Domain::IPV4`).
+#[cfg(not(wasm))]
+pub async fn resolve_ipv4_addr(host: &str, port: u16) -> Result<std::net::SocketAddr> {
+    let addrs = tokio::net::lookup_host((host, port))
+        .await
+        .with_context(|| format!("Failed to resolve domain {host:?} via dns"))?;
+    for addr in addrs {
+        if addr.is_ipv4() {
+            tracing::debug!(?addr, "resolved domain to IPv4 address");
+            return Ok(addr);
+        }
+        tracing::debug!(?addr, "skipping non-IPv4 address for IPv4-only UDP path");
+    }
+    Err(anyhow::anyhow!(
+        "no IPv4 address resolved for domain {host:?}"
+    ))
+}
+
+#[cfg(all(not(wasm), test))]
+mod tests {
+    use super::resolve_ipv4_addr;
+
+    /// `localhost` is resolved from `/etc/hosts` (no network dependency), so
+    /// this is CI-safe. It must yield the IPv4 loopback address.
+    #[tokio::test]
+    async fn resolve_ipv4_addr_localhost() {
+        let addr = resolve_ipv4_addr("localhost", 0)
+            .await
+            .expect("localhost resolves");
+        assert!(addr.is_ipv4(), "expected an IPv4 address, got {addr}");
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+    }
+}

--- a/tng/src/tunnel/utils/udp/mod.rs
+++ b/tng/src/tunnel/utils/udp/mod.rs
@@ -1,0 +1,10 @@
+//! TPROXY UDP plumbing shared by the `netfilter_udp` ingress and egress.
+//!
+//! Two disjoint concerns live here:
+//!   - [`tproxy_recv`] — creating a TPROXY interception socket and recovering
+//!     the original destination (`IP_ORIGDSTADDR`) via `recvmsg`;
+//!   - [`tproxy_send`] — sending UDP datagrams with a fully spoofed IPv4
+//!     source via a `SOCK_RAW` + `IP_HDRINCL` socket (no `bind`).
+
+pub mod tproxy_recv;
+pub mod tproxy_send;

--- a/tng/src/tunnel/utils/udp/tproxy_recv.rs
+++ b/tng/src/tunnel/utils/udp/tproxy_recv.rs
@@ -1,0 +1,276 @@
+//! TPROXY receive-side helpers — create the interception socket and recover the
+//! original destination (`IP_ORIGDSTADDR`) via `recvmsg`.
+//!
+//! Linux only. Both `netfilter_udp` ingress and egress receive through
+//! [`TproxyRecvSocket`]: ingress via the async [`recv`](TproxyRecvSocket::recv)
+//! (it drives its own recv loop); the egress via the synchronous
+//! [`poll_recv`](TproxyRecvSocket::poll_recv), because quinn's
+//! `AsyncUdpSocket::poll_recv` is a sync `Poll` fn (tokio's `AsyncFd` exposes
+//! `poll_read_ready` for exactly this case). `create_tproxy_udp_socket` /
+//! `recvmsg_once` below are the lower-level building blocks `TproxyRecvSocket`
+//! is built on.
+//!
+//! Uses raw libc calls since nix 0.23's recvmsg API doesn't expose `msghdr`
+//! for manual construction.
+
+use std::io;
+use std::mem::{self, MaybeUninit};
+use std::net::SocketAddr;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::task::{Context, Poll};
+
+use anyhow::{Context as _, Result};
+use libc::{cmsghdr, iovec, msghdr, sockaddr_storage, socklen_t};
+use tokio::io::unix::AsyncFd;
+
+/// The Linux socket option for receiving the original destination address.
+pub const IP_RECVORIGDSTADDR: libc::c_int = 20;
+
+/// A single received TPROXY datagram: byte count, the client source address,
+/// and the original destination the client dialed (from `IP_ORIGDSTADDR`).
+///
+/// Named (rather than a positional tuple) so call sites cannot swap the two
+/// addresses by mistake.
+pub(crate) struct RecvPacket {
+    /// Number of payload bytes read.
+    pub len: usize,
+    /// The client that sent the datagram.
+    pub peer: SocketAddr,
+    /// The original destination the client dialed (`IP_ORIGDSTADDR`).
+    pub orig_dst: SocketAddr,
+}
+
+/// Perform a single `recvmsg()` call on a TPROXY-configured UDP socket.
+pub(crate) fn recvmsg_once(
+    fd: RawFd,
+    buf: &mut [u8],
+) -> std::result::Result<RecvPacket, std::io::Error> {
+    let mut storage: MaybeUninit<sockaddr_storage> = MaybeUninit::uninit();
+    let mut iov = [iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    }];
+
+    // Control message buffer
+    let mut cmsg_buf = [0u8; 256];
+
+    let mut msg: msghdr = unsafe { mem::zeroed() };
+    msg.msg_name = &mut storage as *mut _ as *mut libc::c_void;
+    msg.msg_namelen = mem::size_of::<sockaddr_storage>() as socklen_t;
+    msg.msg_iov = iov.as_mut_ptr();
+    msg.msg_iovlen = iov.len() as _;
+    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_buf.len();
+
+    let bytes = unsafe { libc::recvmsg(fd, &mut msg, 0) };
+    if bytes < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let bytes = bytes as usize;
+
+    // Parse client source address
+    let storage = unsafe { storage.assume_init() };
+    let client_src = sockaddr_to_addr(&storage, msg.msg_namelen)?;
+
+    // Parse control messages for IP_ORIGDSTADDR
+    let mut original_dst = None;
+    let mut cmsg_ptr = msg.msg_control as *mut cmsghdr;
+    while !cmsg_ptr.is_null() {
+        let cmsg = unsafe { &*cmsg_ptr };
+        if cmsg.cmsg_level == libc::IPPROTO_IP && cmsg.cmsg_type == IP_RECVORIGDSTADDR {
+            // On Linux, IP_ORIGDSTADDR uses the same constant as IP_RECVORIGDSTADDR
+            // The data is a sockaddr_in
+            let data_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) };
+            let orig = unsafe { &*(data_ptr as *const libc::sockaddr_in) };
+            let ip = std::net::Ipv4Addr::from(u32::from_be(orig.sin_addr.s_addr));
+            let port = u16::from_be(orig.sin_port);
+            original_dst = Some(SocketAddr::new(std::net::IpAddr::V4(ip), port));
+        }
+        cmsg_ptr = unsafe { libc::CMSG_NXTHDR(&msg, cmsg_ptr) };
+    }
+
+    let original_dst = original_dst.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "recvmsg did not return IP_ORIGDSTADDR — packet may not have come through TPROXY",
+        )
+    })?;
+
+    Ok(RecvPacket {
+        len: bytes,
+        peer: client_src,
+        orig_dst: original_dst,
+    })
+}
+
+fn sockaddr_to_addr(
+    storage: &sockaddr_storage,
+    _len: libc::socklen_t,
+) -> std::result::Result<SocketAddr, std::io::Error> {
+    match storage.ss_family as libc::c_int {
+        libc::AF_INET => {
+            let addr: &libc::sockaddr_in =
+                unsafe { &*(storage as *const _ as *const libc::sockaddr_in) };
+            Ok(SocketAddr::V4(std::net::SocketAddrV4::new(
+                std::net::Ipv4Addr::from(addr.sin_addr.s_addr.to_ne_bytes()),
+                u16::from_be(addr.sin_port),
+            )))
+        }
+        libc::AF_INET6 => {
+            let addr: &libc::sockaddr_in6 =
+                unsafe { &*(storage as *const _ as *const libc::sockaddr_in6) };
+            Ok(SocketAddr::V6(std::net::SocketAddrV6::new(
+                std::net::Ipv6Addr::from(addr.sin6_addr.s6_addr),
+                u16::from_be(addr.sin6_port),
+                addr.sin6_flowinfo,
+                addr.sin6_scope_id,
+            )))
+        }
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "unknown socket address family",
+        )),
+    }
+}
+
+/// Create and configure a UDP socket for TPROXY interception.
+pub(crate) fn create_tproxy_udp_socket(bind_addr: std::net::SocketAddr) -> Result<socket2::Socket> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.set_ip_transparent(true)?;
+
+    let fd = socket.as_raw_fd();
+    let val: libc::c_int = 1;
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_IP,
+            IP_RECVORIGDSTADDR,
+            &val as *const _ as *const libc::c_void,
+            mem::size_of_val(&val) as socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(anyhow::anyhow!(
+            "setsockopt IP_RECVORIGDSTADDR failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    socket.bind(&socket2::SockAddr::from(bind_addr))?;
+    socket.set_nonblocking(true)?;
+
+    Ok(socket)
+}
+
+/// A TPROXY interception socket wrapped in an `AsyncFd`, providing both an
+/// async [`recv`](Self::recv) (for ingress, which drives its own recv loop)
+/// and a synchronous [`poll_recv`](Self::poll_recv) (for the egress, whose recv
+/// is driven by quinn's `AsyncUdpSocket::poll_recv` — a sync `Poll` fn). Both
+/// drain via `recvmsg` and `clear_ready()` on `WouldBlock`.
+///
+/// The `AsyncFd` + `clear_ready()` is required because tokio's own
+/// `UdpSocket::readable()` readiness flag is only cleared by tokio's own
+/// `recv`/`try_recv` (not raw `recvmsg`) — without `clear_ready()` the flag is
+/// never cleared and the loop busy-spins forever.
+pub(crate) struct TproxyRecvSocket {
+    inner: AsyncFd<socket2::Socket>,
+    local_addr: SocketAddr,
+}
+
+impl TproxyRecvSocket {
+    /// Create a TPROXY socket bound to `bind_addr` (IP_TRANSPARENT +
+    /// IP_RECVORIGDSTADDR, nonblocking) and register it with tokio's I/O
+    /// driver via `AsyncFd`.
+    pub(crate) fn new(bind_addr: SocketAddr) -> Result<Self> {
+        let socket = create_tproxy_udp_socket(bind_addr)?;
+        let local_addr = socket
+            .local_addr()
+            .context("Failed to get TPROXY listener local addr")?
+            .as_socket()
+            .context("TPROXY listener addr is not an IP socket")?;
+        let inner = AsyncFd::new(socket)?;
+        Ok(Self { inner, local_addr })
+    }
+
+    /// The local address the listener is bound to.
+    pub(crate) fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Receive one datagram, blocking (async) until a packet arrives.
+    ///
+    /// Spurious readiness (the socket is empty) is cleared with
+    /// `clear_ready()` so the next wait actually blocks instead of
+    /// busy-looping.
+    pub(crate) async fn recv(&self, buf: &mut [u8]) -> Result<RecvPacket> {
+        loop {
+            let mut readable_guard = self
+                .inner
+                .readable()
+                .await
+                .context("TPROXY socket readable failed")?;
+            match recvmsg_once(self.inner.get_ref().as_raw_fd(), buf) {
+                Ok(packet) => return Ok(packet),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    // Spurious readiness — the socket is empty. Clear it so the
+                    // next `readable()` actually blocks instead of busy-looping.
+                    readable_guard.clear_ready();
+                    continue;
+                }
+                Err(error) => {
+                    readable_guard.clear_ready();
+                    return Err(anyhow::Error::from(error).context("recvmsg_once failed"));
+                }
+            }
+        }
+    }
+
+    /// Poll for one datagram (synchronous), for callers that drive their own
+    /// poll loop — the egress, whose recv is driven by quinn's
+    /// `AsyncUdpSocket::poll_recv`. Returns `Pending` until a packet is ready;
+    /// spurious readiness is cleared with `clear_ready()` so the next poll does
+    /// not busy-loop.
+    pub(crate) fn poll_recv(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<RecvPacket>> {
+        use std::task::ready;
+        loop {
+            let mut guard = match ready!(self.inner.poll_read_ready(cx)) {
+                Ok(g) => g,
+                Err(error) => return Poll::Ready(Err(error)),
+            };
+            match recvmsg_once(self.inner.get_ref().as_raw_fd(), buf) {
+                Ok(packet) => return Poll::Ready(Ok(packet)),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    guard.clear_ready();
+                    continue;
+                }
+                Err(error) => {
+                    guard.clear_ready();
+                    return Poll::Ready(Err(error));
+                }
+            }
+        }
+    }
+
+    /// Poll for write readiness — used by the egress quinn `UdpPoller`'s
+    /// `poll_writable` as a proxy for "ok to attempt `try_send`". (The actual
+    /// reply send goes through the separate `SOCK_RAW` reply socket, which is
+    /// virtually always writable; this checks the TPROXY socket's
+    /// write-readiness as a stand-in so quinn does not busy-loop if
+    /// `try_send` would block. Preserves the pre-unification behavior.)
+    pub(crate) fn poll_write_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.inner.poll_write_ready(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Ready(Ok(_guard)) => Poll::Ready(Ok(())),
+        }
+    }
+}

--- a/tng/src/tunnel/utils/udp/tproxy_send.rs
+++ b/tng/src/tunnel/utils/udp/tproxy_send.rs
@@ -1,0 +1,174 @@
+//! Spoofed-source UDP send — a `SOCK_RAW` + `IP_HDRINCL` socket that hand-builds
+//! the IPv4 + UDP header so a datagram can be sent from an arbitrary source
+//! address (the `orig_dst:port` the client dialed) without `bind`.
+//!
+//! Used by both `netfilter_udp` reply paths (ingress + egress). The sender is
+//! typically cached by the caller (per listener) rather than created per
+//! packet.
+
+use std::mem;
+use std::os::unix::io::{AsRawFd, FromRawFd};
+
+use libc::socklen_t;
+
+/// A `SOCK_RAW` + `IP_HDRINCL` socket that sends UDP datagrams with a fully
+/// spoofed IPv4 source address (`src_ip:src_port`) without `bind`.
+///
+/// The netfilter_udp ingress and egress reply paths must send from
+/// `orig_dst:port` (the address the QUIC peer dialed) so the connected peer
+/// accepts the reply. Doing this with a normal DGRAM socket requires
+/// `bind(orig_dst:port)`, which collides (`EADDRINUSE`) with a co-located real
+/// backend unless that backend sets `SO_REUSEADDR`. A raw socket hand-builds
+/// the IPv4 + UDP header instead — no `bind`, no `SO_REUSEADDR` dependency, and
+/// co-located / single-node deployments work. Requires `CAP_NET_RAW` (TNG
+/// already runs privileged for iptables/TPROXY).
+pub struct RawUdpSender {
+    sock: socket2::Socket,
+}
+
+impl RawUdpSender {
+    /// Create a raw socket. `so_mark`, if set, marks the outgoing skb so it
+    /// bypasses this node's own mangle `OUTPUT` capture (the
+    /// `--mark so_mark -j RETURN` escape) — used by the ingress reply path.
+    /// The egress reply passes `None`: its destination is the ingress peer
+    /// (never a `capture_dst`), so it is never re-captured, and marking it with
+    /// the TPROXY fwmark would risk routing it back into the local TPROXY
+    /// table.
+    pub fn new(so_mark: Option<u32>) -> std::io::Result<Self> {
+        // IPPROTO_RAW (255) implies IP_HDRINCL (we supply the IP header); set
+        // IP_HDRINCL explicitly too for clarity. SOCK_RAW needs CAP_NET_RAW.
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_RAW, libc::IPPROTO_RAW) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let sock = unsafe { socket2::Socket::from_raw_fd(fd) };
+
+        let val: libc::c_int = 1;
+        let ret = unsafe {
+            libc::setsockopt(
+                sock.as_raw_fd(),
+                libc::IPPROTO_IP,
+                libc::IP_HDRINCL,
+                &val as *const _ as *const libc::c_void,
+                mem::size_of_val(&val) as socklen_t,
+            )
+        };
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if let Some(mark) = so_mark {
+            sock.set_mark(mark)?;
+        }
+        sock.set_nonblocking(true)?;
+        Ok(Self { sock })
+    }
+
+    /// Send `payload` as a UDP datagram from `src` to `dst`, both IPv4. The
+    /// IPv4 header checksum is filled by the kernel under `IP_HDRINCL`; the UDP
+    /// checksum is computed here so the packet is indistinguishable from a
+    /// normal UDP datagram.
+    pub fn send(
+        &self,
+        payload: &[u8],
+        src: std::net::SocketAddr,
+        dst: std::net::SocketAddr,
+    ) -> std::io::Result<()> {
+        let src_ip = match src.ip() {
+            std::net::IpAddr::V4(ip) => ip,
+            std::net::IpAddr::V6(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "RawUdpSender does not support IPv6 source",
+                ));
+            }
+        };
+        let dst_ip = match dst.ip() {
+            std::net::IpAddr::V4(ip) => ip,
+            std::net::IpAddr::V6(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "RawUdpSender does not support IPv6 destination",
+                ));
+            }
+        };
+
+        const IP_HDR_LEN: usize = 20;
+        const UDP_HDR_LEN: usize = 8;
+        let total_len = IP_HDR_LEN + UDP_HDR_LEN + payload.len();
+
+        let mut packet = vec![0u8; total_len];
+
+        // --- IPv4 header (20 bytes, network byte order) ---
+        packet[0] = 0x45; // version 4, IHL 5 (20-byte header)
+        packet[1] = 0; // DSCP/ECN (tos)
+        packet[2..4].copy_from_slice(&(total_len as u16).to_be_bytes()); // total length
+        packet[4..6].copy_from_slice(&0u16.to_be_bytes()); // identification
+        packet[6..8].copy_from_slice(&0u16.to_be_bytes()); // flags + fragment offset (no DF)
+        packet[8] = 64; // TTL
+        packet[9] = libc::IPPROTO_UDP as u8; // protocol
+                                             // Header checksum: 0 here — the kernel fills it under IP_HDRINCL.
+        packet[10..12].copy_from_slice(&0u16.to_be_bytes());
+        packet[12..16].copy_from_slice(&src_ip.octets()); // source IP
+        packet[16..20].copy_from_slice(&dst_ip.octets()); // destination IP
+
+        // --- UDP header (8 bytes) ---
+        packet[IP_HDR_LEN..IP_HDR_LEN + 2].copy_from_slice(&src.port().to_be_bytes());
+        packet[IP_HDR_LEN + 2..IP_HDR_LEN + 4].copy_from_slice(&dst.port().to_be_bytes());
+        let udp_len = (UDP_HDR_LEN + payload.len()) as u16;
+        packet[IP_HDR_LEN + 4..IP_HDR_LEN + 6].copy_from_slice(&udp_len.to_be_bytes());
+        // UDP checksum at [IP_HDR_LEN+6 .. IP_HDR_LEN+8] filled below (0 now).
+
+        // --- payload ---
+        packet[IP_HDR_LEN + UDP_HDR_LEN..].copy_from_slice(payload);
+
+        // Compute the UDP checksum over the UDP header (check=0) + payload,
+        // using the IPv4 pseudo-header.
+        let udp_segment = &packet[IP_HDR_LEN..];
+        let cksum = udp_checksum(src_ip, dst_ip, udp_segment);
+        packet[IP_HDR_LEN + 6..IP_HDR_LEN + 8].copy_from_slice(&cksum.to_be_bytes());
+
+        // send_to: the sockaddr's port is ignored by raw sockets — the IP
+        // header carries the destination. They are kept consistent.
+        self.sock.send_to(&packet, &socket2::SockAddr::from(dst))?;
+        Ok(())
+    }
+}
+
+/// Compute the IPv4 UDP checksum (RFC 768) over the IPv4 pseudo-header plus the
+/// UDP segment (UDP header with its `check` field zeroed + payload). Returns
+/// the one's-complement sum; a computed zero is mapped to `0xFFFF` (a UDP
+/// checksum of `0` means "not computed").
+fn udp_checksum(src: std::net::Ipv4Addr, dst: std::net::Ipv4Addr, segment: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+    let s = src.octets();
+    let d = dst.octets();
+    // Pseudo-header: source IP, destination IP, zero, protocol (UDP=17),
+    // and UDP length (header + payload).
+    sum += u16::from_be_bytes([s[0], s[1]]) as u32;
+    sum += u16::from_be_bytes([s[2], s[3]]) as u32;
+    sum += u16::from_be_bytes([d[0], d[1]]) as u32;
+    sum += u16::from_be_bytes([d[2], d[3]]) as u32;
+    sum += libc::IPPROTO_UDP as u32;
+    sum += segment.len() as u32;
+
+    let len = segment.len();
+    let mut i = 0;
+    while i + 1 < len {
+        sum += u16::from_be_bytes([segment[i], segment[i + 1]]) as u32;
+        i += 2;
+    }
+    if i < len {
+        // Odd length: pad the final byte with a zero byte (network order).
+        sum += (segment[i] as u32) << 8;
+    }
+    // Fold the 32-bit sum into 16 bits, adding carries back.
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+    let cksum = !(sum as u16);
+    if cksum == 0 {
+        0xFFFF
+    } else {
+        cksum
+    }
+}


### PR DESCRIPTION
## Summary

Implement **netfilter_udp** ingress and egress modes, combining iptables TPROXY transparent interception with QUIC Datagram tunneling for UDP traffic.

### Architecture

- **Ingress netfilter_udp**: Intercepts local UDP packets via iptables TPROXY (PREROUTING chain), extracts `IP_ORIGDSTADDR` via `recvmsg`, establishes per-(client, dst) QUIC tunnels to egress.
- **Egress netfilter_udp**: Receives QUIC datagrams, forwards to backend UDP services. Uses TPROXY (PREROUTING chain) for cross-machine interception, with `IP_TRANSPARENT` socket option for transparent sending.
- **Shared datagram flow**: Both modes share the same `DatagramEgressFlow` forwarding logic with `AcceptedConnection.backend_addr`.

### Key changes

1. **Config**: Add `netfilter_udp` args and enum variants for both ingress and egress, including `capture_dst`, `capture_local_traffic`, `listen_port`, `so_mark`, and optional `backend` field for single-machine tests.
2. **Egress impl**: `NetfilterUdpSocket` custom `AsyncUdpSocket` for quinn, with `recvmsg` to extract `IP_ORIGDSTADDR` and `IP_TRANSPARENT` for transparent sending.
3. **Ingress impl**: Async recvmsg loop using `tokio::net::UdpSocket::readable()` (no busy-loop), per-session QUIC tunnel management.
4. **Refactor**: Replace `backend_endpoint()` trait method with `AcceptedConnection.backend_addr` for direct address passing.
5. **Tests**: 5 integration tests (basic, port_range, datagram_size, capture_all, full_path).
6. **Docs**: Configuration documentation (EN/ZH).
