### PR TITLE
Bump patch version to 2.9.1

### DIFF
--- a/APPLICATION/tng/buildspec.yml
+++ b/APPLICATION/tng/buildspec.yml
@@ -30,7 +30,7 @@ images:
       path: Dockerfile
       scene:
         args: []
-        tags: [[2.9.0, latest]]
+        tags: [[2.9.1, latest]]
         registry: [*ACR_PROD]
       # 测试配置
       test_config: [*WORKSPACE, *PROJECT, *TEST_SUITE, *TEST_CONF, *TEST_CASE, *CLOUD_SERVER_TAG[0], '']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "rats-cert"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "anyhow",
  "as-any",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "tng"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "again",
  "anyhow",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "tng-hook-cdylib"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "atty",
  "ctor",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "tng-hook-types"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "cidr",
  "local-ip-address",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "tng-testsuite"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "again",
  "anyhow",
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "tng-wasm"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = ["Kun Lai <laikun@linux.alibaba.com>"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/inclavare-containers/tng"
-version = "2.9.0"
+version = "2.9.1"
 
 [workspace.dependencies]
 again = "0.1.2"

--- a/tng-python/pyproject.toml
+++ b/tng-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tng-sdk"
-version = "2.9.0"
+version = "2.9.1"
 description = "TNG (Trusted Network Gateway) Python SDK — encrypted HTTP requests with remote attestation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/trusted-network-gateway.spec
+++ b/trusted-network-gateway.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: trusted-network-gateway
-Version: 2.9.0
+Version: 2.9.1
 Release: 1%{?dist}
 Summary: Trusted Network Gateway
 Group: Applications/System
@@ -85,6 +85,18 @@ install -p -m 755 %{_builddir}/%{name}-%{version}/src/target/release/libtng_hook
 
 
 %changelog
+* Fri Sep 04 2026 Kun Lai <laikun@linux.alibaba.com> - 2.9.1-1
+- test(log): add integration test for JSON, rolling, and flush-on-exit
+- feat(log): add size-based rolling with per-pid hook files and exit flush
+- feat(log): add JSON output format for the tng binary and hook cdylib
+- docs(claude): add persistent-text writing style rules
+- log: redact secrets and plaintext from logs
+- docs(configuration): fix config-field mismatches between docs and implementation
+- docs(scenarios): fix use-case title numbering to match directory order
+- docs: fix broken scenario cross-links and sync Chinese README Quick Start
+- test(testsuite): resolve nip.io peer hostnames via /etc/hosts for no-DNS envs
+- docs(skill): add release-version project skill
+
 * Mon Aug 31 2026 Kun Lai <laikun@linux.alibaba.com> - 2.9.0-1
 - feat(transparency_log): optional publishedMeasurements + doc clarification
 - refactor(transparency_log): split trust vector for granular failure diagnostics


### PR DESCRIPTION
Patch release bump from 2.9.0 to 2.9.1. Regenerates version info across Cargo.toml, Cargo.lock, buildspec.yml, pyproject.toml, and the RPM spec via make bump-version-patch.