### PR TITLE
Bump trustee to a7cae246 and enable policy-rvps on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
+source = "git+https://github.com/openanolis/trustee/?rev=a7cae2464685dd3b7975213238d3fc09e03a7fa7#a7cae2464685dd3b7975213238d3fc09e03a7fa7"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -580,6 +580,7 @@ dependencies = [
  "ear",
  "futures",
  "getrandom 0.2.15",
+ "getrandom 0.4.2",
  "hex",
  "jsonwebtoken",
  "kbs-types",
@@ -1302,6 +1303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "codicon"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,7 +1895,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2189,6 +2199,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "eventlog"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
+source = "git+https://github.com/openanolis/trustee/?rev=a7cae2464685dd3b7975213238d3fc09e03a7fa7#a7cae2464685dd3b7975213238d3fc09e03a7fa7"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2742,11 +2764,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2998,7 +3022,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3017,7 +3041,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3061,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
@@ -3702,12 +3726,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4180,7 +4204,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hostname",
  "humantime-serde",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memberlist-proto",
  "nodecraft",
  "once_cell",
@@ -4220,7 +4244,7 @@ dependencies = [
  "getifs",
  "getrandom 0.4.2",
  "humantime-serde",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memberlist-core",
  "nodecraft",
  "peekable 0.5.0",
@@ -4285,7 +4309,7 @@ dependencies = [
  "futures",
  "getifs",
  "humantime-serde",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memberlist-core",
  "nodecraft",
  "peekable 0.5.0",
@@ -4404,6 +4428,15 @@ dependencies = [
  "tagptr",
  "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4647,6 +4680,16 @@ name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -5148,7 +5191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5159,7 +5202,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5408,6 +5451,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
  "rand 0.8.5",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -5721,7 +5776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "protobuf 3.7.2",
  "protobuf-support",
@@ -6124,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "reference-value-provider-service"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
+source = "git+https://github.com/openanolis/trustee/?rev=a7cae2464685dd3b7975213238d3fc09e03a7fa7#a7cae2464685dd3b7975213238d3fc09e03a7fa7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6147,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6159,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6170,26 +6225,33 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regorus"
-version = "0.2.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c3d97f07e3b5ac0955d53ad0af4c91fe4a4f8525843ece5bf014f27829b73"
+checksum = "3cc4dc91481b1d4001ba7f2e81f7faf674142e0ac36d37d79e5f02764d06571e"
 dependencies = [
  "anyhow",
  "chrono",
  "chrono-tz",
  "data-encoding",
+ "indexmap 2.14.0",
  "lazy_static",
- "rand 0.8.5",
+ "msvc_spectre_libs",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "parking_lot 0.12.3",
+ "postcard",
+ "rand 0.10.1",
  "regex",
- "scientific",
  "serde",
  "serde_json",
+ "spin 0.12.3",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -6338,7 +6400,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.15.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -6625,26 +6687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scientific"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a4b339a8de779ecb098a772ecbba2ace74e23ed959a5b4f30631d8bf1799a8"
-dependencies = [
- "scientific-macro",
-]
-
-[[package]]
-name = "scientific-macro"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6852,7 +6894,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6921,7 +6963,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6969,7 +7011,7 @@ dependencies = [
  "either",
  "futures",
  "humantime-serde",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memberlist-core",
  "once_cell",
  "parking_lot 0.12.3",
@@ -7134,7 +7176,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror 2.0.17",
  "time",
@@ -7269,6 +7311,12 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
 
 [[package]]
 name = "spki"
@@ -7547,7 +7595,7 @@ dependencies = [
  "const_format",
  "futures-util",
  "http 1.3.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "paste",
  "reqwest 0.12.9",
  "serde",
@@ -7739,7 +7787,7 @@ dependencies = [
  "humantime-serde",
  "hyper 1.8.1",
  "hyper-util 0.1.7",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "local-ip-address",
  "nix 0.30.1",
@@ -8077,7 +8125,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -8088,7 +8136,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -8102,7 +8150,7 @@ version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
@@ -8256,7 +8304,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -8730,7 +8778,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=5587044f471691245e5db1af2be6361aed6c0cf8#5587044f471691245e5db1af2be6361aed6c0cf8"
+source = "git+https://github.com/openanolis/trustee/?rev=a7cae2464685dd3b7975213238d3fc09e03a7fa7#a7cae2464685dd3b7975213238d3fc09e03a7fa7"
 dependencies = [
  "anyhow",
  "asn1-rs",
@@ -8966,7 +9014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -9007,7 +9055,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -9495,7 +9543,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease 0.2.32",
  "syn 2.0.98",
  "wasm-metadata",
@@ -9526,7 +9574,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -9545,7 +9593,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -9815,7 +9863,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.1",
  "hmac",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ as-any = "0.3.2"
 async-http-proxy = {version = "1.2.5", features = ["runtime-tokio"]}
 async-stream = "0.3.6"
 async-trait = "0.1.88"
-attestation-service = {git = "https://github.com/openanolis/trustee/", rev = "5587044f471691245e5db1af2be6361aed6c0cf8", default-features = false}
+attestation-service = {git = "https://github.com/openanolis/trustee/", rev = "a7cae2464685dd3b7975213238d3fc09e03a7fa7", default-features = false}
 atty = "0.2.14"
 auto_enums = {version = "0.8", features = ["std", "tokio1"]}
 axum = {version = "0.8.4", default-features = false}
@@ -96,7 +96,7 @@ rand = "0.9.1"
 rand_chacha = "0.9.0"
 rayon = "1.10.0"
 rcgen = "0.13.2"
-reference-value-provider-service = {git = "https://github.com/openanolis/trustee/", rev = "5587044f471691245e5db1af2be6361aed6c0cf8", default-features = false}
+reference-value-provider-service = {git = "https://github.com/openanolis/trustee/", rev = "a7cae2464685dd3b7975213238d3fc09e03a7fa7", default-features = false}
 regex = "1.11.1"
 reqwest = {version = "=0.12.9", default-features = false, features = ["json", "http2", "rustls-tls-webpki-roots-no-provider", "brotli", "gzip", "zstd"]}# select 0.12.9 version since we have to align to the hyper-util=0.1.7 version used by hyper-util-wasm
 # Override quinn to use aws-lc-rs instead of ring for QUIC crypto (default is rustls-ring)

--- a/rats-cert/Cargo.toml
+++ b/rats-cert/Cargo.toml
@@ -48,19 +48,17 @@ x509-cert = {workspace = true, optional = true}
 zeroize = {workspace = true}
 
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
-# Enable the attestation-service `fs` feature on native builds so the builtin
+# Native builds enable the attestation-service `fs` feature so the builtin
 # converter supports `file://` provenance sources (and on-disk RV storage /
 # signer key/cert paths). `policy-rvps` is also required: the upstream
 # default policy (`ear_broker::DEFAULT_POLICY`, which the builtin converter
 # loads) calls the rego builtin `query_reference_value(...)`, which is only
 # registered under attestation-service's `policy-rvps` feature. Without it,
 # policy appraisal fails with "could not find function query_reference_value".
-# wasm omits it (the wasm verify path uses `trust_all.rego`, which does not
-# query reference values, and `policy-rvps` uses tokio's multi-thread
-# runtime / `spawn_blocking`, unavailable on wasm32-unknown-unknown).
+# wasm enables `policy-rvps` too (see the wasm target block below); `fs` is
+# native-only (the wasm verify path uses in-memory RV storage, not the fs).
 # This is a target-specific re-declaration: cargo merges it with the
-# `[dependencies]` entry for non-wasm only, so wasm keeps the fs-free,
-# pure-library build (no sled / tokio/fs on wasm32-unknown-unknown).
+# `[dependencies]` entry for non-wasm only.
 attestation-service = {workspace = true, default-features = false, features = ["fs", "policy-rvps"], optional = true}
 rustls-webpki = {workspace = true, optional = true, features = ["alloc", "aws-lc-rs"]}
 tempfile = {workspace = true, optional = true}
@@ -69,6 +67,21 @@ tokio = {workspace = true, default-features = true, features = ["fs"]}
 tonic = {workspace = true, default-features = false, features = ["codegen", "channel"], optional = true}
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
+# Enable attestation-service's `policy-rvps` on wasm too. The builtin
+# converter loads the upstream default policy (`ear_broker::DEFAULT_POLICY`),
+# whose rego calls `query_reference_value(...)`; that builtin is only
+# registered under `policy-rvps`. As of trustee a7cae246, `policy-rvps` is
+# wasm-compatible: it now pulls only `tokio/time` (the old `tokio/rt` — the
+# multi-thread runtime / `spawn_blocking`, unavailable on
+# wasm32-unknown-unknown — was dropped), and the rego engine (regorus,
+# pure-Rust) runs on wasm. The getrandom 0.4 that regorus 0.11 -> rand 0.10
+# transitively needs is given the `wasm_js` feature by attestation-service's
+# own renamed `getrandom_04` wasm dep (so the Makefile `getrandom_backend`
+# cfg for the 0.3 line and the `js` feature for the 0.2 line are not enough
+# on their own). `fs` stays off on wasm (in-memory RV storage only). This is
+# a target-specific re-declaration: cargo merges it with the base
+# `[dependencies]` entry for wasm only.
+attestation-service = {workspace = true, default-features = false, features = ["policy-rvps"], optional = true}
 # Web Crypto API deps for the builtin-as challenger keygen path. On wasm the
 # rustcrypto `rsa` prime generation (used by `JwtChallenger::new`) is pure
 # software and slow; instead we ask the host (hardware-accelerated) WebCrypto

--- a/rats-cert/src/errors.rs
+++ b/rats-cert/src/errors.rs
@@ -202,6 +202,12 @@ pub enum Error {
     AttestationServiceCreateFailed(#[source] attestation_service::ServiceError),
 
     #[cfg(feature = "__builtin-as")]
+    #[error("Failed to create builtin attestation service policy engine")]
+    AttestationServicePolicyEngineCreateFailed(
+        #[source] attestation_service::policy_engine::PolicyError,
+    ),
+
+    #[cfg(feature = "__builtin-as")]
     #[error("Failed to create attestation service challenger")]
     AttestationServiceChallengerCreateFailed(#[source] anyhow::Error),
 

--- a/rats-cert/src/tee/coco/converter/builtin.rs
+++ b/rats-cert/src/tee/coco/converter/builtin.rs
@@ -238,7 +238,16 @@ impl BuiltinCocoConverter {
                         attestation_service::policy_engine::opa::OPAInMemory::with_raw_default_policy(
                             attestation_service::token::ear_broker::DEFAULT_POLICY,
                             DEFAULT_POLICY_ID,
-                        ),
+                            // The artifact-server address is only consumed
+                            // under attestation-service's `policy-artifact-server`
+                            // feature (not enabled here), so this value has no
+                            // effect today. Pass trustee's own default
+                            // (`config::DEFAULT_ARTIFACT_SERVER_ADDRESS`) rather
+                            // than `""` so the call site mirrors upstream usage
+                            // and stays correct if that feature is ever enabled.
+                            attestation_service::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+                        )
+                        .map_err(Error::AttestationServicePolicyEngineCreateFailed)?,
                     ),
                 ),
             )
@@ -1295,7 +1304,13 @@ default file_system := 2"#,
         let engine = attestation_service::policy_engine::opa::OPAInMemory::with_raw_default_policy(
             policy,
             DEFAULT_POLICY_ID,
-        );
+            // The artifact-server address is only consumed under
+            // attestation-service's `policy-artifact-server` feature (not
+            // enabled for these tests), so this value has no effect here.
+            // Pass trustee's own default to mirror upstream usage.
+            attestation_service::config::DEFAULT_ARTIFACT_SERVER_ADDRESS,
+        )
+        .expect("create OPA in-memory engine");
         // The four rules our templates define. The real AS also queries four more
         // AR4SI claims (instance-identity, runtime-opaque, ...); those are simply
         // skipped when a policy leaves them undefined, so they need not be queried.


### PR DESCRIPTION
Bump the trustee pin to `a7cae246` and enable attestation-service's `policy-rvps` feature on the wasm build.

## Why

The previous pin (`5587044f`) could not enable `policy-rvps` on wasm: the feature pulled `tokio/rt` (multi-thread runtime / `spawn_blocking`), unavailable on `wasm32-unknown-unknown`. The wasm builtin converter therefore loaded the upstream default policy (`ear_broker::DEFAULT_POLICY`), whose rego calls `query_reference_value(...)`, but that builtin was only registered on native — so the wasm path could not run real policy appraisal.

The new trustee makes `policy-rvps` wasm-compatible:
- `policy-rvps = ["tokio/time"]` — the `tokio/rt` dependency was dropped.
- The rego engine (regorus 0.11, pure-Rust) runs on wasm.
- The getrandom 0.4 that `regorus 0.11 -> rand 0.10` transitively needs is given the `wasm_js` feature by attestation-service's own renamed `getrandom_04` wasm dep.

## Changes

- `Cargo.toml`: pin `attestation-service` + `reference-value-provider-service` to `a7cae246`.
- `rats-cert/Cargo.toml`: target-specific re-declaration enabling `policy-rvps` for the wasm attestation-service dependency (`fs` stays native-only — wasm uses in-memory RV storage). Updated the comments to reflect that both native and wasm now run the default policy.
- `rats-cert/src/tee/coco/converter/builtin.rs`: adapt to the upstream API change — `OPAInMemory::with_raw_default_policy` now takes a third `artifact_server_address: &str` (only consumed under the `policy-artifact-server` feature, not enabled here) and returns `Result<Self, PolicyError>`. Pass trustee's `config::DEFAULT_ARTIFACT_SERVER_ADDRESS` and map the `Result` via a new error variant in both call sites (the production `new()` path and the `eval_policy_vector` test helper).
- `rats-cert/src/errors.rs`: new `AttestationServicePolicyEngineCreateFailed(#[source] PolicyError)` variant (preserves the error chain, matching the existing `ServiceError` variant style).
- `Cargo.lock`: regorus `0.2.8 -> 0.11.0` and the transitive subtree (indexmap, regex, hashbrown; adds cobs/embedded-io/num-bigint/postcard; drops the old `scientific` crates).

## Verification

- `cargo fmt` / `make clippy` (`--all-targets -D warnings`) / `cargo build` — clean.
- `cargo check -p rats-cert --tests` — clean (lib + tests compile natively).
- `make wasm-build-debug` — green: `tng_wasm_bg.wasm` + `tng_wasm.js` produced, package `@inclavare-containers/tng@2.8.0`. This is the real gate: regorus compiles to wasm, `getrandom_04` `wasm_js` unifies correctly, and `tokio/time` works on wasm.

## Behavior note on the third argument

`with_raw_default_policy`'s `artifact_server_address` is only used under the `policy-artifact-server` feature (not enabled by TNG). Passing `DEFAULT_ARTIFACT_SERVER_ADDRESS` mirrors upstream usage and has no effect today (the value is dropped via `let _ =`); it stays correct if that feature is ever enabled.

## Coverage note

No JS integration test currently drives the wasm builtin AS through a `query_reference_value` policy: `js_sdk_builtin_as` uses `trust_all` (which does not query reference values), and `js_sdk_http` exercises the policy on the *remote* trustee AS, not the wasm builtin side. The native analogs (`test_e2e_builtin_flow`, `test_builtin_convert_with_default_policy`, `test_builtin_convert_and_verify_roundtrip`) do target the default-policy path, but genuinely execute `query_reference_value` only on a TDX-capable host (they early-return on non-TDX). Filling the wasm-side gap is left for a follow-up.
