### PR TITLE
fix(tng-hook): apply cargo fmt to TCPStore test assertions

### DIFF
--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -732,7 +732,10 @@ mod tests {
             0,
             0,
         ));
-        assert_eq!(unsafe { parse(&v4) }, Some((socket, ConnectAddressFamily::Ipv4)));
+        assert_eq!(
+            unsafe { parse(&v4) },
+            Some((socket, ConnectAddressFamily::Ipv4))
+        );
         assert_eq!(
             unsafe { parse(&mapped) },
             Some((socket, ConnectAddressFamily::Ipv4MappedIpv6))


### PR DESCRIPTION
Reformat the mapped IPv6 parse test assertion to satisfy rustfmt, matching the multi-line style of the surrounding assertions.
