### PR TITLE
ci(wasm): stop tag-triggered GitHub Pages deployments

### DIFF
--- a/.github/workflows/build-wasm-sdk.yml
+++ b/.github/workflows/build-wasm-sdk.yml
@@ -271,7 +271,6 @@ jobs:
       github.repository == 'inclavare-containers/TNG' &&
       (
         github.ref == 'refs/heads/master' ||
-        startsWith(github.ref, 'refs/tags/') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What & why

Pushing a release tag (e.g. `v2.9.1`) triggered the `deploy-pages` job in `build-wasm-sdk.yml`, but that job deploys to the `github-pages` environment, whose protection rules reject tags — so every release tag failed CI with:

> Tag "v2.9.1" is not allowed to deploy to github-pages due to environment protection rules.

On top of that, tag and master deployments share the `pages` concurrency group, so a tag deploy would cancel/overwrite a master deploy anyway.

## Change

Restrict the `deploy-pages` job's `if` to master pushes and manual `workflow_dispatch`:

```diff
   if: >-
     github.repository == 'inclavare-containers/TNG' &&
     (
       github.ref == 'refs/heads/master' ||
-      startsWith(github.ref, 'refs/tags/') ||
       github.event_name == 'workflow_dispatch'
     )
```

Tag releases still build the wasm SDK and publish to npm / GitHub Packages as before; only the Pages deployment is skipped. To update the live demo for a release, run the workflow manually via `workflow_dispatch`.