### PR TITLE
Bump minor version to 2.9.0

### DIFF
--- a/APPLICATION/tng/buildspec.yml
+++ b/APPLICATION/tng/buildspec.yml
@@ -30,7 +30,7 @@ images:
       path: Dockerfile
       scene:
         args: []
-        tags: [[2.8.0, latest]]
+        tags: [[2.9.0, latest]]
         registry: [*ACR_PROD]
       # 测试配置
       test_config: [*WORKSPACE, *PROJECT, *TEST_SUITE, *TEST_CONF, *TEST_CASE, *CLOUD_SERVER_TAG[0], '']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "rats-cert"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "as-any",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "tng"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "again",
  "anyhow",
@@ -7862,7 +7862,7 @@ dependencies = [
 
 [[package]]
 name = "tng-hook-cdylib"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "atty",
  "ctor",
@@ -7876,7 +7876,7 @@ dependencies = [
 
 [[package]]
 name = "tng-hook-types"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "cidr",
  "local-ip-address",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "tng-testsuite"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "again",
  "anyhow",
@@ -7929,7 +7929,7 @@ dependencies = [
 
 [[package]]
 name = "tng-wasm"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = ["Kun Lai <laikun@linux.alibaba.com>"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/inclavare-containers/tng"
-version = "2.8.0"
+version = "2.9.0"
 
 [workspace.dependencies]
 again = "0.1.2"

--- a/tng-python/pyproject.toml
+++ b/tng-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tng-sdk"
-version = "2.8.0"
+version = "2.9.0"
 description = "TNG (Trusted Network Gateway) Python SDK — encrypted HTTP requests with remote attestation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/trusted-network-gateway.spec
+++ b/trusted-network-gateway.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: trusted-network-gateway
-Version: 2.8.0
+Version: 2.9.0
 Release: 1%{?dist}
 Summary: Trusted Network Gateway
 Group: Applications/System
@@ -85,6 +85,23 @@ install -p -m 755 %{_builddir}/%{name}-%{version}/src/target/release/libtng_hook
 
 
 %changelog
+* Mon Aug 31 2026 Kun Lai <laikun@linux.alibaba.com> - 2.9.0-1
+- feat(transparency_log): optional publishedMeasurements + doc clarification
+- refactor(transparency_log): split trust vector for granular failure diagnostics
+- feat(rats-cert): add transparency_log attestation policy with Rekor v1 verification
+- fix(tng-hook): apply cargo fmt to TCPStore test assertions
+- fix(tng-hook): handle mapped IPv6 TCPStore connections
+- Add strict reference-value builtin AS policy
+- Add strict hardware-only builtin AS policy
+- netfilter(egress): only capture traffic destined for local addresses
+- test(testsuite): revert run_test! cancel-on-first-completion semantics
+- fix(netfilter_udp): gate Linux-only code so non-Linux targets compile
+- feat: add netfilter_udp transparent UDP proxy mode
+- Bump trustee to a7cae246 and enable policy-rvps on wasm
+- fix(rats-cert): enable policy-rvps so the builtin converter can appraise
+- ci: generate AS token-signer key without the EC PARAMETERS block
+- Migrate trustee to upstream openanolis and add builtin-as wasm tests
+
 * Thu Aug 13 2026 Kun Lai <laikun@linux.alibaba.com> - 2.8.0-1
 - test: harden curl-based integration checks
 - fix(ci): pin rv-release-tool to fixed trustee commit 28ce0c6


### PR DESCRIPTION
Bump minor version to 2.9.0 via `make bump-version-minor`.

Regenerates version info across:
- `Cargo.toml` / `Cargo.lock`
- `APPLICATION/tng/buildspec.yml`
- `tng-python/pyproject.toml`
- RPM spec (`Version` + auto-collected `%changelog` from commit subjects since `v2.8.0`)

No code logic changes — version-only bump. Tag `v2.9.0` will be pushed after CI is green.