### PR TITLE
Migrate trustee to upstream openanolis and add builtin-as wasm tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/imlk0/trustee/?rev=1dc7318887b883c619ae337fa29490a9c78e91ee#1dc7318887b883c619ae337fa29490a9c78e91ee"
+source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "eventlog"
 version = "0.1.0"
-source = "git+https://github.com/imlk0/trustee/?rev=1dc7318887b883c619ae337fa29490a9c78e91ee#1dc7318887b883c619ae337fa29490a9c78e91ee"
+source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5574,7 +5574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5594,7 +5594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5626,7 +5626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -5639,7 +5639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6001,6 +6001,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.14.0",
+ "js-sys",
  "jsonwebtoken",
  "kbs-types",
  "p256",
@@ -6040,6 +6041,9 @@ dependencies = [
  "tracing-subscriber",
  "ttrpc",
  "ttrpc-codegen",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "web-time",
  "wiremock",
  "x509-cert",
@@ -6120,7 +6124,7 @@ dependencies = [
 [[package]]
 name = "reference-value-provider-service"
 version = "0.1.0"
-source = "git+https://github.com/imlk0/trustee/?rev=1dc7318887b883c619ae337fa29490a9c78e91ee#1dc7318887b883c619ae337fa29490a9c78e91ee"
+source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7891,6 +7895,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "js-sys",
+ "rats-cert",
  "reqwest 0.12.9",
  "serde",
  "serde-wasm-bindgen",
@@ -8725,7 +8730,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier"
 version = "0.1.0"
-source = "git+https://github.com/imlk0/trustee/?rev=1dc7318887b883c619ae337fa29490a9c78e91ee#1dc7318887b883c619ae337fa29490a9c78e91ee"
+source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ as-any = "0.3.2"
 async-http-proxy = {version = "1.2.5", features = ["runtime-tokio"]}
 async-stream = "0.3.6"
 async-trait = "0.1.88"
-attestation-service = {git = "https://github.com/imlk0/trustee/", rev = "1dc7318887b883c619ae337fa29490a9c78e91ee", default-features = false}
+attestation-service = {git = "https://github.com/openanolis/trustee/", rev = "5587044f471691245e5db1af2be6361aed6c0cf8", default-features = false}
 atty = "0.2.14"
 auto_enums = {version = "0.8", features = ["std", "tokio1"]}
 axum = {version = "0.8.4", default-features = false}
@@ -96,7 +96,7 @@ rand = "0.9.1"
 rand_chacha = "0.9.0"
 rayon = "1.10.0"
 rcgen = "0.13.2"
-reference-value-provider-service = {git = "https://github.com/imlk0/trustee/", rev = "1dc7318887b883c619ae337fa29490a9c78e91ee", default-features = false}
+reference-value-provider-service = {git = "https://github.com/openanolis/trustee/", rev = "5587044f471691245e5db1af2be6361aed6c0cf8", default-features = false}
 regex = "1.11.1"
 reqwest = {version = "=0.12.9", default-features = false, features = ["json", "http2", "rustls-tls-webpki-roots-no-provider", "brotli", "gzip", "zstd"]}# select 0.12.9 version since we have to align to the hyper-util=0.1.7 version used by hyper-util-wasm
 # Override quinn to use aws-lc-rs instead of ring for QUIC crypto (default is rustls-ring)

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,10 @@ test-dep-aa:
 # All steps share a single shell block so the backgrounded `crane` process
 # stays alive until `restful-as` (the last foreground command) exits — see
 # commit 422c112.
+# The AS token-signer key (/tmp/as.key) uses `openssl ecparam -genkey -noout`:
+# without -noout, openssl prepends an EC PARAMETERS block, yielding a two-block
+# PEM that trustee >= 1.9.0's token-signer PKCS#8 parser rejects with
+# "PEM error in post-encapsulation boundary" (older trustee tolerated it).
 .PHONY: test-dep-as
 test-dep-as:
 	@set -e; \
@@ -528,7 +532,7 @@ test-dep-as:
 	openssl ecparam -genkey -name prime256v1 -out /tmp/as-ca.key; \
 	openssl req -x509 -sha256 -nodes -days 365 -key /tmp/as-ca.key -out /tmp/as-ca.pem -subj "/O=Trustee CA" \
 		-addext keyUsage=critical,cRLSign,keyCertSign,digitalSignature; \
-	openssl ecparam -genkey -name prime256v1 -out /tmp/as.key; \
+	openssl ecparam -genkey -name prime256v1 -noout -out /tmp/as.key; \
 	openssl req -new -key /tmp/as.key -out /tmp/as.csr -subj "/CN=Trustee/O=Trustee CA"; \
 	echo '[v3_req]' > /tmp/as-ext.cnf; \
 	echo 'subjectKeyIdentifier = hash' >> /tmp/as-ext.cnf; \

--- a/rats-cert/Cargo.toml
+++ b/rats-cert/Cargo.toml
@@ -61,6 +61,15 @@ tokio = {workspace = true, default-features = true, features = ["fs"]}
 tonic = {workspace = true, default-features = false, features = ["codegen", "channel"], optional = true}
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
+# Web Crypto API deps for the builtin-as challenger keygen path. On wasm the
+# rustcrypto `rsa` prime generation (used by `JwtChallenger::new`) is pure
+# software and slow; instead we ask the host (hardware-accelerated) WebCrypto
+# `SubtleCrypto::generateKey` for an RSA-2048 key, export it as PKCS#8, and feed
+# it to `JwtChallenger::new_with_private_key`. Only pulled on wasm targets.
+js-sys = {workspace = true}
+wasm-bindgen = {workspace = true}
+wasm-bindgen-futures = {workspace = true}
+web-sys = {workspace = true, features = ["Crypto", "SubtleCrypto", "Window", "CryptoKey"]}
 ring = {workspace = true, features = ["wasm32_unknown_unknown_js"]}
 rustls-webpki = {workspace = true, optional = true, features = ["alloc", "ring"]}
 time = {workspace = true, features = ["std", "wasm-bindgen", "parsing"]}

--- a/rats-cert/Cargo.toml
+++ b/rats-cert/Cargo.toml
@@ -50,10 +50,18 @@ zeroize = {workspace = true}
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
 # Enable the attestation-service `fs` feature on native builds so the builtin
 # converter supports `file://` provenance sources (and on-disk RV storage /
-# signer key/cert paths). This is a target-specific re-declaration: cargo merges
-# it with the `[dependencies]` entry for non-wasm only, so wasm keeps the
-# fs-free, pure-library build (no sled / tokio/fs on wasm32-unknown-unknown).
-attestation-service = {workspace = true, default-features = false, features = ["fs"], optional = true}
+# signer key/cert paths). `policy-rvps` is also required: the upstream
+# default policy (`ear_broker::DEFAULT_POLICY`, which the builtin converter
+# loads) calls the rego builtin `query_reference_value(...)`, which is only
+# registered under attestation-service's `policy-rvps` feature. Without it,
+# policy appraisal fails with "could not find function query_reference_value".
+# wasm omits it (the wasm verify path uses `trust_all.rego`, which does not
+# query reference values, and `policy-rvps` uses tokio's multi-thread
+# runtime / `spawn_blocking`, unavailable on wasm32-unknown-unknown).
+# This is a target-specific re-declaration: cargo merges it with the
+# `[dependencies]` entry for non-wasm only, so wasm keeps the fs-free,
+# pure-library build (no sled / tokio/fs on wasm32-unknown-unknown).
+attestation-service = {workspace = true, default-features = false, features = ["fs", "policy-rvps"], optional = true}
 rustls-webpki = {workspace = true, optional = true, features = ["alloc", "aws-lc-rs"]}
 tempfile = {workspace = true, optional = true}
 time = {workspace = true, features = ["std", "parsing"]}

--- a/rats-cert/src/errors.rs
+++ b/rats-cert/src/errors.rs
@@ -202,12 +202,20 @@ pub enum Error {
     AttestationServiceCreateFailed(#[source] attestation_service::ServiceError),
 
     #[cfg(feature = "__builtin-as")]
+    #[error("Failed to create attestation service challenger")]
+    AttestationServiceChallengerCreateFailed(#[source] anyhow::Error),
+
+    #[cfg(feature = "__builtin-as")]
     #[error("Failed to set attestation policy")]
     AttestationServiceSetPolicyFailed(#[source] anyhow::Error),
 
     #[cfg(feature = "__builtin-as")]
     #[error("Failed to generate attestation challenge")]
     AttestationServiceGenerateChallengeFailed(#[source] anyhow::Error),
+
+    #[cfg(feature = "__builtin-as")]
+    #[error("Failed to parse attestation challenge response")]
+    AttestationServiceChallengeParseFailed(#[source] anyhow::Error),
 
     #[cfg(feature = "__builtin-as")]
     #[error("Attestation evidence verification failed")]

--- a/rats-cert/src/tee/coco/converter/builtin.rs
+++ b/rats-cert/src/tee/coco/converter/builtin.rs
@@ -65,7 +65,7 @@ impl attestation_service::token::signer::SignKeyProvider<p256::SecretKey> for Se
     fn cert_url(&self) -> Option<&str> {
         None
     }
-    fn cert_pem_raw(&self) -> Option<anyhow::Result<Vec<u8>>> {
+    fn cert_pem_live(&self) -> Option<anyhow::Result<Vec<u8>>> {
         // Return None here since this function will not be called actually
         None
     }
@@ -219,7 +219,7 @@ impl BuiltinCocoConverter {
         let (self_signed_signer, mut attestation_service) = {
             let self_signed_signer = Arc::new(SelfSignedSigner::new()?);
 
-            let rvps = Box::new(attestation_service::rvps::builtin::BuiltinRvps::new(
+            let rvps = Arc::new(attestation_service::rvps::builtin::BuiltinRvps::new(
                 reference_value_provider_service::config::Config {
                     storage:
                         reference_value_provider_service::storage::ReferenceValueStorageConfig::InMemory(
@@ -228,14 +228,14 @@ impl BuiltinCocoConverter {
                 },
             )
             .map_err(attestation_service::ServiceError::Rvps)
-            .map_err(Error::AttestationServiceCreateFailed)?) as Box<dyn attestation_service::rvps::RvpsApi + Send + Sync>;
+            .map_err(Error::AttestationServiceCreateFailed)?) as Arc<dyn attestation_service::rvps::RvpsApi>;
 
             let token_broker = Box::new(
                 attestation_service::token::ear_broker::EarAttestationTokenBroker::from_components(
                     attestation_service::token::ear_broker::TokenBrokerSettings::default(),
                     self_signed_signer.clone(),
                     Arc::new(
-                        attestation_service::policy_engine::opa_in_memory::InMemoryPolicyEngine::with_raw_default_policy(
+                        attestation_service::policy_engine::opa::OPAInMemory::with_raw_default_policy(
                             attestation_service::token::ear_broker::DEFAULT_POLICY,
                             DEFAULT_POLICY_ID,
                         ),
@@ -244,7 +244,15 @@ impl BuiltinCocoConverter {
             )
             as Box<dyn attestation_service::token::AttestationTokenBroker + Send + Sync>;
 
-            let challenger = Box::new(attestation_service::challenge::LocalNonceChallenger::new());
+            // The builtin AS now stores the challenger by value as a concrete
+            // `JwtChallenger` (the old `Challenger` trait / `LocalNonceChallenger`
+            // were removed upstream). On non-wasm we let rustcrypto generate the
+            // RSA-2048 key; on wasm that prime generation is pure software and
+            // slow, so we ask the host Web Crypto API to generate the key
+            // (hardware-accelerated) and feed it in via `new_with_private_key`.
+            let challenger = Self::build_challenger()
+                .await
+                .map_err(Error::AttestationServiceChallengerCreateFailed)?;
 
             (
                 self_signed_signer,
@@ -271,6 +279,105 @@ impl BuiltinCocoConverter {
             self_signed_signer,
             attestation_service,
         })
+    }
+
+    /// Construct the [`JwtChallenger`] used by the embedded attestation service.
+    ///
+    /// The builtin AS stores the challenger by value as a concrete
+    /// `JwtChallenger` (the `Challenger` trait and `LocalNonceChallenger` were
+    /// removed upstream in favor of a single JWT-based challenger).
+    ///
+    /// `JwtChallenger::new` generates a fresh RSA-2048 key with rustcrypto.
+    /// That is fine on native, but on wasm rustcrypto prime generation is pure
+    /// software and prohibitively slow, so on wasm we ask the host Web Crypto
+    /// API (`SubtleCrypto::generateKey`, hardware-accelerated) to produce the
+    /// RSA key, export it as PKCS#8, and feed it to `new_with_private_key`.
+    /// The actual RS384 signing in the challenger still uses rustcrypto; only
+    /// key generation is offloaded to WebCrypto.
+    async fn build_challenger() -> anyhow::Result<attestation_service::JwtChallenger> {
+        #[cfg(wasm)]
+        {
+            Self::build_challenger_webcrypto().await
+        }
+        #[cfg(not(wasm))]
+        {
+            attestation_service::JwtChallenger::new()
+        }
+    }
+
+    /// wasm path: generate the challenger's RSA key via the Web Crypto API.
+    #[cfg(wasm)]
+    async fn build_challenger_webcrypto() -> anyhow::Result<attestation_service::JwtChallenger> {
+        use rsa::pkcs8::DecodePrivateKey as _;
+        use rsa::RsaPrivateKey;
+        use wasm_bindgen::JsCast as _;
+        use wasm_bindgen_futures::JsFuture;
+
+        // Helper to convert a thrown `JsValue` into an `anyhow::Error`. A
+        // `JsValue` carries no Rust error chain, so there is nothing to preserve
+        // via `.context()`; rendering its Debug form is the only option.
+        fn js_err(msg: &str, value: wasm_bindgen::JsValue) -> anyhow::Error {
+            anyhow::Error::msg(format!("{msg}: {value:?}"))
+        }
+
+        let window = web_sys::window().ok_or_else(|| {
+            anyhow::anyhow!("no global `window` available (not a browser/WASM worker context)")
+        })?;
+        let crypto = window.crypto().map_err(|e| js_err("window.crypto", e))?;
+        let subtle = crypto.subtle();
+
+        // RSASSA-PKCS1-v1_5 with SHA-384 == RS384, the scheme JwtChallenger
+        // signs with. modulusLength 2048, publicExponent 65537 ([1,0,1]).
+        let algorithm = js_sys::Object::new();
+        js_sys::Reflect::set(&algorithm, &"name".into(), &"RSASSA-PKCS1-v1_5".into())
+            .map_err(|e| js_err("set algorithm.name", e))?;
+        js_sys::Reflect::set(&algorithm, &"modulusLength".into(), &2048u32.into())
+            .map_err(|e| js_err("set algorithm.modulusLength", e))?;
+        let public_exponent = js_sys::Uint8Array::from(&[1u8, 0, 1][..]);
+        js_sys::Reflect::set(&algorithm, &"publicExponent".into(), &public_exponent)
+            .map_err(|e| js_err("set algorithm.publicExponent", e))?;
+        let hash = js_sys::Object::new();
+        js_sys::Reflect::set(&hash, &"name".into(), &"SHA-384".into())
+            .map_err(|e| js_err("set algorithm.hash.name", e))?;
+        js_sys::Reflect::set(&algorithm, &"hash".into(), &hash)
+            .map_err(|e| js_err("set algorithm.hash", e))?;
+
+        // extractable=true so we can export the private key material as PKCS#8.
+        let key_usages = js_sys::Array::new();
+        key_usages.push(&"sign".into());
+        let key_gen_promise = subtle
+            .generate_key_with_object(&algorithm, true, &key_usages)
+            .map_err(|e| js_err("SubtleCrypto::generateKey", e))?;
+        let key_pair_value = JsFuture::from(key_gen_promise)
+            .await
+            .map_err(|e| js_err("await SubtleCrypto::generateKey", e))?;
+
+        // `generateKey` for an asymmetric algorithm resolves to a JS object
+        // `{ privateKey: CryptoKey, publicKey: CryptoKey }`. web-sys models
+        // `CryptoKeyPair` as a write-only dictionary (setters, no getters), so
+        // read the `privateKey` property off the raw value via Reflect instead.
+        let private_key_value = js_sys::Reflect::get(&key_pair_value, &"privateKey".into())
+            .map_err(|e| js_err("read CryptoKeyPair.privateKey", e))?;
+        let private_key: web_sys::CryptoKey = private_key_value
+            .dyn_into()
+            .map_err(|_| anyhow::anyhow!("CryptoKeyPair.privateKey is not a CryptoKey"))?;
+
+        let export_promise = subtle
+            .export_key("pkcs8", &private_key)
+            .map_err(|e| js_err("SubtleCrypto::exportKey", e))?;
+        let exported = JsFuture::from(export_promise)
+            .await
+            .map_err(|e| js_err("await SubtleCrypto::exportKey", e))?;
+        let buffer: js_sys::ArrayBuffer = exported.dyn_into().map_err(|_| {
+            anyhow::anyhow!("SubtleCrypto::exportKey did not return an ArrayBuffer")
+        })?;
+        let der = js_sys::Uint8Array::new(&buffer).to_vec();
+
+        let rsa_key = RsaPrivateKey::from_pkcs8_der(&der)
+            .map_err(|e| anyhow::Error::from(e).context("parse WebCrypto RSA key as PKCS#8"))?;
+        Ok(attestation_service::JwtChallenger::new_with_private_key(
+            rsa_key,
+        ))
     }
 
     /// Builtin converters run the attestation service in-process and have no
@@ -498,12 +605,33 @@ impl GenericConverter for BuiltinCocoConverter {
     }
 
     async fn get_nonce(&self) -> Result<Self::Nonce> {
-        // Generate a challenge nonce for the attestation
-        self.attestation_service
+        // The builtin AS issues the challenge as a JSON object
+        // `{"nonce": <b64>, "extra-params": {"jwt": <signed jwt>}}` (see
+        // `JwtChallenger::generate_challenge_json`). The client echoes only the
+        // JWT back as `runtime_data["challenge_token"]`, which the AS verifies via
+        // `verify_challenge_token` (signature + `exp` — it splits on `.` and treats
+        // the value as a bare JWT, NOT the wrapper JSON). So extract the bare JWT
+        // here, mirroring the REST converter (`challenge_response.extra_params.jwt`).
+        let challenge_json = self
+            .attestation_service
             .generate_challenge(None, None)
             .await
-            .map_err(Error::AttestationServiceGenerateChallengeFailed)
-            .map(CoCoNonce::Jwt)
+            .map_err(Error::AttestationServiceGenerateChallengeFailed)?;
+        let challenge: serde_json::Value = serde_json::from_str(&challenge_json).map_err(|e| {
+            Error::AttestationServiceChallengeParseFailed(
+                anyhow::Error::from(e).context("parse attestation challenge response"),
+            )
+        })?;
+        let jwt = challenge
+            .get("extra-params")
+            .and_then(|p| p.get("jwt"))
+            .and_then(|j| j.as_str())
+            .ok_or_else(|| {
+                Error::AttestationServiceChallengeParseFailed(anyhow::anyhow!(
+                    "missing `extra-params.jwt` in attestation challenge response"
+                ))
+            })?;
+        Ok(CoCoNonce::Jwt(jwt.to_string()))
     }
 }
 
@@ -602,7 +730,7 @@ default file_system := 2"#;
     #[serial]
     async fn test_converter_new_with_sample_inline_reference() {
         let mut rvs = std::collections::HashMap::new();
-        rvs.insert("example-measurement".to_string(), vec![]);
+        rvs.insert("example-measurement".to_string(), json!([]));
         let provenance = Provenance { rvs };
         let reference = ReferenceValueConfig::Sample {
             payload: SampleProvenancePayloadConfig::Inline {
@@ -754,11 +882,11 @@ default file_system := 2"#;
     #[serial]
     async fn test_converter_new_with_multiple_references() {
         let mut rvs1 = std::collections::HashMap::new();
-        rvs1.insert("component-a".to_string(), vec![]);
+        rvs1.insert("component-a".to_string(), json!([]));
         let provenance1 = Provenance { rvs: rvs1 };
 
         let mut rvs2 = std::collections::HashMap::new();
-        rvs2.insert("component-b".to_string(), vec![]);
+        rvs2.insert("component-b".to_string(), json!([]));
         let provenance2 = Provenance { rvs: rvs2 };
 
         let references = vec![
@@ -816,10 +944,7 @@ default file_system := 2"#;
         let mut rvs = std::collections::HashMap::new();
         rvs.insert(
             "my-component".to_string(),
-            vec![
-                "expected-value-1".to_string(),
-                "expected-value-2".to_string(),
-            ],
+            json!(["expected-value-1", "expected-value-2"]),
         );
         let provenance = Provenance { rvs };
 
@@ -1167,9 +1292,7 @@ default file_system := 2"#,
     /// Evaluate a bundled rego policy against `input` and return the four AR4SI
     /// trust-vector values as (executables, hardware, configuration, file_system).
     async fn eval_policy_vector(policy: &str, input: &str) -> (i8, i8, i8, i8) {
-        use attestation_service::policy_engine::PolicyEngineType;
-
-        let engine = attestation_service::policy_engine::opa_in_memory::InMemoryPolicyEngine::with_raw_default_policy(
+        let engine = attestation_service::policy_engine::opa::OPAInMemory::with_raw_default_policy(
             policy,
             DEFAULT_POLICY_ID,
         );
@@ -1182,15 +1305,32 @@ default file_system := 2"#,
             "configuration".to_string(),
             "file_system".to_string(),
         ];
+        // The upstream `PolicyEngine::evaluate` now resolves Rego
+        // `query_reference_value(...)` calls through a `ReferenceValueResolver`
+        // (backed by an `RvpsApi` implementor). None of these policy templates
+        // query reference values, so an empty in-memory RVPS resolver suffices.
+        let resolver = Arc::new(attestation_service::rvps::ReferenceValueResolver::new(
+            Arc::new(
+                attestation_service::rvps::builtin::BuiltinRvps::new(
+                    reference_value_provider_service::config::Config {
+                        storage: reference_value_provider_service::storage::ReferenceValueStorageConfig::InMemory(
+                            reference_value_provider_service::storage::in_memory::Config {},
+                        ),
+                    },
+                )
+                .expect("create in-memory RVPS for policy test"),
+            ) as Arc<dyn attestation_service::rvps::RvpsApi>,
+        ));
         let result = engine
-            .evaluate("{}", input, "default", rules)
+            .evaluate(input, DEFAULT_POLICY_ID, rules, resolver)
             .await
             .expect("evaluate policy");
         let get = |name: &str| -> i8 {
             result
                 .rules_result
                 .get(name)
-                .and_then(|v| v.as_i8().ok())
+                .and_then(|v| v.as_i64())
+                .and_then(|n| i8::try_from(n).ok())
                 .unwrap_or_else(|| panic!("policy did not produce a value for {name}"))
         };
         (

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -121,6 +121,11 @@ path = "tests/js_sdk_http.rs"
 required-features = ["js-sdk"]
 
 [[test]]
+name = "js_sdk_builtin_as"
+path = "tests/js_sdk_builtin_as.rs"
+required-features = ["js-sdk"]
+
+[[test]]
 name = "netfilter_ingress_recursion_detect"
 path = "tests/netfilter/netfilter_ingress_recursion_detect.rs"
 

--- a/tng-testsuite/src/task/app/browser_client.rs
+++ b/tng-testsuite/src/task/app/browser_client.rs
@@ -75,6 +75,19 @@ pub async fn launch_browser_client(
                 .await
                 .context(if log_level_all { "Failed to connect to chromedriver" } else {"Failed to connect to chromedriver. Set TNG_WASM_TEST_CHROMEDRIVER_LOG_ALL=true to see all chromedriver logs"})?;
 
+            // Navigate to the static file server's localhost root before running
+            // any JS. Chrome otherwise sits on its initial blank page, which is
+            // NOT a secure context — so `window.crypto.subtle` (the WebCrypto
+            // API, used by the builtin-as challenger keygen path) is `undefined`
+            // there. A page served from `http://127.0.0.1:<port>/` is a secure
+            // context (localhost is a trustworthy origin), making `crypto.subtle`
+            // available to the wasm SDK. Harmless for tests that don't use
+            // WebCrypto; required for the builtin-as wasm integration test.
+            driver
+                .goto(format!("http://127.0.0.1:{listen_port}/tng_wasm.js"))
+                .await
+                .context("Failed to navigate browser to the static file server root (secure context needed for WebCrypto)")?;
+
             let res = async {
                 for i in 1..6 {
                     // repeat 5 times

--- a/tng-testsuite/tests/js_sdk_builtin_as.rs
+++ b/tng-testsuite/tests/js_sdk_builtin_as.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use serial_test::serial;
+use tng_testsuite::{
+    run_test,
+    task::{app::AppType, tng::TngInstance, Task as _},
+};
+
+/// End-to-end builtin-AS verification through the WASM SDK in a headless browser.
+///
+/// Unlike `js_sdk_http` (which drives a *remote* attestation service via
+/// `as_addr`), here the browser-side `verify` config selects `as_type: "builtin"`,
+/// so the attestation service runs **in-process inside the wasm SDK** — exactly
+/// the migrated path (`JwtChallenger` by value, WebCrypto RSA keygen on wasm via
+/// `build_challenger_webcrypto`, and `get_nonce` extracting the bare JWT). The
+/// builtin AS generates the challenge and verifies the egress's evidence itself,
+/// so this test does **not** depend on `make test-dep-as`.
+///
+/// The egress still attests via the remote Attestation Agent (`aa_addr` unix
+/// socket, `make test-dep-aa`): the builtin *attester* (server-side evidence
+/// production) is not yet implemented (`tng/src/tunnel/provider/factory.rs`),
+/// so the AA is the evidence source. The builtin AS (verifier) then verifies
+/// that evidence end-to-end.
+#[cfg(feature = "js-sdk")]
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn server_builtin_as_background_check() -> Result<()> {
+    run_test!(vec![
+        TngInstance::TngServer(
+            r#"
+            {
+                "add_egress": [
+                    {
+                        "netfilter": {
+                            "capture_dst": {
+                                "port": 30001
+                            }
+                        },
+                        "ohttp": {},
+                        "attest": {
+                            "model": "background_check",
+                            "aa_addr": "unix:///run/confidential-containers/attestation-agent/attestation-agent.sock"
+                        }
+                    }
+                ]
+            }
+            "#,
+        ).boxed(),
+        AppType::HttpServer {
+            port: 30001,
+            expected_host_header: "192.168.1.1:30001",
+            expected_path_and_query: "/foo/bar/www?type=1&case=1",
+        }.boxed(),
+        AppType::BrowserClient {
+            js: r#"
+                await tng_init();
+
+                const config = {
+                    ohttp: {},
+                    verify: {
+                        model: "background_check",
+                        // Run the attestation service in-process (builtin) inside
+                        // the wasm SDK instead of calling a remote AS. No as_addr.
+                        as_type: "builtin",
+                        // `trust_all` affirms every trustworthiness dimension
+                        // unconditionally — but only AFTER the builtin AS has
+                        // cryptographically verified the AA's TDX evidence (quote
+                        // signature + PCCS collateral). It is the right level for
+                        // this integration test, which exercises the builtin-as
+                        // plumbing (WebCrypto keygen → challenge → evidence
+                        // verification → token issuance) rather than asserting
+                        // specific TEE measurements (the AA's quotes carry no
+                        // known-good reference values to match against).
+                        attestation_policy: {
+                            type: "trust_all"
+                        },
+                        reference_values: []
+                    }
+                };
+
+                // Builtin-as leaves as_addr / policy_ids null (the shared
+                // common_check_response helper requires them for coco), so use a
+                // dedicated check that asserts the builtin path produced an
+                // attestation result (only issued after evidence verification
+                // succeeded) and that no remote AS address is present.
+                async function check_builtin_response(response) {
+                    if (!response.ok) {
+                        let errorMessage = `Response status: ${response.status} ${response.statusText}`;
+                        try {
+                            const responseBody = await response.text();
+                            if (responseBody) {
+                                errorMessage += `\nResponse body: ${responseBody.trim()}`;
+                            }
+                        } catch (err) {
+                            errorMessage += `\nFailed to read response body: ${err.message}`;
+                        }
+                        throw new Error(errorMessage);
+                    }
+
+                    if (!(response.attest_info !== undefined && response.attest_info !== null)) {
+                        throw new Error('attest_info not exist');
+                    }
+
+                    const info = response.attest_info;
+
+                    if (!(info.attestation_result !== undefined && info.attestation_result !== null)) {
+                        throw new Error('attest_info.attestation_result not exist');
+                    }
+                    if (typeof info.attestation_result !== 'string' || info.attestation_result.length === 0) {
+                        throw new Error(`attest_info.attestation_result should be a non-empty token string but got ${info.attestation_result}`);
+                    }
+
+                    if (info.as_provider !== 'coco') {
+                        throw new Error(`expected as_provider='coco', got '${info.as_provider}'`);
+                    }
+
+                    // Builtin AS has no remote attestation service address.
+                    if (info.as_addr !== undefined && info.as_addr !== null) {
+                        throw new Error(`builtin-as should have no as_addr, got '${info.as_addr}'`);
+                    }
+                }
+
+                {
+                    const response = await tng_fetch("http://192.168.1.1:30001/foo/bar/www?type=1&case=1",
+                        {
+                            method: "GET",
+                            headers: {
+                                "custom": "custom-value",
+                            },
+                        }, config);
+                    await check_builtin_response(response);
+                }
+                {
+                    const response = await tng_fetch("http://192.168.1.1:30001/foo/bar/www?type=1&case=1",
+                        {
+                            method: "POST",
+                            headers: {
+                                "custom": "custom-value",
+                            },
+                            body: JSON.stringify({ answer: 42 }),
+                        }, config);
+                    await check_builtin_response(response);
+                }
+            "#
+        }.boxed(),
+    ])
+    .await?;
+
+    Ok(())
+}

--- a/tng-wasm/Cargo.toml
+++ b/tng-wasm/Cargo.toml
@@ -53,6 +53,10 @@ tokio_with_wasm_proc = {workspace = true}
 
 [dev-dependencies]
 reqwest = {workspace = true}
+# Direct access to the builtin-as converter so a wasm-bindgen-test can exercise
+# the WebCrypto challenger keygen path (`build_challenger_webcrypto`). The
+# features unify with the ones already enabled via `tng`'s rats-cert dep.
+rats-cert = {path = "../rats-cert", default-features = false, features = ["crypto-rustcrypto", "builtin-as-tdx-rust"]}
 wasm-bindgen-test = "0.3.76"
 
 [build-dependencies]

--- a/tng-wasm/src/lib.rs
+++ b/tng-wasm/src/lib.rs
@@ -26,3 +26,53 @@ pub fn init_tng() {
 
     tng::show_banner("wasm");
 }
+
+#[cfg(all(
+    test,
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+))]
+mod tests {
+    use wasm_bindgen_test::*;
+
+    use rats_cert::cert::verify::PolicyConfig;
+    use rats_cert::tee::coco::converter::builtin::BuiltinCocoConverter;
+    use rats_cert::tee::coco::converter::CoCoNonce;
+    use rats_cert::tee::GenericConverter;
+
+    // Run these in a real browser so `window.crypto.subtle` (the Web Crypto API
+    // used by `build_challenger_webcrypto`) is available. Run with:
+    //   make wasm-unit-test-chrome
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    // Constructing the builtin attestation-service converter on wasm must drive
+    // the WebCrypto RSA keygen path (`build_challenger_webcrypto`) rather than
+    // the slow pure-software `rsa` prime generation, and then produce a
+    // challenge nonce that is a bare 3-segment JWT. This exercises that whole
+    // flow end-to-end in a headless browser.
+    #[wasm_bindgen_test]
+    async fn builtin_challenger_webcrypto_keygen_and_nonce() {
+        let converter = match BuiltinCocoConverter::new(
+            &PolicyConfig::HardwareWithReferenceValues,
+            &[],
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(error) => panic!("failed to build builtin converter: {error:?}"),
+        };
+
+        let nonce = match converter.get_nonce().await {
+            Ok(n) => n,
+            Err(error) => panic!("failed to get nonce: {error:?}"),
+        };
+
+        let CoCoNonce::Jwt(jwt) = nonce;
+        assert_eq!(
+            jwt.split('.').count(),
+            3,
+            "builtin challenge nonce should be a bare 3-segment JWT, got: {jwt}"
+        );
+    }
+}

--- a/tng/src/tunnel/ra_context.rs
+++ b/tng/src/tunnel/ra_context.rs
@@ -746,7 +746,7 @@ mod tests {
             use std::collections::HashMap;
             // Sample reference value payload (inline Provenance)
             let mut rvs = HashMap::new();
-            rvs.insert("example-measurement".to_string(), vec![]);
+            rvs.insert("example-measurement".to_string(), serde_json::json!([]));
             let provenance = Provenance { rvs };
             let verify_args = make_verify_builtin_args(
                 PolicyConfig::HardwareWithReferenceValues,
@@ -994,11 +994,11 @@ mod tests {
             use std::collections::HashMap;
 
             let mut rvs1 = HashMap::new();
-            rvs1.insert("component-a".to_string(), vec![]);
+            rvs1.insert("component-a".to_string(), serde_json::json!([]));
             let provenance1 = Provenance { rvs: rvs1 };
 
             let mut rvs2 = HashMap::new();
-            rvs2.insert("component-b".to_string(), vec![]);
+            rvs2.insert("component-b".to_string(), serde_json::json!([]));
             let provenance2 = Provenance { rvs: rvs2 };
 
             let verify_args = make_verify_builtin_args(


### PR DESCRIPTION
Move the attestation-service / reference-value-provider-service pins from the imlk0 fork to upstream openanolis/trustee@5587044f, and adapt the builtin-as converter to the upstream API.