### PR TITLE
log: datagram UDS for hook-log centralization + integration tests

### DIFF
--- a/tng-hook/cdylib/src/lib.rs
+++ b/tng-hook/cdylib/src/lib.rs
@@ -1,8 +1,8 @@
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::os::raw::c_void;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
-use std::os::unix::net::UnixStream;
+use std::os::unix::net::UnixDatagram;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use libc::{c_int, size_t, sockaddr, socklen_t, ssize_t};
@@ -67,31 +67,22 @@ unsafe fn resolve_libc_symbol<T>(name: &str) -> Option<T> {
     }
 }
 
-/// Per-connection state for the centralized socket sink. `pending` holds the
-/// unsent tail of at most one partially-written frame. Because framing is
-/// length-prefixed with no resync marker, the writer must never leave a
-/// half-frame on the wire: a partial is either completed on the next event or
-/// dropped at cdylib exit (and the collector's `FrameDecoder::drain_partial`
-/// handles a truncated final frame on EOF). One pending frame bounds memory.
-struct ConnState {
-    stream: UnixStream,
-    pending: Option<Vec<u8>>,
-}
+/// A shared, mutex-guarded datagram socket connected to the collector's
+/// abstract-namespace socket. One `Conn` is reused across both the Info and
+/// Error sinks when both streams carry the same socket name (the route byte
+/// demuxes on the collector). A datagram socket carries no per-connection
+/// state — a `send` is atomic, so there is no pending tail to track — so
+/// `Conn` is just the socket.
+type Conn = Arc<Mutex<UnixDatagram>>;
 
-/// A shared, mutex-guarded connection to the collector's abstract-namespace
-/// socket. One `Conn` is reused across both the Info and Error sinks when
-/// both streams carry the same socket name (route byte demuxes on the
-/// collector).
-type Conn = Arc<Mutex<ConnState>>;
-
-/// Where a hook log line goes: an abstract-namespace UDS to the `tng exec`
-/// collector (`Socket`), a directly-appended file (`File`), or stderr
-/// (`Stderr`). `Socket` is the centralized path: the cdylib frames each
-/// record and streams it to the collector, which owns rolling/file rotation.
-/// `File`/`Stderr` are the non-centralized fallbacks.
+/// Where a hook log line goes: an abstract-namespace UDS datagram to the
+/// `tng exec` collector (`Socket`), a directly-appended file (`File`), or
+/// stderr (`Stderr`). `Socket` is the centralized path: the cdylib frames each
+/// record and sends it as one datagram to the collector, which owns
+/// rolling/file rotation. `File`/`Stderr` are the non-centralized fallbacks.
 #[derive(Clone)]
 enum SinkKind {
-    Socket(Arc<Mutex<ConnState>>),
+    Socket(Arc<Mutex<UnixDatagram>>),
     File(Arc<Mutex<std::fs::File>>),
     Stderr,
 }
@@ -115,11 +106,12 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for HookSink {
 }
 
 /// Per-event write handle. `Socket` buffers writes in memory and emits one
-/// framed record (`encode_frame`) on drop, so each tracing event becomes
-/// exactly one wire frame. `File`/`Stderr` write straight through (no
-/// framing), matching the old append/stderr behavior. The socket is
-/// non-blocking (set at connect time), so a stalled collector can never block
-/// the hooked host: `WouldBlock` and other I/O errors are swallowed.
+/// framed record (`encode_frame`) on drop as a single datagram, so each
+/// tracing event becomes exactly one datagram. `File`/`Stderr` write straight
+/// through (no framing), matching the old append/stderr behavior. The socket
+/// is non-blocking (set at connect time), so a stalled collector can never
+/// block the hooked host: a `WouldBlock` (buffer full) or other I/O error
+/// drops the datagram atomically rather than splitting it.
 struct HookSinkWriter {
     kind: SinkKind,
     route: Route,
@@ -140,8 +132,9 @@ impl Write for HookSinkWriter {
 
     fn flush(&mut self) -> io::Result<()> {
         match &self.kind {
-            // The buffered payload is framed and sent on Drop, not here: a
-            // mid-event `flush()` must not split one record into partial frames.
+            // The buffered payload is framed and sent as one datagram on Drop,
+            // not here: a mid-event `flush()` must not split one record into
+            // partial sends.
             SinkKind::Socket(_) => Ok(()),
             SinkKind::File(f) => f.lock().unwrap_or_else(|e| e.into_inner()).flush(),
             SinkKind::Stderr => std::io::stderr().flush(),
@@ -149,63 +142,16 @@ impl Write for HookSinkWriter {
     }
 }
 
-/// Try to flush a stuck partial tail (`pending`) non-blocking. Returns true
-/// when there is no pending tail left (it drained fully, there was none, or a
-/// dead stream made us drop it); false when `WouldBlock` left bytes still
-/// unflushed, in which case the caller must not send a new frame this round
-/// (the partial must complete first to keep the wire framed).
-fn drain_pending<W: Write>(stream: &mut W, pending: &mut Option<Vec<u8>>) -> bool {
-    let mut tail = match pending.take() {
-        Some(t) => t,
-        None => return true,
-    };
-    let mut written = 0;
-    while written < tail.len() {
-        match stream.write(&tail[written..]) {
-            Ok(0) => return true,
-            Ok(n) => written += n,
-            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                tail.drain(..written);
-                *pending = Some(tail);
-                return false;
-            }
-            Err(_) => return true,
-        }
-    }
-    true
-}
-
-/// Send a new `frame` non-blocking. Returns `Some(unsent_tail)` when a partial
-/// write left bytes unflushed (to store as the sole pending frame); `None`
-/// when the whole frame was sent or the stream is closed or errored (frame
-/// dropped). Never blocks.
-fn send_frame<W: Write>(stream: &mut W, frame: &[u8]) -> Option<Vec<u8>> {
-    let mut written = 0;
-    while written < frame.len() {
-        match stream.write(&frame[written..]) {
-            Ok(0) => return None,
-            Ok(n) => written += n,
-            Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
-            Err(_) => return None,
-        }
-    }
-    if written < frame.len() {
-        Some(frame[written..].to_vec())
-    } else {
-        None
-    }
-}
-
 impl HookSinkWriter {
-    /// Flush the in-memory buffer into one framed record on the socket. The
-    /// socket is non-blocking, so a stalled collector can never block the host
-    /// here. Drain ordering guarantees the wire only ever carries complete
-    /// frames mid-stream: (1) finish any pending tail first, and if it is
-    /// still stuck, drop this event's frame rather than queue behind it; (2)
-    /// otherwise send this frame, and a partial leaves the unsent tail as the
-    /// sole pending frame for the next round.
+    /// Flush the in-memory buffer into one framed datagram on the socket. A
+    /// connected datagram socket sends the whole frame atomically: it either
+    /// queues the complete datagram or fails (`WouldBlock` = the collector's
+    /// recv buffer is full, `EMSGSIZE` = too large, peer gone, etc.). On any
+    /// failure the datagram is dropped — lossy by design, so a stalled
+    /// collector can never block the hooked host and never leaves a partial
+    /// frame on the wire.
     fn flush_frame(&mut self) {
-        let SinkKind::Socket(conn) = &self.kind else {
+        let SinkKind::Socket(sock) = &self.kind else {
             return;
         };
         if self.buf.is_empty() {
@@ -213,15 +159,10 @@ impl HookSinkWriter {
         }
         let frame = encode_frame(self.route, &self.buf);
         self.buf.clear();
-        // Bind a `&mut ConnState` so the disjoint `stream`/`pending` field
-        // borrows below are accepted (disjoint borrows do not propagate
-        // through `MutexGuard`'s `DerefMut`).
-        let mut guard = conn.lock().unwrap_or_else(|e| e.into_inner());
-        let state = &mut *guard;
-        if !drain_pending(&mut state.stream, &mut state.pending) {
-            return;
-        }
-        state.pending = send_frame(&mut state.stream, &frame);
+        let guard = sock.lock().unwrap_or_else(|e| e.into_inner());
+        // `send` on a connected datagram socket is atomic; `Ok` means the whole
+        // frame was queued, any error means it was dropped. Never blocks.
+        let _ = guard.send(&frame);
     }
 }
 
@@ -306,25 +247,27 @@ fn resolve_connections<C: Fn(&str) -> io::Result<Conn>>(
 }
 
 /// Connect to the `tng exec` log collector over an abstract-namespace Unix
-/// domain socket (`\0<name>`). Abstract namespaces avoid filesystem path
-/// collisions and need no cleanup. The socket is set non-blocking before the
-/// fd is handed to `UnixStream`, so a collector that stalls can never block the
-/// hooked process's log path.
-fn connect_hook_socket(name: &str) -> io::Result<Arc<Mutex<ConnState>>> {
-    let sock = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None)?;
+/// domain **datagram** socket (`\0<name>`). Abstract namespaces avoid
+/// filesystem path collisions and need no cleanup. The socket is set
+/// non-blocking before the fd is handed to `UnixDatagram`, so a collector that
+/// stalls can never block the hooked process's log path: a full recv buffer
+/// surfaces as `WouldBlock` on `send` and the datagram is dropped.
+fn connect_hook_socket(name: &str) -> io::Result<Arc<Mutex<UnixDatagram>>> {
+    let sock = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::DGRAM, None)?;
     let addr = socket2::SockAddr::unix(std::path::Path::new(&format!("\0{}", name)))?;
+    // `connect` on a datagram socket fixes the default peer so `send` needs no
+    // destination per write. It routes through this library's own intercepted
+    // `connect`, which passes AF_UNIX sockets through to the real connect, so
+    // REAL_CONNECT must already be resolved (the caller does so first).
     sock.connect(&addr)?;
     sock.set_nonblocking(true)?;
-    // socket2 has no `From<Socket>` for `UnixStream`; convert via the raw fd.
+    // socket2 has no `From<Socket>` for `UnixDatagram`; convert via the raw fd.
     // The non-blocking flag set above persists on the fd.
     let fd = sock.into_raw_fd();
-    // SAFETY: `fd` is a valid, connected, non-blocking UNIX socket we just
-    // created; `into_raw_fd` transferred ownership to us.
-    let stream = unsafe { UnixStream::from_raw_fd(fd) };
-    Ok(Arc::new(Mutex::new(ConnState {
-        stream,
-        pending: None,
-    })))
+    // SAFETY: `fd` is a valid, connected, non-blocking UNIX datagram socket we
+    // just created; `into_raw_fd` transferred ownership to us.
+    let dgram = unsafe { UnixDatagram::from_raw_fd(fd) };
+    Ok(Arc::new(Mutex::new(dgram)))
 }
 
 /// Initialize the library at load time.
@@ -1061,143 +1004,77 @@ mod tests {
 #[cfg(test)]
 mod sink_tests {
     use super::*;
-    use std::io::{Read, Write};
-    use tng_hook_types::{encode_frame, FrameDecoder, Route};
+    use std::io::Write;
+    use tng_hook_types::{decode_frame, Route};
 
     #[test]
-    fn socket_kind_buffers_and_frames_one_frame_per_writer_drop() {
-        // Socket kind with a real stream: use a socketpair to capture bytes.
-        let (mut a, b) = UnixStream::pair().unwrap();
+    fn socket_kind_buffers_and_sends_one_datagram_per_writer_drop() {
+        // Socket kind with a real datagram pair: send on b (the writer's
+        // connected socket), recv on a.
+        let (a, b) = UnixDatagram::pair().unwrap();
         b.set_nonblocking(true).unwrap();
-        let conn = Arc::new(Mutex::new(ConnState {
-            stream: b,
-            pending: None,
-        }));
+        let sock = Arc::new(Mutex::new(b));
         {
             let mut w = HookSinkWriter {
-                kind: SinkKind::Socket(conn.clone()),
+                kind: SinkKind::Socket(sock.clone()),
                 route: Route::Info,
                 buf: Vec::new(),
             };
             w.write_all(b"hello ").unwrap();
             w.write_all(b"world\n").unwrap();
-            // drop -> one frame
+            // drop -> flush_frame sends exactly one datagram (one complete frame)
         }
-        // Close the write end so read_to_end sees EOF; the outer `conn` still
-        // holds b, so without this drop the read would block forever.
-        drop(conn);
-        let mut bytes = Vec::new();
-        a.read_to_end(&mut bytes).unwrap();
-        let mut d = FrameDecoder::new();
-        d.push(&bytes);
-        let (route, payload) = d.next_frame().unwrap().unwrap();
+        // The Arc still holds b; recv on a gets the single datagram.
+        let mut buf = vec![0u8; 256];
+        let n = a.recv(&mut buf).unwrap();
+        let (route, payload) = decode_frame(&buf[..n]).expect("one complete frame");
         assert_eq!(route, Route::Info);
         assert_eq!(payload, b"hello world\n");
-        assert!(d.next_frame().is_none());
     }
 
-    /// A writer that accepts up to `budget` total bytes, then returns
-    /// `WouldBlock` (models a full kernel send buffer). The test raises the
-    /// budget to simulate the collector draining.
-    struct BudgetWriter {
-        out: Vec<u8>,
-        budget: usize,
-        written: usize,
-    }
-
-    impl Write for BudgetWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            if self.written >= self.budget {
-                return Err(io::Error::new(ErrorKind::WouldBlock, "send buffer full"));
-            }
-            let n = std::cmp::min(buf.len(), self.budget - self.written);
-            self.out.extend_from_slice(&buf[..n]);
-            self.written += n;
-            Ok(n)
+    /// `flush_frame` must never panic or block when `send` fails: the lossy
+    /// contract drops the datagram and returns. A connected datagram socket
+    /// whose peer has been dropped surfaces an error on the next send
+    /// (ECONNREFUSED / EPIPE); `let _ = send` swallows it and the writer
+    /// drops cleanly. A subsequent event on a fresh working socket still sends,
+    /// proving the failed send left no corrupted shared state.
+    #[test]
+    fn socket_kind_drops_frame_silently_on_send_failure() {
+        // First prove the lossy contract: a writer whose socket cannot deliver
+        // drops cleanly with no panic and no hang.
+        let (a, b) = UnixDatagram::pair().unwrap();
+        b.set_nonblocking(true).unwrap();
+        drop(a); // peer gone -> sends on b error
+                 // Let the kernel tear down the peer so the async error surfaces on send.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let dead = Arc::new(Mutex::new(b));
+        {
+            let mut w = HookSinkWriter {
+                kind: SinkKind::Socket(dead.clone()),
+                route: Route::Info,
+                buf: Vec::new(),
+            };
+            w.write_all(b"doomed\n").unwrap();
+            // drop -> flush_frame -> send errors -> swallowed; must NOT panic/hang.
         }
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
+        drop(dead);
+
+        // A fresh working socket still sends exactly one datagram per event.
+        let (a2, b2) = UnixDatagram::pair().unwrap();
+        b2.set_nonblocking(true).unwrap();
+        let sock = Arc::new(Mutex::new(b2));
+        {
+            let mut w = HookSinkWriter {
+                kind: SinkKind::Socket(sock.clone()),
+                route: Route::Info,
+                buf: Vec::new(),
+            };
+            w.write_all(b"survived\n").unwrap();
         }
-    }
-
-    /// A partial first send must leave the unsent tail as `pending` instead of
-    /// writing a truncated length-prefixed frame that would desync the
-    /// collector. The wire only carries the bytes that actually went out.
-    #[test]
-    fn send_frame_partial_leaves_unsent_tail_as_pending() {
-        let frame = encode_frame(Route::Info, b"hello world\n"); // 17 bytes
-        let mut w = BudgetWriter {
-            out: Vec::new(),
-            budget: 3,
-            written: 0,
-        };
-        let pending = send_frame(&mut w, &frame);
-        assert_eq!(pending.as_deref(), Some(&frame[3..]));
-        // Only the first 3 bytes hit the wire; the rest is pending, so no
-        // complete valid frame is decodable yet (no desync).
-        assert_eq!(w.out, &frame[..3]);
-        let mut d = FrameDecoder::new();
-        d.push(&w.out);
-        assert!(
-            !matches!(d.next_frame(), Some(Ok(_))),
-            "partial bytes must not decode to a valid frame (would desync)"
-        );
-    }
-
-    /// When the collector drains (budget raised), the pending tail is flushed
-    /// and the frame completes. The reassembled wire bytes decode to the
-    /// original full frame.
-    #[test]
-    fn drain_pending_completes_truncated_frame_after_drain() {
-        let frame = encode_frame(Route::Info, b"hello world\n");
-        let mut w = BudgetWriter {
-            out: Vec::new(),
-            budget: 3,
-            written: 0,
-        };
-        // First event: partial -> pending = frame[3..].
-        let mut pending = send_frame(&mut w, &frame);
-        assert_eq!(pending.as_deref(), Some(&frame[3..]));
-        // Collector drained: raise the budget so the tail can flush fully.
-        w.budget = frame.len() + 10;
-        let fully_drained = drain_pending(&mut w, &mut pending);
-        assert!(fully_drained);
-        assert!(pending.is_none());
-        // The wire now has the complete frame and decodes cleanly.
-        assert_eq!(w.out, &frame[..]);
-        let mut d = FrameDecoder::new();
-        d.push(&w.out);
-        let (route, payload) = d.next_frame().unwrap().unwrap();
-        assert_eq!(route, Route::Info);
-        assert_eq!(payload, b"hello world\n");
-        assert!(d.next_frame().is_none());
-    }
-
-    /// If the pending tail still cannot fully drain (EAGAIN mid-tail), the
-    /// remaining bytes stay pending and the partially-flushed bytes are on
-    /// the wire (still no complete frame, still no desync).
-    #[test]
-    fn drain_pending_eagain_keeps_remaining_tail() {
-        let frame = encode_frame(Route::Info, b"hello world\n"); // 17 bytes
-                                                                 // 14-byte pending tail (frame[3..]) with a 5-byte budget.
-        let mut pending = Some(frame[3..].to_vec());
-        let mut w = BudgetWriter {
-            out: Vec::new(),
-            budget: 5,
-            written: 0,
-        };
-        let fully_drained = drain_pending(&mut w, &mut pending);
-        assert!(!fully_drained);
-        // 5 of 14 bytes drained; the remaining 9 stay pending.
-        assert_eq!(pending.as_deref(), Some(&frame[3 + 5..]));
-        assert_eq!(w.out, &frame[3..3 + 5]);
-        // Still no complete valid frame decodable from the partial bytes.
-        let mut d = FrameDecoder::new();
-        d.push(&w.out);
-        assert!(
-            !matches!(d.next_frame(), Some(Ok(_))),
-            "partial bytes must not decode to a valid frame (would desync)"
-        );
+        let mut buf = vec![0u8; 256];
+        let n = a2.recv(&mut buf).unwrap();
+        let (_route, payload) = decode_frame(&buf[..n]).expect("one complete frame");
+        assert_eq!(payload, b"survived\n");
     }
 
     #[test]
@@ -1223,22 +1100,20 @@ mod sink_tests {
     }
 
     /// Both an Info and an Error `HookSinkWriter` sharing one
-    /// `Arc<Mutex<ConnState>>` (the single shared socket the cdylib opens when
-    /// both streams are centralized) must frame each event independently with
-    /// its own route tag. Interleaved drops produce a byte stream a real
-    /// `FrameDecoder` reassembles into two correctly-tagged frames. Guards
-    /// against a regression that reuses a single route for both streams.
+    /// `Arc<Mutex<UnixDatagram>>` (the single shared socket the cdylib opens
+    /// when both streams are centralized) must frame each event independently
+    /// with its own route tag, as separate datagrams. Interleaved drops
+    /// produce three datagrams a `decode_frame` decodes into three
+    /// correctly-tagged records. Guards against a regression that reuses a
+    /// single route for both streams.
     #[test]
     fn shared_socket_dual_route_frames_independently() {
-        let (mut a, b) = UnixStream::pair().unwrap();
+        let (a, b) = UnixDatagram::pair().unwrap();
         b.set_nonblocking(true).unwrap();
-        let conn = Arc::new(Mutex::new(ConnState {
-            stream: b,
-            pending: None,
-        }));
+        let conn: Conn = Arc::new(Mutex::new(b));
 
         // Interleave drops: Info writer, then Error writer, then another Info,
-        // all on the same shared connection.
+        // all on the same shared socket.
         {
             let mut w = HookSinkWriter {
                 kind: SinkKind::Socket(conn.clone()),
@@ -1246,7 +1121,7 @@ mod sink_tests {
                 buf: Vec::new(),
             };
             w.write_all(b"info-1\n").unwrap();
-            // drop -> one Info frame
+            // drop -> one Info datagram
         }
         {
             let mut w = HookSinkWriter {
@@ -1255,7 +1130,7 @@ mod sink_tests {
                 buf: Vec::new(),
             };
             w.write_all(b"error-1\n").unwrap();
-            // drop -> one Error frame
+            // drop -> one Error datagram
         }
         {
             let mut w = HookSinkWriter {
@@ -1264,33 +1139,32 @@ mod sink_tests {
                 buf: Vec::new(),
             };
             w.write_all(b"info-2\n").unwrap();
-            // drop -> one Info frame
+            // drop -> one Info datagram
         }
-        // Release the write end so read_to_end sees EOF.
         drop(conn);
 
-        let mut bytes = Vec::new();
-        a.read_to_end(&mut bytes).unwrap();
+        // Each datagram is one independently-framed record; recv three times.
+        let mut buf = vec![0u8; 256];
+        let mut decoded = Vec::new();
+        for _ in 0..3 {
+            let n = a.recv(&mut buf).unwrap();
+            let (r, p) = decode_frame(&buf[..n]).expect("one complete frame");
+            decoded.push((r, p.to_vec()));
+        }
 
-        let mut d = FrameDecoder::new();
-        d.push(&bytes);
-        let (r1, p1) = d.next_frame().unwrap().expect("frame 1 ok");
-        let (r2, p2) = d.next_frame().unwrap().expect("frame 2 ok");
-        let (r3, p3) = d.next_frame().unwrap().expect("frame 3 ok");
-        assert!(d.next_frame().is_none());
-
-        assert_eq!(r1, Route::Info);
-        assert_eq!(p1, b"info-1\n");
-        assert_eq!(r2, Route::Error);
-        assert_eq!(p2, b"error-1\n");
-        assert_eq!(r3, Route::Info);
-        assert_eq!(p3, b"info-2\n");
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0].0, Route::Info);
+        assert_eq!(decoded[0].1, b"info-1\n");
+        assert_eq!(decoded[1].0, Route::Error);
+        assert_eq!(decoded[1].1, b"error-1\n");
+        assert_eq!(decoded[2].0, Route::Info);
+        assert_eq!(decoded[2].1, b"info-2\n");
     }
 
     /// Mock connector for `resolve_connections`: counts how many times it is
     /// called, records the paths it was asked to connect, and returns a fresh
-    /// dummy `ConnState` (a real socketpair end, never read). The dedup logic
-    /// is pure modulo this callback, so this exercises it without any real
+    /// dummy `Conn` (a real datagram-pair end, never read). The dedup logic is
+    /// pure modulo this callback, so this exercises it without any real
     /// abstract-namespace socket.
     struct MockConnector {
         calls: usize,
@@ -1306,20 +1180,15 @@ mod sink_tests {
         }
     }
 
-    fn mock_connect(
-        state: &Mutex<MockConnector>,
-    ) -> impl Fn(&str) -> io::Result<Arc<Mutex<ConnState>>> + '_ {
+    fn mock_connect(state: &Mutex<MockConnector>) -> impl Fn(&str) -> io::Result<Conn> + '_ {
         move |path: &str| {
             let mut g = state.lock().unwrap();
             g.calls += 1;
             g.paths.push(path.to_string());
-            // A throwaway socketpair end satisfies `ConnState`'s `UnixStream`
-            // field; the unit test never reads it.
-            let (_a, b) = UnixStream::pair().unwrap();
-            Ok(Arc::new(Mutex::new(ConnState {
-                stream: b,
-                pending: None,
-            })))
+            // A throwaway datagram-pair end satisfies `Conn`; the unit test
+            // never reads it.
+            let (_a, b) = UnixDatagram::pair().unwrap();
+            Ok(Arc::new(Mutex::new(b)))
         }
     }
 

--- a/tng-hook/types/src/lib.rs
+++ b/tng-hook/types/src/lib.rs
@@ -10,4 +10,4 @@ pub use ingress::{
 };
 pub use level_routing::{EitherWriter, LevelRoutingWriter};
 pub use log_format::LogFormat;
-pub use wire::{encode_frame, FrameDecoder, FrameError, Route};
+pub use wire::{decode_frame, encode_frame, FrameError, Route};

--- a/tng-hook/types/src/wire.rs
+++ b/tng-hook/types/src/wire.rs
@@ -1,27 +1,21 @@
 //! Wire format for hook log IPC.
 //!
-//! Each record on a hook connection is a length-prefixed, route-tagged frame:
+//! Each hook log record is **one Unix-domain datagram**:
 //!
 //! ```text
-//! +----------+------------+-----------------------------+
-//! | route:1  | len:4 (LE) | payload[len]                |
-//! +----------+------------+-----------------------------+
+//! +----------+-----------------------------+
+//! | route:1  | payload                     |
+//! +----------+-----------------------------+
 //! ```
 //!
 //! `route` selects the info vs error stream on the collector side; `payload`
-//! is the exact formatted log line. The 4-byte length gives clean per-record
-//! framing across `read()` boundaries. The collector buffers partial frames
-//! per connection; on EOF mid-frame the partial is dropped (a crashed hook
-//! truncates only its own last record).
+//! is the exact formatted log line. There is no length prefix: that was a
+//! stream-protocol artifact (a byte stream needs lengths to delimit records),
+//! and a datagram is self-delimiting — one `recv` yields exactly one record.
+//! Framing is atomic: one `send` on the cdylib side is one complete record,
+//! and a malformed datagram is dropped without desynchronizing the next one.
 
 use thiserror::Error;
-
-/// Frame header size: 1 route byte + 4 length bytes (little-endian).
-const HEADER_LEN: usize = 5;
-
-/// Guard against a malformed/garbage length field dragging the decoder into an
-/// unbounded allocation. 16 MiB is far above any single formatted log line.
-const MAX_PAYLOAD: u64 = 16 * 1024 * 1024;
 
 /// Frame route: which stream a payload belongs to. The numeric values are the
 /// on-the-wire bytes; do not renumber.
@@ -43,97 +37,35 @@ impl TryFrom<u8> for Route {
     }
 }
 
-/// Errors raised while parsing a frame.
+/// Errors raised while parsing a datagram.
 #[derive(Debug, Error)]
 pub enum FrameError {
+    /// The datagram has no route byte (zero-length datagram).
+    #[error("empty datagram has no route byte")]
+    Empty,
+
     /// The route byte is not a known `Route` variant.
     #[error("unknown route byte {0}")]
     BadRoute(u8),
-
-    /// The declared payload length exceeds `MAX_PAYLOAD`.
-    #[error("frame payload length {0} exceeds max {1}")]
-    TooLarge(u64, u64),
 }
 
-/// Encode a single frame: `[route:u8][len:u32 LE][payload]`.
-///
-/// The length field is `u32`, so a payload larger than `u32::MAX` would
-/// silently wrap and desync the decoder. Real formatted log lines are tiny, so
-/// this is a debug-only guard that documents the invariant the decoder relies
-/// on rather than a runtime check on a hot path.
+/// Encode one datagram: `[route:u8][payload]`.
 pub fn encode_frame(route: Route, payload: &[u8]) -> Vec<u8> {
-    debug_assert!(payload.len() <= u32::MAX as usize);
-    let mut out = Vec::with_capacity(HEADER_LEN + payload.len());
+    let mut out = Vec::with_capacity(1 + payload.len());
     out.push(route as u8);
-    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
     out.extend_from_slice(payload);
     out
 }
 
-/// Incremental frame parser. Feed bytes via `push`; pull decoded frames via
-/// `next_frame`. Partial frames are buffered until enough bytes arrive.
-pub struct FrameDecoder {
-    buf: Vec<u8>,
-}
-
-impl FrameDecoder {
-    pub fn new() -> Self {
-        Self { buf: Vec::new() }
+/// Decode one datagram. Returns the route and a borrow of the payload slice
+/// (everything after the route byte). On any error the whole datagram is
+/// rejected; the caller drops it and moves on to the next `recv`.
+pub fn decode_frame(buf: &[u8]) -> Result<(Route, &[u8]), FrameError> {
+    if buf.is_empty() {
+        return Err(FrameError::Empty);
     }
-
-    /// Append more bytes from a `read()` (may be a full frame, a partial
-    /// frame, or several frames at once).
-    pub fn push(&mut self, data: &[u8]) {
-        self.buf.extend_from_slice(data);
-    }
-
-    /// Try to decode the next complete frame from the buffered bytes.
-    ///
-    /// Returns `None` when no full frame is available yet. On a malformed
-    /// route or an oversized length, returns `Some(Err(..))` once and drops
-    /// the rest of the buffer: the stream is desynchronized, so trusting the
-    /// length field to skip past the bad frame is unsafe.
-    pub fn next_frame(&mut self) -> Option<Result<(Route, Vec<u8>), FrameError>> {
-        if self.buf.len() < HEADER_LEN {
-            return None;
-        }
-
-        let route = match Route::try_from(self.buf[0]) {
-            Ok(r) => r,
-            Err(e) => {
-                self.buf.clear();
-                return Some(Err(e));
-            }
-        };
-
-        let len = u32::from_le_bytes(self.buf[1..HEADER_LEN].try_into().unwrap()) as u64;
-        if len > MAX_PAYLOAD {
-            self.buf.clear();
-            return Some(Err(FrameError::TooLarge(len, MAX_PAYLOAD)));
-        }
-
-        let end = HEADER_LEN + len as usize;
-        if self.buf.len() < end {
-            // Partial payload: wait for more bytes.
-            return None;
-        }
-
-        let payload = self.buf[HEADER_LEN..end].to_vec();
-        self.buf.drain(..end);
-        Some(Ok((route, payload)))
-    }
-
-    /// Drop any buffered partial frame. Called on EOF so a truncated last
-    /// record does not leak into the next connection's decode state.
-    pub fn drain_partial(&mut self) {
-        self.buf.clear();
-    }
-}
-
-impl Default for FrameDecoder {
-    fn default() -> Self {
-        Self::new()
-    }
+    let route = Route::try_from(buf[0])?;
+    Ok((route, &buf[1..]))
 }
 
 #[cfg(test)]
@@ -143,104 +75,34 @@ mod tests {
     #[test]
     fn round_trip_single() {
         let frame = encode_frame(Route::Info, b"hello world\n");
-        let mut d = FrameDecoder::new();
-        d.push(&frame);
-        let (route, payload) = d.next_frame().expect("frame available").expect("frame ok");
+        let (route, payload) = decode_frame(&frame).expect("frame ok");
         assert_eq!(route, Route::Info);
         assert_eq!(payload, b"hello world\n");
-        assert!(d.next_frame().is_none());
-    }
-
-    #[test]
-    fn two_frames_one_chunk() {
-        let chunk = [
-            encode_frame(Route::Info, b"first\n").as_slice(),
-            encode_frame(Route::Error, b"second\n").as_slice(),
-        ]
-        .concat();
-        let mut d = FrameDecoder::new();
-        d.push(&chunk);
-
-        let (r1, p1) = d.next_frame().unwrap().unwrap();
-        assert_eq!(r1, Route::Info);
-        assert_eq!(p1, b"first\n");
-
-        let (r2, p2) = d.next_frame().unwrap().unwrap();
-        assert_eq!(r2, Route::Error);
-        assert_eq!(p2, b"second\n");
-
-        assert!(d.next_frame().is_none());
-    }
-
-    #[test]
-    fn frame_split_across_chunks() {
-        let frame = encode_frame(Route::Error, b"split payload");
-        // Split somewhere inside the header+payload, not at a frame boundary.
-        let split = 3;
-        let (a, b) = frame.split_at(split);
-
-        let mut d = FrameDecoder::new();
-        d.push(a);
-        // Not enough bytes yet.
-        assert!(d.next_frame().is_none());
-
-        d.push(b);
-        let (route, payload) = d.next_frame().unwrap().unwrap();
-        assert_eq!(route, Route::Error);
-        assert_eq!(payload, b"split payload");
-        assert!(d.next_frame().is_none());
-    }
-
-    #[test]
-    fn eof_mid_payload_drops_partial() {
-        let frame = encode_frame(Route::Info, b"complete payload");
-        // Feed only the header plus part of the payload: a truncated last record.
-        let partial = &frame[..HEADER_LEN + 3];
-        let mut d = FrameDecoder::new();
-        d.push(partial);
-        // No full frame yet.
-        assert!(d.next_frame().is_none());
-
-        // EOF: drop the partial so it does not leak into the next connection.
-        d.drain_partial();
-        assert!(d.next_frame().is_none());
     }
 
     #[test]
     fn bad_route_byte_is_error() {
         let mut frame = encode_frame(Route::Info, b"bad route");
         frame[0] = 0; // not a valid route
-        let mut d = FrameDecoder::new();
-        d.push(&frame);
-        match d.next_frame() {
-            Some(Err(FrameError::BadRoute(0))) => {}
+        match decode_frame(&frame) {
+            Err(FrameError::BadRoute(0)) => {}
             other => panic!("expected BadRoute(0), got {:?}", other),
         }
-        // The bad frame is consumed; the decoder does not re-yield it.
-        assert!(d.next_frame().is_none());
     }
 
-    /// A length field claiming more than `MAX_PAYLOAD` is rejected as
-    /// `TooLarge` rather than dragging the decoder into a huge allocation. The
-    /// decoder clears its buffer on the error (the stream is desynchronized).
     #[test]
-    fn oversized_length_is_too_large() {
-        let mut frame = encode_frame(Route::Info, b"small payload");
-        // Patch the 4 length bytes (offset 1..5) to claim 16 MiB + 1, which
-        // is one past `MAX_PAYLOAD`. The real payload bytes are irrelevant:
-        // the length check fires before the decoder waits for the full body.
-        let oversize: u32 = (MAX_PAYLOAD + 1) as u32;
-        frame[1..5].copy_from_slice(&oversize.to_le_bytes());
-        let mut d = FrameDecoder::new();
-        d.push(&frame);
-        match d.next_frame() {
-            Some(Err(FrameError::TooLarge(len, max))) => {
-                assert_eq!(len, MAX_PAYLOAD + 1);
-                assert_eq!(max, MAX_PAYLOAD);
-            }
-            other => panic!("expected TooLarge, got {:?}", other),
+    fn empty_datagram_is_error() {
+        match decode_frame(&[]) {
+            Err(FrameError::Empty) => {}
+            other => panic!("expected Empty, got {:?}", other),
         }
-        // Buffer is cleared after the error; no frame re-yields.
-        assert!(d.next_frame().is_none());
+    }
+
+    #[test]
+    fn empty_payload_round_trips() {
+        let frame = encode_frame(Route::Error, b"");
+        let (route, payload) = decode_frame(&frame).expect("frame ok");
+        assert_eq!(route, Route::Error);
+        assert!(payload.is_empty());
     }
 }

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -295,3 +295,8 @@ name = "log_error_routing"
 path = "tests/hook/log_error_routing.rs"
 required-features = ["on-bin"]
 
+[[test]]
+name = "log_centralization_subprocess"
+path = "tests/hook/log_centralization_subprocess.rs"
+required-features = ["on-bin"]
+

--- a/tng-testsuite/Cargo.toml
+++ b/tng-testsuite/Cargo.toml
@@ -300,3 +300,8 @@ name = "log_centralization_subprocess"
 path = "tests/hook/log_centralization_subprocess.rs"
 required-features = ["on-bin"]
 
+[[test]]
+name = "log_rolling"
+path = "tests/hook/log_rolling.rs"
+required-features = ["on-bin"]
+

--- a/tng-testsuite/tests/hook/log_centralization_subprocess.rs
+++ b/tng-testsuite/tests/hook/log_centralization_subprocess.rs
@@ -1,0 +1,475 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::fs;
+use tempfile::TempDir;
+use tng_testsuite::{
+    run_test,
+    task::{
+        shell::{ShellMode, ShellTask},
+        tng::{TngExecTask, TngInstance},
+        NodeType, Task,
+    },
+};
+
+use serial_test::serial;
+
+/// Marker the hook cdylib emits from its `#[ctor::ctor]` init. Finding it in
+/// the main `info.log` proves a cdylib instance's logs flowed through the
+/// collector (the `.so` is LD_PRELOAD'd only into the child, never the main
+/// `tng` process).
+const HOOK_INIT_MARKER: &str = "tng-hook: initialized";
+
+/// Marker the hook emits per successful hooked connect (connect interception →
+/// tunnel established). Finding it in `info.log` proves the connect
+/// interception's INFO event flushed through the datagram sink (`libc::send`,
+/// un-intercepted) to the collector without recursion or deadlock.
+const TUNNEL_MARKER: &str = "tunnel established";
+
+/// Threaded echo server on `port` (Server node), backgrounded for the test's
+/// lifetime. One thread per connection so concurrent clients are handled in
+/// parallel.
+fn echo_server(port: u16) -> Box<dyn Task> {
+    let script = format!(
+        r#"
+python3 -c '
+import socket, threading
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", {port}))
+s.listen(16)
+def handle(c):
+    try:
+        d = c.recv(4096)
+        if d:
+            c.sendall(d)
+    finally:
+        c.close()
+while True:
+    conn, _ = s.accept()
+    threading.Thread(target=handle, args=(conn,), daemon=True).start()
+' &
+sleep 120
+"#
+    );
+    ShellTask {
+        name: "echo server".to_owned(),
+        node_type: NodeType::Server,
+        script,
+        mode: ShellMode::BackgroundContinue,
+    }
+    .boxed()
+}
+
+/// Assert centralization + anomaly invariants on `info` / `error` after a
+/// `tng exec` run that exercises the hook:
+///
+/// - Both files are the only entries in the tempdir (no per-pid files).
+/// - Every non-blank line in both files is valid JSON.
+/// - Disjoint routing: `info.log` holds no ERROR-level record (ERROR+ goes to
+///   `error.log` only); `error.log` holds only ERROR-level records.
+/// - No panic/stack-trace markers leaked into either file.
+/// - Hook INFO markers never leaked into `error.log`.
+fn assert_logs_ok(dir: &TempDir, info: &std::path::Path, error: &std::path::Path) {
+    let info_contents = fs::read_to_string(info).unwrap_or_else(|e| panic!("read info.log: {e}"));
+    assert!(
+        !info_contents.trim().is_empty(),
+        "{:?} is empty (flush on exit failed?)",
+        info
+    );
+    // No panic / stack-trace markers: a cdylib or main-process panic would
+    // surface here as an anomaly.
+    assert!(
+        !info_contents.contains("panicked"),
+        "panic marker found in info.log:\n{}",
+        info_contents
+    );
+    for (i, line) in info_contents.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let obj: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("{:?}:{} not JSON: {} — {}", info, i, e, line));
+        let level = obj
+            .get("level")
+            .and_then(|v| v.as_str())
+            .unwrap_or("UNKNOWN");
+        assert_ne!(
+            level, "ERROR",
+            "ERROR-level line leaked into info.log (disjoint routing broken): {}",
+            line
+        );
+    }
+
+    assert!(
+        error.exists(),
+        "error.log should be created when --log-error-file is set"
+    );
+    let error_contents = fs::read_to_string(error).unwrap_or_default();
+    assert!(
+        !error_contents.contains("panicked"),
+        "panic marker found in error.log:\n{}",
+        error_contents
+    );
+    // Hook INFO must never leak into the error file.
+    assert!(
+        !error_contents.contains(HOOK_INIT_MARKER),
+        "hook INFO leaked into error.log; level routing broken"
+    );
+    assert!(
+        !error_contents.contains(TUNNEL_MARKER),
+        "hook tunnel-established INFO leaked into error.log; level routing broken"
+    );
+    for line in error_contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let obj: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("error.log not JSON: {} — {}", e, line));
+        let level = obj
+            .get("level")
+            .and_then(|v| v.as_str())
+            .unwrap_or("UNKNOWN");
+        assert_eq!(
+            level, "ERROR",
+            "non-ERROR line leaked into error.log (should be ERROR-only): {}",
+            line
+        );
+    }
+
+    // No per-pid hook files: centralization means the cdylib never opens its
+    // own pid-derived file, so the tempdir holds exactly the two merged logs.
+    let mut names: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().into_string().unwrap_or_default())
+        .collect();
+    names.sort();
+    let mut expected = vec!["error.log.tng".to_string(), "info.log.tng".to_string()];
+    expected.sort();
+    assert_eq!(
+        names, expected,
+        "expected only merged info.log.tng + error.log.tng; per-pid files present: {:?}",
+        names
+    );
+}
+
+/// Recursion / no-deadlock smoke test: a shell-script target spawns ONE
+/// subprocess (python — a grandchild of `tng exec`) that makes MANY real
+/// hooked connects. Each connect runs the cdylib's `connect` interception,
+/// which emits an INFO event that flushes via the datagram sink (`libc::send`)
+/// to the collector. If the UDS path recursed into the hook's intercepted
+/// `connect`/`sendto`, or deadlocked on the per-conn mutex, the very first
+/// connect would hang or crash. Completing the run + finding the
+/// tunnel-established marker in `info.log` proves the connect→trace→send path
+/// is recursion-free over many iterations.
+///
+/// Requires `on-bin` (external tng binary + libtng_hook.so).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[serial]
+async fn hook_log_many_real_connects_no_recursion() -> Result<()> {
+    let dir = TempDir::new()?;
+    let info = dir.path().join("info.log.tng");
+    let error = dir.path().join("error.log.tng");
+
+    let tasks: Vec<Box<dyn Task>> = vec![
+        echo_server(30010),
+        // Server side: egress forwards 0.0.0.0:20010 -> 127.0.0.1:30010 (echo).
+        TngInstance::TngServer(
+            r#"{
+                "add_egress": [{
+                    "mapping": {"in": {"host": "0.0.0.0", "port": 20010},
+                                 "out": {"host": "127.0.0.1", "port": 30010}},
+                    "no_ra": true
+                }]
+            }"#,
+        )
+        .boxed(),
+        // Client side: tng exec with ingress hook + centralized logs. The
+        // child is a shell script that runs one python (a grandchild of tng
+        // exec) making 30 real hooked connects to the captured, non-local
+        // 192.168.1.1:20010. Each connect retries briefly to ride out an
+        // echo-server readiness race at startup; a recursion/deadlock would
+        // hang past the per-task timeout regardless of retries.
+        TngExecTask::new(
+            r#"{
+                "add_ingress": [{
+                    "hook": {"capture_dst": [{"port": 20010}]},
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+python3 -c '
+import socket, time, sys
+def one():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect(("192.168.1.1", 20010))
+    s.sendall(b"ping")
+    s.shutdown(socket.SHUT_WR)
+    d = s.recv(4096)
+    s.close()
+    assert d == b"ping", f"expected ping, got: {d}"
+for i in range(30):
+    err = None
+    for a in range(5):
+        try:
+            one()
+            break
+        except Exception as e:
+            err = e
+            time.sleep(0.3)
+    else:
+        print(f"FAIL iter {i}: {err}")
+        sys.exit(1)
+print("OK: 30 hooked connects echoed")
+'
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Client,
+        )
+        .with_log_file(info.to_string_lossy().to_string())
+        .with_log_format("json")
+        .with_log_error_file(error.to_string_lossy().to_string())
+        .boxed(),
+    ];
+
+    run_test!(tasks).await?;
+
+    // Completing the run is the no-recursion proof (a recursion/deadlock would
+    // hang past the per-task timeout). The log content confirms the
+    // connect→trace→send path delivered to the collector, repeatedly.
+    let info_contents = fs::read_to_string(&info)?;
+    let tunnel_count = info_contents.matches(TUNNEL_MARKER).count();
+    assert!(
+        tunnel_count >= 20,
+        "expected >=20 '{}' lines in info.log (30 hooked connects), got {}; centralization or the hook send path is broken",
+        TUNNEL_MARKER,
+        tunnel_count
+    );
+    assert!(
+        info_contents.contains(HOOK_INIT_MARKER),
+        "info.log missing hook init line; centralization not wired"
+    );
+    assert_logs_ok(&dir, &info, &error);
+    Ok(())
+}
+
+/// Fork / multi-producer test: a shell-script target spawns FIVE concurrent
+/// subprocesses (fork+exec), each a grandchild of `tng exec`, each making a
+/// real hooked connect. Each fork+exec'd subprocess reloads the cdylib
+/// (`#[ctor::ctor]` re-runs), opens its OWN datagram socket to the single
+/// collector, and sends its hook logs there. If the datagram collector broke
+/// with multiple senders, or fork+exec didn't re-init the cdylib, the
+/// subprocesses' logs would vanish or the run would hang. Finding >=5 init
+/// lines + tunnel-established lines in `info.log` proves the 1-collector-fd,
+/// N-producer datagram model works under fork.
+///
+/// Requires `on-bin` (external tng binary + libtng_hook.so).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[serial]
+async fn hook_log_forked_subprocesses_merge_into_collector() -> Result<()> {
+    let dir = TempDir::new()?;
+    let info = dir.path().join("info.log.tng");
+    let error = dir.path().join("error.log.tng");
+
+    let tasks: Vec<Box<dyn Task>> = vec![
+        echo_server(30011),
+        TngInstance::TngServer(
+            r#"{
+                "add_egress": [{
+                    "mapping": {"in": {"host": "0.0.0.0", "port": 20011},
+                                 "out": {"host": "127.0.0.1", "port": 30011}},
+                    "no_ra": true
+                }]
+            }"#,
+        )
+        .boxed(),
+        // Client side: tng exec with ingress hook + centralized logs. The
+        // child shell script spawns 5 concurrent python subprocesses
+        // (grandchildren of tng exec), each making one hooked connect; it
+        // waits for all and exits non-zero if any failed. Each python is
+        // fork+exec'd, so the cdylib ctor re-runs and each connects its own
+        // datagram socket to the collector.
+        TngExecTask::new(
+            r#"{
+                "add_ingress": [{
+                    "hook": {"capture_dst": [{"port": 20011}]},
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+pids=""
+for i in 1 2 3 4 5; do
+  python3 -c '
+import socket, time, sys
+err = None
+for a in range(5):
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(5)
+        s.connect(("192.168.1.1", 20011))
+        s.sendall(b"hello")
+        s.shutdown(socket.SHUT_WR)
+        d = s.recv(4096)
+        s.close()
+        assert d == b"hello", f"expected hello, got: {d}"
+        print("OK")
+        sys.exit(0)
+    except Exception as e:
+        err = e
+        time.sleep(0.3)
+print(f"FAIL: {err}")
+sys.exit(1)
+' &
+  pids="$pids $!"
+done
+rc=0
+for p in $pids; do wait "$p" || rc=1; done
+exit $rc
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Client,
+        )
+        .with_log_file(info.to_string_lossy().to_string())
+        .with_log_format("json")
+        .with_log_error_file(error.to_string_lossy().to_string())
+        .boxed(),
+    ];
+
+    run_test!(tasks).await?;
+
+    // Completing the run (exit 0) proves no fork/deadlock failure. The log
+    // content proves each fork+exec'd grandchild re-init'd the cdylib AND
+    // reached the single collector through its own datagram socket.
+    let info_contents = fs::read_to_string(&info)?;
+    let init_count = info_contents.matches(HOOK_INIT_MARKER).count();
+    // 5 python grandchildren + the sh parent each re-init the cdylib (>=5
+    // proves multi-process; allows a lossy drop under the datagram lossy
+    // contract).
+    assert!(
+        init_count >= 5,
+        "expected >=5 '{}' lines in info.log (5 fork+exec'd grandchildren), got {}; fork+exec re-init or multi-producer collection is broken",
+        HOOK_INIT_MARKER,
+        init_count
+    );
+    assert!(
+        info_contents.contains(TUNNEL_MARKER),
+        "info.log missing hook tunnel-established line; centralization not wired under fork"
+    );
+    assert_logs_ok(&dir, &info, &error);
+    Ok(())
+}
+
+/// Deep-nesting / great-grandchild test: verifies `LD_PRELOAD` + the hook-log
+/// env contract propagate through TWO levels of fork+exec, and the
+/// great-grandchild's cdylib re-inits and reaches the collector.
+///
+/// Process tree: `tng exec` → `sh` (child) → `python3` A (grandchild, writes
+/// the connect script and spawns B) → `python3` B (great-grandchild, makes
+/// the hooked connect). Each exec reloads `libtng_hook.so`, so B's `#[ctor]`
+/// re-runs, opens its own datagram socket to the collector, and its init +
+/// tunnel-established records must land in `info.log`.
+///
+/// Requires `on-bin` (external tng binary + libtng_hook.so).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[serial]
+async fn hook_log_great_grandchild_reaches_collector() -> Result<()> {
+    let dir = TempDir::new()?;
+    let info = dir.path().join("info.log.tng");
+    let error = dir.path().join("error.log.tng");
+
+    let tasks: Vec<Box<dyn Task>> = vec![
+        echo_server(30012),
+        TngInstance::TngServer(
+            r#"{
+                "add_egress": [{
+                    "mapping": {"in": {"host": "0.0.0.0", "port": 20012},
+                                 "out": {"host": "127.0.0.1", "port": 30012}},
+                    "no_ra": true
+                }]
+            }"#,
+        )
+        .boxed(),
+        // Client side: tng exec with ingress hook + centralized logs. The
+        // child shell script writes a connect script to a temp file, then
+        // runs python3 A which spawns python3 B (great-grandchild of tng exec)
+        // to run it. B makes the real hooked connect.
+        TngExecTask::new(
+            r#"{
+                "add_ingress": [{
+                    "hook": {"capture_dst": [{"port": 20012}]},
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+cat > /tmp/tng_deep_conn.py <<'PYEOF'
+import socket, time, sys
+err = None
+for a in range(5):
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(5)
+        s.connect(("192.168.1.1", 20012))
+        s.sendall(b"deep")
+        s.shutdown(socket.SHUT_WR)
+        d = s.recv(4096)
+        s.close()
+        assert d == b"deep", f"expected deep, got: {d}"
+        print("OK deep")
+        sys.exit(0)
+    except Exception as e:
+        err = e
+        time.sleep(0.3)
+print(f"FAIL deep: {err}")
+sys.exit(1)
+PYEOF
+python3 -c 'import subprocess, sys; sys.exit(subprocess.run([sys.executable, "/tmp/tng_deep_conn.py"]).returncode)'
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Client,
+        )
+        .with_log_file(info.to_string_lossy().to_string())
+        .with_log_format("json")
+        .with_log_error_file(error.to_string_lossy().to_string())
+        .boxed(),
+    ];
+
+    run_test!(tasks).await?;
+
+    // The great-grandchild (python3 B) re-init'd the cdylib and reached the
+    // collector. >=3 init lines = sh + python3 A + python3 B (allows a lossy
+    // drop); the tunnel marker proves B's hooked connect flowed through.
+    let info_contents = fs::read_to_string(&info)?;
+    let init_count = info_contents.matches(HOOK_INIT_MARKER).count();
+    assert!(
+        init_count >= 3,
+        "expected >=3 '{}' lines in info.log (sh + python A + python B great-grandchild), got {}; deep fork+exec propagation broken",
+        HOOK_INIT_MARKER,
+        init_count
+    );
+    assert!(
+        info_contents.contains(TUNNEL_MARKER),
+        "info.log missing hook tunnel-established line; great-grandchild connect did not reach the collector"
+    );
+    assert_logs_ok(&dir, &info, &error);
+    Ok(())
+}

--- a/tng-testsuite/tests/hook/log_centralization_subprocess.rs
+++ b/tng-testsuite/tests/hook/log_centralization_subprocess.rs
@@ -25,6 +25,12 @@ const HOOK_INIT_MARKER: &str = "tng-hook: initialized";
 /// un-intercepted) to the collector without recursion or deadlock.
 const TUNNEL_MARKER: &str = "tunnel established";
 
+/// Marker the hook cdylib emits when it intercepts a server's `bind()` to a
+/// captured egress port and rewrites it to the real port (egress hook mode).
+/// Finding it in `info.log` proves the egress hook's bind interception ran
+/// in a subprocess and its log flowed through the collector.
+const EGRESS_BIND_MARKER: &str = "bind hijacked";
+
 /// Threaded echo server on `port` (Server node), backgrounded for the test's
 /// lifetime. One thread per connection so concurrent clients are handled in
 /// parallel.
@@ -469,6 +475,151 @@ python3 -c 'import subprocess, sys; sys.exit(subprocess.run([sys.executable, "/t
     assert!(
         info_contents.contains(TUNNEL_MARKER),
         "info.log missing hook tunnel-established line; great-grandchild connect did not reach the collector"
+    );
+    assert_logs_ok(&dir, &info, &error);
+    Ok(())
+}
+
+/// Egress multi-process test: a shell-script SERVER target spawns THREE
+/// subprocesses (grandchildren of `tng exec`), each an echo server that
+/// `bind()`s a different captured egress port. Each fork+exec'd subprocess
+/// re-inits the cdylib; its `bind()` is intercepted (`bind hijacked`) and
+/// that log flows through the collector into the server's `info.log`. Three
+/// TCP clients (over the client-side TNG ingress + tunnel) each echo through
+/// one server, proving the bind interception + tunnel still work under
+/// multi-process egress. The run completing exit-0 is the "correct work"
+/// proof; the log assertions cover multi-producer centralization + anomalies.
+///
+/// Requires `on-bin` (external tng binary + libtng_hook.so).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[serial]
+async fn hook_log_egress_multiprocess_centralized() -> Result<()> {
+    let dir = TempDir::new()?;
+    let info = dir.path().join("info.log.tng");
+    let error = dir.path().join("error.log.tng");
+
+    let tasks: Vec<Box<dyn Task>> = vec![
+        // Server side: tng exec with egress hook (captures bind to 20001/2/3)
+        // and centralized logs. The child shell script spawns 3 python echo
+        // servers (grandchildren), each binding a different captured port,
+        // accepting ONE connection, echoing, then exiting; the shell waits for
+        // all and exits non-zero if any failed. Each server handles exactly one
+        // connection (the client below connects once per port, retrying until
+        // the server is bound); stop_after_exit=true so the tng exec process
+        // exits gracefully after the shell (WorkerGuard drops -> flush).
+        TngExecTask::new(
+            r#"{
+                "add_egress": [{
+                    "hook": {"capture_listen": [{"port": 20001}, {"port": 20002}, {"port": 20003}]},
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+pids=""
+for p in 20001 20002 20003; do
+  python3 -c '
+import socket, sys
+port = int(sys.argv[1])
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", port))
+s.listen(5)
+c, _ = s.accept()
+d = c.recv(4096)
+if d:
+    c.sendall(d)
+c.close()
+s.close()
+' "$p" &
+  pids="$pids $!"
+done
+rc=0
+for pid in $pids; do wait "$pid" || rc=1; done
+exit $rc
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Server,
+        )
+        .with_log_file(info.to_string_lossy().to_string())
+        .with_log_format("json")
+        .with_log_error_file(error.to_string_lossy().to_string())
+        .boxed(),
+        // Client side: TNG client with one ingress mapping per server port.
+        TngInstance::TngClient(
+            r#"{
+                "add_ingress": [
+                    {"mapping": {"in": {"port": 10001}, "out": {"host": "192.168.1.1", "port": 20001}}, "no_ra": true},
+                    {"mapping": {"in": {"port": 10002}, "out": {"host": "192.168.1.1", "port": 20002}}, "no_ra": true},
+                    {"mapping": {"in": {"port": 10003}, "out": {"host": "192.168.1.1", "port": 20003}}, "no_ra": true}
+                ]
+            }"#,
+        )
+        .boxed(),
+        // One client (Client node) that connects to 10001/10002/10003 in turn,
+        // echoing through the tunnel. Each connect retries until the matching
+        // server's hook-rewritten bind is in place (readiness race); a failed
+        // connect does NOT abort the run the way a non-retrying TcpClient would.
+        ShellTask {
+            name: "egress client".to_owned(),
+            node_type: NodeType::Client,
+            script: r#"
+python3 -c '
+import socket, time, sys
+def echo(port, payload):
+    err = None
+    for _ in range(30):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(5)
+            s.connect(("127.0.0.1", port))
+            s.sendall(payload)
+            s.shutdown(socket.SHUT_WR)
+            d = s.recv(4096)
+            s.close()
+            assert d == payload, f"port {port}: expected {payload}, got: {d}"
+            return
+        except Exception as e:
+            err = e
+            time.sleep(0.2)
+    raise RuntimeError(f"port {port} failed after 30 attempts: {err}")
+echo(10001, b"egress-1")
+echo(10002, b"egress-2")
+echo(10003, b"egress-3")
+print("OK: 3 egress echoes through the tunnel")
+'
+"#
+            .to_owned(),
+            mode: ShellMode::ForegroundStop,
+        }
+        .boxed(),
+    ];
+
+    run_test!(tasks).await?;
+
+    // Completing the run (exit 0) proves the 3 server subprocesses each
+    // intercepted bind + echoed 5 connections through the tunnel. The log
+    // content proves each fork+exec'd server's bind-interception log reached
+    // the collector (multi-producer egress centralization).
+    let info_contents = fs::read_to_string(&info)?;
+    let bind_count = info_contents.matches(EGRESS_BIND_MARKER).count();
+    assert!(
+        bind_count >= 2,
+        "expected >=2 '{}' lines in info.log (3 egress server subprocesses), got {}; multi-process egress bind interception or centralization is broken",
+        EGRESS_BIND_MARKER,
+        bind_count
+    );
+    let init_count = info_contents.matches(HOOK_INIT_MARKER).count();
+    assert!(
+        init_count >= 3,
+        "expected >=3 '{}' lines in info.log (sh + 3 egress server grandchildren), got {}; fork+exec re-init broken on the egress side",
+        HOOK_INIT_MARKER,
+        init_count
     );
     assert_logs_ok(&dir, &info, &error);
     Ok(())

--- a/tng-testsuite/tests/hook/log_rolling.rs
+++ b/tng-testsuite/tests/hook/log_rolling.rs
@@ -1,0 +1,265 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::fs;
+use tempfile::TempDir;
+use tng_testsuite::{
+    run_test,
+    task::{
+        shell::{ShellMode, ShellTask},
+        tng::{TngExecTask, TngInstance},
+        NodeType, Task,
+    },
+};
+
+use serial_test::serial;
+
+/// Marker the hook cdylib emits from its `#[ctor::ctor]` init.
+const HOOK_INIT_MARKER: &str = "tng-hook: initialized";
+/// Marker the hook emits per successful hooked connect.
+const TUNNEL_MARKER: &str = "tunnel established";
+
+/// Threaded echo server on `port` (Server node), backgrounded for the test.
+fn echo_server(port: u16) -> Box<dyn Task> {
+    let script = format!(
+        r#"
+python3 -c '
+import socket, threading
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", {port}))
+s.listen(16)
+def handle(c):
+    try:
+        d = c.recv(4096)
+        if d:
+            c.sendall(d)
+    finally:
+        c.close()
+while True:
+    conn, _ = s.accept()
+    threading.Thread(target=handle, args=(conn,), daemon=True).start()
+' &
+sleep 120
+"#
+    );
+    ShellTask {
+        name: "echo server".to_owned(),
+        node_type: NodeType::Server,
+        script,
+        mode: ShellMode::BackgroundContinue,
+    }
+    .boxed()
+}
+
+/// Rolling-under-tng-exec integration test: with `--log-rolling` and a tiny
+/// `--log-max-size`, a run that produces enough hook + main log volume must
+/// rotate the active `info.log.tng` into numbered backups (`info.log.tng.1`
+/// .. `.N`, capped at `--log-max-backups`). The hook logs and the main
+/// process's access-log lines merge into the SAME rolling appender the main
+/// process owns (centralization + rolling together), so this also proves
+/// centralization keeps working through a rotation.
+///
+/// Assertions (correct work + log-content sanity):
+/// - The run completes exit-0 (the hook path still works under rolling).
+/// - At least one numbered backup exists (rotation actually happened).
+/// - No more than `max_backups` backups (the cap is enforced).
+/// - Every file in the tempdir is `info.log.tng*` or `error.log.tng*` (no
+///   pid-derived per-process files; centralization holds under rolling).
+/// - The active `info.log` is non-empty, valid JSON, has no ERROR-level line
+///   (disjoint), and no panic markers.
+/// - `error.log` exists, is ERROR-only, and has no hook INFO leaked.
+///
+/// Requires `on-bin` (external tng binary + libtng_hook.so).
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+#[serial]
+async fn hook_log_rolling_rotates_under_tng_exec() -> Result<()> {
+    let dir = TempDir::new()?;
+    let info = dir.path().join("info.log.tng");
+    let error = dir.path().join("error.log.tng");
+    const MAX_BACKUPS: usize = 5;
+
+    let tasks: Vec<Box<dyn Task>> = vec![
+        echo_server(30020),
+        // Server side: egress forwards 0.0.0.0:20020 -> 127.0.0.1:30020 (echo).
+        TngInstance::TngServer(
+            r#"{
+                "add_egress": [{
+                    "mapping": {"in": {"host": "0.0.0.0", "port": 20020},
+                                 "out": {"host": "127.0.0.1", "port": 30020}},
+                    "no_ra": true
+                }]
+            }"#,
+        )
+        .boxed(),
+        // Client side: tng exec with ingress hook + rolling logs. A tiny
+        // max-size forces rotation from a modest number of hook + main log
+        // lines. The child loops 30 real hooked connects, each emitting a
+        // tunnel-established (hook) + an ingress access-log (main) line, enough
+        // to rotate several times. Each connect retries briefly to ride out
+        // an echo-server readiness race.
+        TngExecTask::new(
+            r#"{
+                "add_ingress": [{
+                    "hook": {"capture_dst": [{"port": 20020}]},
+                    "no_ra": true
+                }]
+            }"#
+            .to_string(),
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                r#"
+python3 -c '
+import socket, time, sys
+def one():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect(("192.168.1.1", 20020))
+    s.sendall(b"ping")
+    s.shutdown(socket.SHUT_WR)
+    d = s.recv(4096)
+    s.close()
+    assert d == b"ping", f"expected ping, got: {d}"
+for i in range(30):
+    err = None
+    for a in range(5):
+        try:
+            one()
+            break
+        except Exception as e:
+            err = e
+            time.sleep(0.3)
+    else:
+        print(f"FAIL iter {i}: {err}")
+        sys.exit(1)
+print("OK: 30 hooked connects echoed")
+'
+"#
+                .to_string(),
+            ],
+            true,
+            NodeType::Client,
+        )
+        .with_log_file(info.to_string_lossy().to_string())
+        .with_log_format("json")
+        .with_log_rolling(true)
+        .with_log_max_size("1024")
+        .with_log_max_backups(MAX_BACKUPS)
+        .with_log_error_file(error.to_string_lossy().to_string())
+        .boxed(),
+    ];
+
+    run_test!(tasks).await?;
+
+    // Gather all info files (active info.log.tng + numbered backups
+    // info.log.tng.1..N) and concat their content. Under rolling the hook +
+    // main log lines are spread across the active file and the backups, so the
+    // presence/panic checks apply to the combined content and the JSON/level
+    // checks apply per file (each rotated fragment must still be valid JSON
+    // and disjoint).
+    let mut info_files: Vec<String> = fs::read_dir(dir.path())?
+        .map(|e| e.unwrap().file_name().into_string().unwrap_or_default())
+        .filter(|n| n == "info.log.tng" || n.starts_with("info.log.tng."))
+        .collect();
+    info_files.sort();
+    let combined_info: String = info_files
+        .iter()
+        .map(|n| fs::read_to_string(dir.path().join(n)).unwrap_or_default())
+        .collect();
+    assert!(
+        !combined_info.trim().is_empty(),
+        "no info.log content across active + backups (flush on exit failed?)"
+    );
+    assert!(
+        !combined_info.contains("panicked"),
+        "panic marker found in info.log (active + backups):\n{}",
+        combined_info
+    );
+    assert!(
+        combined_info.contains(TUNNEL_MARKER),
+        "info.log (active + backups) missing hook tunnel-established line; hook path broken under rolling"
+    );
+    for name in &info_files {
+        let content = fs::read_to_string(dir.path().join(name)).unwrap_or_default();
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let obj: Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("{name}: not JSON: {} — {}", e, line));
+            let level = obj
+                .get("level")
+                .and_then(|v| v.as_str())
+                .unwrap_or("UNKNOWN");
+            assert_ne!(
+                level, "ERROR",
+                "{name}: ERROR leaked into info.log (disjoint routing broken): {}",
+                line
+            );
+        }
+    }
+
+    // error.log sanity: exists, ERROR-only, no hook INFO leaked, no panic.
+    assert!(
+        error.exists(),
+        "error.log should be created when --log-error-file is set"
+    );
+    let error_contents = fs::read_to_string(&error).unwrap_or_default();
+    assert!(
+        !error_contents.contains("panicked"),
+        "panic marker found in error.log:\n{}",
+        error_contents
+    );
+    assert!(
+        !error_contents.contains(HOOK_INIT_MARKER) && !error_contents.contains(TUNNEL_MARKER),
+        "hook INFO leaked into error.log; level routing broken under rolling"
+    );
+    for line in error_contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let obj: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("error.log not JSON: {} — {}", e, line));
+        let level = obj
+            .get("level")
+            .and_then(|v| v.as_str())
+            .unwrap_or("UNKNOWN");
+        assert_eq!(
+            level, "ERROR",
+            "non-ERROR line leaked into error.log (should be ERROR-only): {}",
+            line
+        );
+    }
+
+    // Rotation: at least one numbered backup must exist; no more than
+    // max_backups; and every tempdir entry is info.log.tng* or error.log.tng*
+    // (no per-pid files -> centralization holds under rolling).
+    let mut names: Vec<String> = fs::read_dir(dir.path())?
+        .map(|e| e.unwrap().file_name().into_string().unwrap_or_default())
+        .collect();
+    names.sort();
+    let info_backups: Vec<&String> = names
+        .iter()
+        .filter(|n| n.starts_with("info.log.tng."))
+        .collect();
+    assert!(
+        !info_backups.is_empty(),
+        "expected >=1 rolling backup (info.log.tng.N); rotation did not happen. entries: {:?}",
+        names
+    );
+    assert!(
+        info_backups.len() <= MAX_BACKUPS,
+        "more than max_backups={MAX_BACKUPS} info backups: {:?}",
+        info_backups
+    );
+    for n in &names {
+        assert!(
+            n.starts_with("info.log.tng") || n.starts_with("error.log.tng"),
+            "unexpected file in tempdir (per-pid file? centralization broken under rolling): {}",
+            n
+        );
+    }
+    Ok(())
+}

--- a/tng/src/bin/tng/main.rs
+++ b/tng/src/bin/tng/main.rs
@@ -318,36 +318,6 @@ async fn main() -> anyhow::Result<()> {
                     }
                 };
 
-                // Raise RLIMIT_NOFILE to the hard limit so the hook-log
-                // collector's N (one fd per child) + O(1) file descriptors fit
-                // alongside the tunnel's own fds. Best-effort: a failure here
-                // only limits how many hook processes can be logged
-                // concurrently, so warn and continue rather than aborting.
-                #[cfg(target_os = "linux")]
-                {
-                    use libc::{getrlimit, rlimit, setrlimit, RLIMIT_NOFILE};
-                    let mut cur = rlimit {
-                        rlim_cur: 0,
-                        rlim_max: 0,
-                    };
-                    if unsafe { getrlimit(RLIMIT_NOFILE, &mut cur) } == 0
-                        && cur.rlim_max > cur.rlim_cur
-                    {
-                        let raised = rlimit {
-                            rlim_cur: cur.rlim_max,
-                            rlim_max: cur.rlim_max,
-                        };
-                        if unsafe { setrlimit(RLIMIT_NOFILE, &raised) } != 0 {
-                            let error = std::io::Error::last_os_error();
-                            tracing::warn!(
-                                ?error,
-                                hard_limit = cur.rlim_max,
-                                "failed to raise RLIMIT_NOFILE; many hook processes may exhaust fds"
-                            );
-                        }
-                    }
-                }
-
                 let exit_code = TngExec::run(
                     config,
                     options.command,

--- a/tng/src/exec.rs
+++ b/tng/src/exec.rs
@@ -339,10 +339,12 @@ impl TngExec {
 
         tracing::info!(?exit_status, "Child process exited");
 
-        // Drain the hook log collector before returning: signal the accept
-        // loop to stop and join its task so in-flight hook frames are flushed
-        // into the main's writers. The collector's own JoinSet drain (with its
-        // 2s timeout) bounds how long a stuck reader can hold shutdown.
+        // Drain the hook log collector before returning: signal the recv
+        // loop to stop and join its task so in-flight hook datagrams are
+        // flushed into the main's writers. After the loop breaks the
+        // collector drains any datagrams still queued in the kernel recv
+        // buffer with non-blocking try_recv, so a frame the child sent just
+        // before exit is not lost.
         #[cfg(target_os = "linux")]
         if let Some(handle) = collector {
             let _ = handle.cancel_tx.send(());

--- a/tng/src/hook_log_collector.rs
+++ b/tng/src/hook_log_collector.rs
@@ -1,121 +1,58 @@
 //! Main-process collector for centralized hook logging.
 //!
-//! The `tng exec` process listens on an abstract-namespace Unix domain socket
-//! (`\0tng-hook-log-<pid>`). The `tng-hook` cdylib (LD_PRELOAD'd into the
-//! hooked child) connects to this socket and streams length-prefixed,
-//! route-tagged frames (see `tng_hook_types::wire`). This module decodes those
-//! frames and fans each payload into the main process's `info.log` /
-//! `error.log` via cloned `NonBlocking` writers, so hook logs merge into the
-//! same rolling files the main process owns.
+//! The `tng exec` process binds an abstract-namespace Unix-domain **datagram**
+//! socket (`\0tng-hook-log-<pid>`). The `tng-hook` cdylib (LD_PRELOAD'd into
+//! the hooked child) sends one route-tagged datagram per log record (see
+//! `tng_hook_types::wire`). This module receives each datagram and fans the
+//! payload into the main process's `info.log` / `error.log` via cloned
+//! `NonBlocking` writers, so hook logs merge into the same rolling files the
+//! main process owns.
+//!
+//! A datagram transport means the collector holds exactly **one** file
+//! descriptor regardless of how many hook children are logging concurrently
+//! (a stream transport needed one accept-loop fd per child), so the parent no
+//! longer raises `RLIMIT_NOFILE`. Framing is also atomic: one `recv` yields
+//! one complete frame, with no partial-frame reassembly and no stream-desync
+//! recovery — a malformed datagram is dropped and the next one decodes
+//! independently.
 //!
 //! Abstract-namespace sockets are Linux-only (no filesystem path, no cleanup),
 //! and the cdylib is Linux-only too, so this whole module is
 //! `#[cfg(target_os = "linux")]`-gated (the module-level gate lives in
 //! `lib.rs`; this file is only compiled on Linux).
 
-use std::future::Future;
 use std::io::{self, Write};
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::Path;
-use std::pin::Pin;
-use std::time::Duration;
 
 use socket2::{Domain, SockAddr, Socket, Type};
-use tokio::io::AsyncReadExt;
-use tokio::net::unix::SocketAddr;
-use tokio::net::{UnixListener, UnixStream};
+use tokio::net::UnixDatagram;
 use tokio::sync::oneshot;
-use tokio::task::JoinSet;
-use tokio::time::timeout;
 use tracing_appender::non_blocking::NonBlocking;
 
-use tng_hook_types::{FrameDecoder, Route};
+use tng_hook_types::{decode_frame, Route};
 
-/// The future returned by an [`AcceptSource`]. Boxed so the loop is polymorphic
-/// over the accept source (real `UnixListener` in prod, an injected
-/// perpetually-`Err` source in the backoff behavioral test) without naming the
-/// concrete `accept` future type. `+ Send` so the loop can run on the
-/// multi-thread runtime; the elided lifetime ties the borrow to `&self`.
-type AcceptFut<'a> =
-    Pin<Box<dyn Future<Output = io::Result<(UnixStream, SocketAddr)>> + Send + 'a>>;
+/// Receive buffer for the datagram socket. 256 KiB covers any plausible
+/// formatted log record (a single line is normally well under 8 KiB; even a
+/// large `{:#?}` debug dump of a mapping table stays in the tens of KiB). The
+/// kernel delivers datagrams up to roughly `wmem_max` (default ~212 KiB), so a
+/// buffer below that would silently truncate a large record — see the
+/// `large_datagram_is_delivered_whole_not_truncated` test. The buffer is
+/// allocated once and reused, so its size is not a per-event cost.
+const RECV_BUF_SIZE: usize = 256 * 1024;
 
-/// Source of accepted hook connections. Prod impls this for `UnixListener`;
-/// tests impl it for a perpetually-failing source so the backoff path can be
-/// exercised deterministically (a real listener cannot be made to fail
-/// synchronously and persistently without fd hacks).
-trait AcceptSource {
-    fn accept(&self) -> AcceptFut<'_>;
-}
-
-impl AcceptSource for UnixListener {
-    fn accept(&self) -> AcceptFut<'_> {
-        Box::pin(<UnixListener>::accept(self))
-    }
-}
-
-/// Read buffer size for each connection. A single formatted log line is well
-/// under 8 KiB; a larger chunk simply carries several frames at once, which the
-/// `FrameDecoder` handles regardless of buffer size.
-const READ_BUF_SIZE: usize = 8 * 1024;
-
-/// Cap on how long `run` waits for in-flight connection readers to finish after
-/// cancel before forcing them down. A hooked child that hangs mid-read should
-/// not block main-process shutdown indefinitely.
-const DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
-
-/// Number of consecutive accept errors that retry immediately, with no sleep,
-/// before any backoff kicks in. A handful of transient failures (the common
-/// case, e.g. a brief EMFILE spike) stay zero-latency; only sustained failures
-/// back off.
-const ACCEPT_BACKOFF_IMMEDIATE: u32 = 3;
-
-/// Floor and ceiling for the accept-error backoff sleep (see `accept_backoff`).
-/// Starts at 1 ms once the immediate-retry threshold is exceeded and doubles
-/// per consecutive error, capped at 100 ms: a persistently broken listener
-/// never spins at full tilt, but the collector never goes quiet for long
-/// either (it is a logging path, not a hot server).
-const ACCEPT_BACKOFF_MIN: Duration = Duration::from_millis(1);
-const ACCEPT_BACKOFF_MAX: Duration = Duration::from_millis(100);
-
-/// Backoff applied before re-accepting after `consecutive_errors` consecutive
-/// accept failures. The first `ACCEPT_BACKOFF_IMMEDIATE` failures return
-/// `Duration::ZERO` so transient errors (the common case) add no latency;
-/// beyond that the sleep doubles per consecutive error up to
-/// `ACCEPT_BACKOFF_MAX`. Pure so the run loop can stay a thin cancel-aware
-/// shell around it.
-///
-/// `consecutive_errors` counts failures so far including the most recent one,
-/// so `0` means "last accept succeeded" and yields `Duration::ZERO`.
-fn accept_backoff(consecutive_errors: u32) -> Duration {
-    if consecutive_errors <= ACCEPT_BACKOFF_IMMEDIATE {
-        return Duration::ZERO;
-    }
-    // Saturating shift count: the cap dominates well before this bound, and a
-    // large shift would overflow the millis value on huge counts (e.g. a
-    // listener fd that never recovers). 7 keeps the un-capped value <= 128 ms
-    // before the final `.min` clamps it to 100 ms.
-    let shifts = (consecutive_errors - ACCEPT_BACKOFF_IMMEDIATE - 1).min(7);
-    let millis = (ACCEPT_BACKOFF_MIN.as_millis() as u64) << shifts;
-    let cap_millis: u64 = ACCEPT_BACKOFF_MAX
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX);
-    Duration::from_millis(millis.min(cap_millis))
-}
-
-/// Centralized hook log collector. Owns the listening socket and the cloned
-/// `NonBlocking` writers that hook payloads are merged into. `run` spawns one
-/// reader task per accepted connection inside a `JoinSet`, so a misbehaving or
-/// panicking child is isolated from the rest.
+/// Centralized hook log collector. Owns the bound datagram socket and the
+/// cloned `NonBlocking` writers that hook payloads are merged into. `run`
+/// reads datagrams in a single task — no per-connection state, no accept loop.
 pub struct HookLogCollector {
-    listener: UnixListener,
+    sock: UnixDatagram,
     info_nb: NonBlocking,
     error_nb: Option<NonBlocking>,
 }
 
 impl HookLogCollector {
-    /// Bind the abstract-namespace listener `\0tng-hook-log-<pid>` and return
-    /// the BARE name `tng-hook-log-<pid>` (for `TNG_HOOK_LOG_SOCKET` env
+    /// Bind the abstract-namespace datagram socket `\0tng-hook-log-<pid>` and
+    /// return the BARE name `tng-hook-log-<pid>` (for `TNG_HOOK_LOG_SOCKET` env
     /// injection into hooked children) plus the collector, ready to `run`.
     ///
     /// The returned name carries no leading NUL: `setenv` uses NUL-terminated
@@ -125,14 +62,14 @@ impl HookLogCollector {
     /// callers inject the bare name into the child env verbatim.
     ///
     /// The socket is set non-blocking before being handed to tokio, so the
-    /// accept loop never blocks the reactor on a stale fd. socket2 has no
-    /// `From<Socket>` for `UnixListener`, so the conversion goes through the
+    /// recv loop never blocks the reactor on a stale fd. socket2 has no
+    /// `From<Socket>` for `UnixDatagram`, so the conversion goes through the
     /// raw fd.
     pub async fn start(
         info_nb: NonBlocking,
         error_nb: Option<NonBlocking>,
     ) -> io::Result<(Self, String)> {
-        let sock = Socket::new(Domain::UNIX, Type::STREAM, None)?;
+        let sock = Socket::new(Domain::UNIX, Type::DGRAM, None)?;
         // Bare name for env injection (no leading NUL): the cdylib prepends `\0`
         // itself when connecting, and setenv would truncate a NUL-bearing value.
         let name = format!("tng-hook-log-{}", std::process::id());
@@ -140,18 +77,17 @@ impl HookLogCollector {
         // (no filesystem path, no unlink on exit, per-pid so names never collide).
         let addr = SockAddr::unix(Path::new(&format!("\0{}", name)))?;
         sock.bind(&addr)?;
-        sock.listen(1024)?;
         // Non-blocking must be set before the fd leaves socket2's ownership so
         // tokio's registration sees a non-blocking fd.
         sock.set_nonblocking(true)?;
         let fd = sock.into_raw_fd();
-        // SAFETY: `fd` is a valid bound listening non-blocking UNIX socket we
+        // SAFETY: `fd` is a valid bound non-blocking UNIX datagram socket we
         // just created; `into_raw_fd` transferred ownership to us.
-        let std_listener = unsafe { std::os::unix::net::UnixListener::from_raw_fd(fd) };
-        let listener = UnixListener::from_std(std_listener)?;
+        let std_sock = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd) };
+        let sock = UnixDatagram::from_std(std_sock)?;
         Ok((
             Self {
-                listener,
+                sock,
                 info_nb,
                 error_nb,
             },
@@ -159,161 +95,103 @@ impl HookLogCollector {
         ))
     }
 
-    /// Accept loop. Each accepted connection is read by a per-connection task
-    /// owned by a `JoinSet`; on cancel, in-flight readers are drained (up to
-    /// `DRAIN_TIMEOUT`) and then shut down so a stuck reader cannot block
-    /// shutdown. Sustained accept errors back off (see `accept_backoff`) so a
-    /// persistently failing listener cannot busy-spin.
+    /// Receive loop. Each datagram is one complete frame, decoded and written
+    /// to the matching `NonBlocking` writer. On cancel the loop breaks, then
+    /// drains whatever children already queued in the kernel recv buffer
+    /// (non-blocking `try_recv` until `WouldBlock`) so in-flight frames are not
+    /// lost on shutdown.
     pub async fn run(self, cancel: oneshot::Receiver<()>) {
         let Self {
-            listener,
-            info_nb,
-            error_nb,
+            sock,
+            mut info_nb,
+            mut error_nb,
         } = self;
-        run_loop(&listener, info_nb, error_nb, cancel).await;
-    }
-}
-
-/// The accept loop, parameterized over an [`AcceptSource`] so the backoff path
-/// is testable with an injected failing source. The body is SEQUENTIAL, not
-/// concurrent: the backoff sleep is completed (cancel-raced) BEFORE accept is
-/// polled. A concurrent `select!` over sleep + accept would let a
-/// synchronously failing accept (`Poll::Ready(Err)`, e.g. EMFILE or a broken
-/// listener fd) win every iteration before the sleep elapses, defeating the
-/// backoff entirely. Here the sleep is its own cancel-raced `select!`, and
-/// only after it completes (or is skipped, for the first few errors) does a
-/// second cancel-raced `select!` poll accept. Cancel breaks out of BOTH
-/// `select!`s immediately, so shutdown is never delayed by backoff.
-async fn run_loop<A: AcceptSource>(
-    acceptor: &A,
-    info_nb: NonBlocking,
-    error_nb: Option<NonBlocking>,
-    mut cancel: oneshot::Receiver<()>,
-) {
-    let mut conns: JoinSet<()> = JoinSet::new();
-    // Consecutive accept failures. Reset on any successful accept. A
-    // persistently failing listener (e.g. EMFILE that never clears, or a
-    // broken listener fd) would otherwise busy-spin the accept loop until
-    // cancel fires; `accept_backoff` throttles that without adding latency
-    // to the common transient case.
-    let mut consecutive_errors: u32 = 0;
-    loop {
-        let backoff = accept_backoff(consecutive_errors);
-        // 1. Cancel-raced backoff sleep, completed BEFORE polling accept. The
-        // first `ACCEPT_BACKOFF_IMMEDIATE` errors yield `Duration::ZERO`, so
-        // this is skipped and accept is polled immediately (zero added latency
-        // for the common transient case). Cancel wins immediately here.
-        if !backoff.is_zero() {
+        let mut buf = vec![0u8; RECV_BUF_SIZE];
+        let mut cancel = cancel;
+        loop {
             tokio::select! {
+                // `&mut` so the same receiver can be polled across loop
+                // iterations until it fires.
                 _ = &mut cancel => break,
-                _ = tokio::time::sleep(backoff) => {}
+                res = sock.recv(&mut buf) => match res {
+                    // Empty datagram: nothing to decode, keep receiving.
+                    Ok(0) => continue,
+                    Ok(n) => {
+                        // A datagram at least as large as the recv buffer is
+                        // truncated by the kernel to `buf.len()` and the excess
+                        // is silently discarded (`recv` returns `min(msg_len,
+                        // buf_len)` without `MSG_TRUNC`). A real log line never
+                        // fills a 256 KiB buffer, so `n == buf.len()` means an
+                        // oversized record — drop it with a warning rather than
+                        // writing a truncated half-line to the log.
+                        if n == buf.len() {
+                            tracing::warn!(
+                                size = n,
+                                "hook log datagram truncated; oversized record dropped"
+                            );
+                            continue;
+                        }
+                        dispatch_frame(&buf[..n], &mut info_nb, &mut error_nb);
+                    }
+                    Err(error) => {
+                        // A transient recv failure must not tear down
+                        // collection for every other child. Log and keep
+                        // receiving; the cancel branch still breaks on
+                        // shutdown.
+                        tracing::warn!(?error, "hook log recv failed");
+                    }
+                }
             }
         }
-        // 2. Cancel-raced accept. Only polled once the backoff (if any) has
-        // actually elapsed, so a synchronous `Ready(Err)` cannot race past the
-        // sleep. Cancel wins immediately here too.
-        let accept = tokio::select! {
-            _ = &mut cancel => break,
-            res = acceptor.accept() => res,
-        };
-        match accept {
-            Ok((conn, _peer)) => {
-                consecutive_errors = 0;
-                let info_nb = info_nb.clone();
-                let error_nb = error_nb.clone();
-                conns.spawn(async move {
-                    serve_conn(conn, info_nb, error_nb).await;
-                });
-            }
-            Err(error) => {
-                consecutive_errors = consecutive_errors.saturating_add(1);
-                // A transient accept failure (e.g. EMFILE) must not tear down
-                // collection for every other child. Log and keep accepting; the
-                // cancel branches above still break the loop on shutdown, and
-                // `accept_backoff` (sleep next iteration) keeps a sustained
-                // failure from busy-spinning.
-                tracing::warn!(consecutive_errors, ?error, "hook log accept failed");
-            }
-        }
-    }
 
-    // Give in-flight readers a bounded chance to finish their current
-    // frame, then force the rest down so shutdown is not held hostage by a
-    // stuck child.
-    let drain = async { while conns.join_next().await.is_some() {} };
-    if timeout(DRAIN_TIMEOUT, drain).await.is_err() {
-        tracing::warn!(
-            "hook log connection drain did not complete within {:?}, aborting remaining readers",
-            DRAIN_TIMEOUT
-        );
+        // Drain datagrams the children already queued before the socket is
+        // dropped. `try_recv` returns WouldBlock when the kernel buffer is
+        // empty, so this is bounded and fast. By the time `run` is cancelled
+        // (after `child.wait()` returned in `exec.rs`), no child is still
+        // sending, so the buffered set is final. The same truncation guard
+        // applies so a queued oversized record is dropped, not half-written.
+        while let Ok(n) = sock.try_recv(&mut buf) {
+            if n == 0 {
+                continue;
+            }
+            if n == buf.len() {
+                tracing::warn!(
+                    size = n,
+                    "hook log datagram truncated; oversized record dropped"
+                );
+                continue;
+            }
+            dispatch_frame(&buf[..n], &mut info_nb, &mut error_nb);
+        }
     }
-    conns.shutdown().await;
 }
 
-/// Read loop for one hook connection. Decodes `[route][len][payload]` frames
-/// and writes each payload to the matching `NonBlocking` writer. `NonBlocking`
-/// is lossy by default (`write_all` never blocks, never errors), so a slow
-/// rolling appender cannot stall the hook log path.
+/// Decode one datagram's frame and write its payload to the matching
+/// `NonBlocking` writer. `NonBlocking` is lossy by default (`write_all` never
+/// blocks, never errors), so a slow rolling appender cannot stall the hook log
+/// path.
 ///
 /// Route dispatch: `Route::Error` goes to the error writer when one exists;
 /// otherwise it falls back to the info writer (the "no separate error file"
 /// case, mirroring `LevelRoutingWriter`'s behavior in the main subscriber).
-/// `Route::Info` always goes to the info writer.
-///
-/// On EOF mid-frame (`read` returns 0 with a partial frame buffered), the
-/// partial is dropped via `drain_partial` so a crashed hook truncates only its
-/// own last record instead of leaking into the next connection's decode state.
-async fn serve_conn(
-    mut conn: UnixStream,
-    mut info_nb: NonBlocking,
-    mut error_nb: Option<NonBlocking>,
-) {
-    let mut decoder = FrameDecoder::new();
-    let mut buf = vec![0u8; READ_BUF_SIZE];
-    loop {
-        match conn.read(&mut buf).await {
-            Ok(0) => {
-                // EOF: drop any buffered partial frame so a truncated final
-                // record does not leak into the next connection.
-                decoder.drain_partial();
-                return;
-            }
-            Ok(n) => {
-                decoder.push(&buf[..n]);
-                // Drain every complete frame in the buffer before reading more;
-                // one `read` may carry several frames or a partial of the next.
-                while let Some(frame) = decoder.next_frame() {
-                    match frame {
-                        Ok((route, payload)) => {
-                            // Disjoint mutable borrow: pick the writer for this
-                            // route without cloning.
-                            let target: &mut NonBlocking = match (route, &mut error_nb) {
-                                (Route::Error, Some(e)) => e,
-                                _ => &mut info_nb,
-                            };
-                            // Lossy + never blocks; a dropped line is
-                            // preferable to stalling a hooked host.
-                            let _ = target.write_all(&payload);
-                        }
-                        Err(error) => {
-                            // The stream is desynchronized (bad route byte or
-                            // an absurd length). The decoder has already
-                            // cleared its buffer; continuing to read would
-                            // misalign on the next length field. Drop the
-                            // connection.
-                            tracing::warn!(
-                                ?error,
-                                "hook log frame decode error; closing connection"
-                            );
-                            return;
-                        }
-                    }
-                }
-            }
-            Err(error) => {
-                tracing::warn!(?error, "hook log connection read error");
-                return;
-            }
+/// `Route::Info` always goes to the info writer. A malformed datagram (empty,
+/// or a bad route byte) is dropped — the next datagram decodes independently,
+/// so one bad frame cannot desync the stream.
+fn dispatch_frame(payload: &[u8], info_nb: &mut NonBlocking, error_nb: &mut Option<NonBlocking>) {
+    match decode_frame(payload) {
+        Ok((route, body)) => {
+            // Disjoint mutable borrow: pick the writer for this route without
+            // cloning.
+            let target: &mut NonBlocking = match (route, error_nb) {
+                (Route::Error, Some(e)) => e,
+                _ => info_nb,
+            };
+            // Lossy + never blocks; a dropped line is preferable to stalling a
+            // hooked host.
+            let _ = target.write_all(body);
+        }
+        Err(error) => {
+            tracing::warn!(?error, "hook log datagram decode error; dropped");
         }
     }
 }
@@ -322,31 +200,12 @@ async fn serve_conn(
 mod tests {
     use super::*;
 
-    use std::io::Write;
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use serial_test::serial;
     use tng_hook_types::encode_frame;
     use web_time_compat::InstantExt;
-
-    /// Accept source whose `accept` always resolves to a synchronous `Err`,
-    /// simulating a persistently broken listener (EMFILE that never clears, a
-    /// bad listener fd). Each call increments `calls`, so the behavioral test
-    /// can count accept attempts and prove the loop is throttled rather than
-    /// busy-spinning. This is why `run` is parameterized over [`AcceptSource`]:
-    /// a real `UnixListener` cannot be made to fail synchronously and
-    /// persistently without unsound fd hacks.
-    struct AlwaysErr {
-        calls: Arc<AtomicU64>,
-    }
-
-    impl AcceptSource for AlwaysErr {
-        fn accept(&self) -> AcceptFut<'_> {
-            self.calls.fetch_add(1, Ordering::Relaxed);
-            Box::pin(async { Err(io::Error::other("persistent accept failure")) })
-        }
-    }
 
     /// In-memory writer backed by a shared `Vec`, so the test can read what the
     /// `NonBlocking` worker thread eventually flushed. `tracing_appender`'s
@@ -370,15 +229,16 @@ mod tests {
         }
     }
 
-    /// Connect a socket2 client to the abstract-namespace listener that `start`
-    /// bound for the bare `name`. This mirrors the cdylib's `connect_hook_socket`
-    /// exactly: it prepends `\0` to the bare name, then connects over the
-    /// abstract namespace. std's `UnixStream::connect` cannot reach abstract
-    /// namespaces, so socket2 is used for the client side too. Exercising the
-    /// real prepend-`\0` contract (instead of relying on a NUL-bearing name)
-    /// is what makes the tests cover the cdylib connect path.
+    /// Connect a socket2 datagram client to the abstract-namespace socket that
+    /// `start` bound for the bare `name`. This mirrors the cdylib's
+    /// `connect_hook_socket` exactly: it prepends `\0` to the bare name, then
+    /// connects over the abstract namespace. std's
+    /// `UnixDatagram::connect` cannot reach abstract namespaces, so socket2 is
+    /// used for the client side too. Exercising the real prepend-`\0` contract
+    /// (instead of relying on a NUL-bearing name) is what makes the tests cover
+    /// the cdylib connect path.
     fn connect_abstract(name: &str) -> anyhow::Result<Socket> {
-        let sock = Socket::new(Domain::UNIX, Type::STREAM, None)?;
+        let sock = Socket::new(Domain::UNIX, Type::DGRAM, None)?;
         let addr = SockAddr::unix(Path::new(&format!("\0{}", name)))?;
         sock.connect(&addr)?;
         Ok(sock)
@@ -386,16 +246,13 @@ mod tests {
 
     /// Poll a captured buffer until it contains `needle`, up to `timeout`. The
     /// `NonBlocking` worker flushes asynchronously from its own thread, so the
-    /// bytes land in `captured` some time after `serve_conn` writes them. Tests
-    /// must wait for the expected output BEFORE canceling the accept loop: the
-    /// run loop's `select!` must poll `listener.accept()` at least once to
-    /// register interest with the reactor, and if `cancel` is already sent
-    /// when `select!` is first polled, the cancel branch wins without ever
-    /// polling accept, so the connection is never accepted and `serve_conn`
-    /// never runs. Polling the captured bytes for the expected output proves
-    /// `serve_conn` ran before teardown. Blocking the test thread is fine:
-    /// these tests use the multi-thread runtime, so worker threads keep
-    /// draining while this thread sleeps.
+    /// bytes land in `captured` some time after `dispatch_frame` writes them.
+    /// Tests wait for the expected output BEFORE canceling the recv loop:
+    /// canceling first is safe (the post-cancel `try_recv` drain catches any
+    /// queued datagram), but waiting here keeps the success assertion off the
+    /// cancel race and fails fast if a datagram never lands. Blocking the test
+    /// thread is fine: these tests use the multi-thread runtime, so worker
+    /// threads keep draining while this thread sleeps.
     fn wait_for_contains(captured: &Arc<Mutex<Vec<u8>>>, needle: &[u8], timeout: Duration) {
         let start = web_time_compat::Instant::get();
         loop {
@@ -410,12 +267,12 @@ mod tests {
         }
     }
 
-    /// Two frames (Info + Error) on one connection are decoded in order and
-    /// both payloads land in the merged info writer (no error writer set, so
-    /// the Error route falls back to info, mirroring `LevelRoutingWriter`).
+    /// Two datagrams (Info + Error) are decoded in order and both payloads land
+    /// in the merged info writer (no error writer set, so the Error route falls
+    /// back to info, mirroring `LevelRoutingWriter`).
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn collects_and_routes_frames_into_merged_nonblocking() -> anyhow::Result<()> {
+    async fn collects_and_routes_datagrams_into_merged_nonblocking() -> anyhow::Result<()> {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let (info_nb, guard) = tracing_appender::non_blocking(CapturedWriter(captured.clone()));
 
@@ -424,26 +281,21 @@ mod tests {
         #[allow(clippy::disallowed_methods)]
         let run_task = tokio::spawn(async move { collector.run(cancel_rx).await });
 
-        let mut client = connect_abstract(&name)?;
-        // Send one Info frame then one Error frame. With no error writer, both
-        // must route to the info writer, in order.
-        let mut bytes = encode_frame(Route::Info, b"info-line\n");
-        bytes.extend_from_slice(&encode_frame(Route::Error, b"error-line\n"));
-        client.write_all(&bytes)?;
-        // Signal EOF so serve_conn drains, then returns.
-        client.shutdown(std::net::Shutdown::Write)?;
+        let client = connect_abstract(&name)?;
+        // Send one Info datagram then one Error datagram. With no error writer,
+        // both must route to the info writer, in order. Each datagram is one
+        // complete atomic frame.
+        client.send(&encode_frame(Route::Info, b"info-line\n"))?;
+        client.send(&encode_frame(Route::Error, b"error-line\n"))?;
 
-        // Wait for serve_conn to accept the connection and flush both payloads
-        // through the NonBlocking worker BEFORE canceling. See
-        // `wait_for_contains`: canceling first would race the accept poll.
+        // Wait for the recv loop to flush both payloads through the NonBlocking
+        // worker before canceling.
         wait_for_contains(
             &captured,
             b"info-line\nerror-line\n",
             Duration::from_secs(2),
         );
 
-        // Cancel the accept loop; run drains the now-completed serve_conn task
-        // within the drain timeout.
         let _ = cancel_tx.send(());
         let _ = run_task.await;
 
@@ -456,12 +308,13 @@ mod tests {
         Ok(())
     }
 
-    /// A connection that closes mid-frame (header + partial payload sent, then
-    /// EOF) must not panic and must not emit a truncated record: the partial is
-    /// dropped and the merged writer stays empty.
+    /// A datagram with a bad route byte must be dropped without panicking and
+    /// must NOT desync the collector: the very next well-formed datagram still
+    /// lands. This is the datagram-transport robustness property a byte stream
+    /// cannot offer.
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
-    async fn eof_mid_frame_is_dropped_not_panicked() -> anyhow::Result<()> {
+    async fn bad_route_datagram_is_dropped_then_next_lands() -> anyhow::Result<()> {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let (info_nb, guard) = tracing_appender::non_blocking(CapturedWriter(captured.clone()));
 
@@ -470,38 +323,128 @@ mod tests {
         #[allow(clippy::disallowed_methods)]
         let run_task = tokio::spawn(async move { collector.run(cancel_rx).await });
 
-        let mut client = connect_abstract(&name)?;
-        // A full frame for a 16-byte payload, truncated to header + 3 payload
-        // bytes: the length field promises 16 but only 3 arrive.
-        let full = encode_frame(Route::Info, b"complete payload");
-        let partial = &full[..5 + 3];
-        client.write_all(partial)?;
-        client.shutdown(std::net::Shutdown::Write)?;
+        let client = connect_abstract(&name)?;
+        // A datagram whose route byte is not a known Route. decode_frame
+        // rejects it (BadRoute) and the datagram is dropped.
+        let mut bad = encode_frame(Route::Info, b"garbage\n");
+        bad[0] = 0;
+        client.send(&bad)?;
+        // Then a well-formed datagram. Under a byte stream, a bad byte mid-stream
+        // would misalign the decoder and swallow this too; under datagrams it
+        // lands cleanly.
+        client.send(&encode_frame(Route::Info, b"good-line\n"))?;
 
-        // Give serve_conn time to accept and read the partial + EOF before
-        // canceling, so the empty assertion below is not vacuously true from
-        // serve_conn never running (the accept-poll race noted above). A
-        // partial frame must never emit a record, so the buffer stays empty.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Wait for the good datagram to land; the bad-route datagram must never
+        // appear in the captured bytes.
+        wait_for_contains(&captured, b"good-line\n", Duration::from_secs(2));
 
         let _ = cancel_tx.send(());
-        // serve_conn must return cleanly (no panic) on EOF mid-frame.
         let _ = run_task.await;
 
         drop(guard);
         let merged = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert!(
-            merged.is_empty(),
-            "partial frame leaked into the writer: {merged:?}"
+        assert_eq!(
+            merged, b"good-line\n",
+            "expected only the good frame; bad-route frame desynced the collector: {merged:?}"
         );
         Ok(())
     }
 
-    /// With a separate error writer set, `Route::Error` frames demux into the
-    /// error writer and `Route::Info` frames into the info writer, with no
+    /// Datagrams already queued in the kernel recv buffer when shutdown is
+    /// signaled must still be delivered — either serviced by the recv loop
+    /// or caught by the post-cancel `try_recv` drain. Cancel is pre-fulfilled
+    /// before `run` is spawned, so the recv loop may break on its very first
+    /// iteration; whatever it does not service must be drained. This exercises
+    /// the "in-flight frames are not lost on shutdown" claim. The outcome is
+    /// deterministic on correct code: the loop + drain together always deliver
+    /// every buffered datagram; a regression that removes the drain would
+    /// (flakily) lose datagrams when cancel preempts the recv loop.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn queued_datagrams_survive_cancellation() -> anyhow::Result<()> {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (info_nb, guard) = tracing_appender::non_blocking(CapturedWriter(captured.clone()));
+
+        let (collector, name) = HookLogCollector::start(info_nb, None).await?;
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+
+        // Queue three datagrams before run starts, so they sit in the kernel
+        // recv buffer when the recv loop first polls.
+        let client = connect_abstract(&name)?;
+        client.send(&encode_frame(Route::Info, b"first\n"))?;
+        client.send(&encode_frame(Route::Info, b"second\n"))?;
+        client.send(&encode_frame(Route::Info, b"third\n"))?;
+
+        // Pre-fulfill cancel, then spawn run: the select may break on its
+        // first iteration, forcing the try_recv drain to catch whatever the
+        // loop did not service.
+        let _ = cancel_tx.send(());
+        #[allow(clippy::disallowed_methods)]
+        let run_task = tokio::spawn(async move { collector.run(cancel_rx).await });
+        let _ = run_task.await;
+
+        drop(guard);
+        let merged = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(
+            merged, b"first\nsecond\nthird\n",
+            "queued datagrams lost on shutdown: {merged:?}"
+        );
+        Ok(())
+    }
+
+    /// A datagram larger than the old 64 KiB recv buffer (but within the
+    /// kernel's ~210 KiB deliverable ceiling — verified by probe) must land
+    /// WHOLE, not silently truncated to the buffer size. With `RECV_BUF_SIZE`
+    /// sized above the kernel ceiling, `recv` never truncates a legitimate
+    /// record; this test would fail under the old 64 KiB buffer (a 100 KiB
+    /// datagram truncated to 65535 payload bytes). The `n == buf.len()` guard
+    /// in `run` is defense-in-depth for a misbehaving sender that raises
+    /// `SO_SNDBUF` past the default ceiling; it cannot be triggered here
+    /// because the kernel `EMSGSIZE`s any datagram at or above the buffer.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn large_datagram_is_delivered_whole_not_truncated() -> anyhow::Result<()> {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (info_nb, guard) = tracing_appender::non_blocking(CapturedWriter(captured.clone()));
+
+        let (collector, name) = HookLogCollector::start(info_nb, None).await?;
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        #[allow(clippy::disallowed_methods)]
+        let run_task = tokio::spawn(async move { collector.run(cancel_rx).await });
+
+        // 100 KiB payload: above the old 64 KiB buffer, well below the 256 KiB
+        // buffer and the ~210 KiB kernel ceiling.
+        let payload = vec![b'x'; 100 * 1024];
+        let client = connect_abstract(&name)?;
+        client.send(&encode_frame(Route::Info, &payload))?;
+
+        // Wait for the full payload to flush through the NonBlocking worker.
+        wait_for_contains(&captured, &payload, Duration::from_secs(2));
+
+        let _ = cancel_tx.send(());
+        let _ = run_task.await;
+
+        drop(guard);
+        let merged = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert_eq!(
+            merged.len(),
+            payload.len(),
+            "datagram truncated: got {} bytes, expected {}",
+            merged.len(),
+            payload.len()
+        );
+        assert!(
+            merged.iter().all(|&b| b == b'x'),
+            "datagram payload corrupted: {merged:?}"
+        );
+        Ok(())
+    }
+
+    /// With a separate error writer set, `Route::Error` datagrams demux into the
+    /// error writer and `Route::Info` datagrams into the info writer, with no
     /// cross-contamination. This is the spec's central promised behavior: the
     /// collector only demuxes. Exercises the `(Route::Error, Some(e))` arm of
-    /// `serve_conn` over a real abstract-namespace round-trip.
+    /// `dispatch_frame` over a real abstract-namespace round-trip.
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn error_route_demuxes_to_error_writer() -> anyhow::Result<()> {
@@ -517,17 +460,14 @@ mod tests {
         #[allow(clippy::disallowed_methods)]
         let run_task = tokio::spawn(async move { collector.run(cancel_rx).await });
 
-        let mut client = connect_abstract(&name)?;
-        // One Info frame then one Error frame on the SAME connection: the
-        // single shared socket must demux them into the two writers.
-        let mut bytes = encode_frame(Route::Info, b"info-line\n");
-        bytes.extend_from_slice(&encode_frame(Route::Error, b"error-line\n"));
-        client.write_all(&bytes)?;
-        client.shutdown(std::net::Shutdown::Write)?;
+        let client = connect_abstract(&name)?;
+        // One Info datagram then one Error datagram on the SAME shared socket:
+        // the route byte must demux them into the two writers.
+        client.send(&encode_frame(Route::Info, b"info-line\n"))?;
+        client.send(&encode_frame(Route::Error, b"error-line\n"))?;
 
         // Wait for BOTH payloads to flush through their respective NonBlocking
-        // workers before canceling. See `wait_for_contains`: canceling first
-        // would race the accept poll and skip serving the connection.
+        // workers before canceling.
         wait_for_contains(&info_captured, b"info-line\n", Duration::from_secs(2));
         wait_for_contains(&error_captured, b"error-line\n", Duration::from_secs(2));
 
@@ -563,116 +503,6 @@ mod tests {
                 .windows(b"info-line\n".len())
                 .any(|w| w == b"info-line\n"),
             "info payload leaked into error writer: {error_merged:?}"
-        );
-        Ok(())
-    }
-
-    /// The first `ACCEPT_BACKOFF_IMMEDIATE` consecutive failures retry
-    /// immediately: zero added latency for the common transient case.
-    #[test]
-    fn accept_backoff_first_errors_are_zero() {
-        assert_eq!(accept_backoff(0), Duration::ZERO);
-        assert_eq!(accept_backoff(1), Duration::ZERO);
-        assert_eq!(accept_backoff(2), Duration::ZERO);
-        assert_eq!(accept_backoff(ACCEPT_BACKOFF_IMMEDIATE), Duration::ZERO);
-    }
-
-    /// Sustained failures yield a nonzero, bounded, monotonically non-decreasing
-    /// backoff that saturates at the cap, even for absurd error counts (a
-    /// listener fd that never recovers).
-    #[test]
-    fn accept_backoff_grows_and_caps() {
-        let first_nonzero = accept_backoff(ACCEPT_BACKOFF_IMMEDIATE + 1);
-        assert!(
-            first_nonzero > Duration::ZERO,
-            "first sustained backoff must be nonzero, got {first_nonzero:?}"
-        );
-        assert!(first_nonzero >= ACCEPT_BACKOFF_MIN);
-        assert!(first_nonzero <= ACCEPT_BACKOFF_MAX);
-
-        let mut prev = Duration::ZERO;
-        for n in 0..10_000 {
-            let d = accept_backoff(n);
-            assert!(d <= ACCEPT_BACKOFF_MAX, "n={n} d={d:?} exceeds cap");
-            assert!(
-                d >= prev,
-                "n={n} d={d:?} shrunk below prev {prev:?} (non-monotonic)"
-            );
-            prev = d;
-        }
-        assert_eq!(accept_backoff(u32::MAX), ACCEPT_BACKOFF_MAX);
-    }
-
-    /// The exponential growth is bounded between the floor and the ceiling once
-    /// it kicks in, with explicit checkpoints so a regression in the shift math
-    /// (e.g. off-by-one in the threshold subtraction) is caught.
-    #[test]
-    fn accept_backoff_checkpoints() {
-        // First sustained step is the floor (1 ms), doubling each failure.
-        assert_eq!(
-            accept_backoff(ACCEPT_BACKOFF_IMMEDIATE + 1),
-            ACCEPT_BACKOFF_MIN
-        );
-        assert_eq!(
-            accept_backoff(ACCEPT_BACKOFF_IMMEDIATE + 2),
-            ACCEPT_BACKOFF_MIN * 2
-        );
-        assert_eq!(
-            accept_backoff(ACCEPT_BACKOFF_IMMEDIATE + 3),
-            ACCEPT_BACKOFF_MIN * 4
-        );
-        // Eventually saturates at the cap and stays there.
-        assert_eq!(
-            accept_backoff(ACCEPT_BACKOFF_IMMEDIATE + 100),
-            ACCEPT_BACKOFF_MAX
-        );
-    }
-
-    /// A persistently failing accept (synchronous `Ready(Err)` every call) must
-    /// NOT busy-spin: with the sequential backoff, accept is only re-polled
-    /// after the backoff sleep elapses, so a bounded window yields only a
-    /// bounded number of accept attempts. A concurrent sleep+accept `select!`
-    /// (the bug this round fixes) would let the ready `Err` win every iteration
-    /// and rack up tens of thousands of calls in the same window. Counts via
-    /// the injected `AlwaysErr` source, so the assertion is deterministic and
-    /// not wall-clock-fragile (generous margins).
-    #[tokio::test(flavor = "multi_thread")]
-    #[serial]
-    async fn persistent_accept_error_is_throttled_not_busy_spin() -> anyhow::Result<()> {
-        let captured = Arc::new(Mutex::new(Vec::new()));
-        let (info_nb, guard) = tracing_appender::non_blocking(CapturedWriter(captured.clone()));
-
-        let calls = Arc::new(AtomicU64::new(0));
-        let acceptor = AlwaysErr {
-            calls: calls.clone(),
-        };
-        let (cancel_tx, cancel_rx) = oneshot::channel();
-        #[allow(clippy::disallowed_methods)]
-        let run_task =
-            tokio::spawn(async move { run_loop(&acceptor, info_nb, None, cancel_rx).await });
-
-        // Window large enough for the backoff to saturate at the 100 ms cap:
-        // errors 1..=3 are immediate, 4..=10 take 1+2+4+8+16+32+64 = 127 ms,
-        // then each takes ~100 ms. So a throttled loop does well under 20
-        // attempts in 400 ms; a busy-spin would do >100k. 500 is a generous
-        // non-flaky ceiling that still fails loudly on the bug.
-        tokio::time::sleep(Duration::from_millis(400)).await;
-
-        let _ = cancel_tx.send(());
-        let _ = run_task.await;
-        drop(guard);
-
-        let observed = calls.load(Ordering::Relaxed);
-        assert!(
-            observed <= 500,
-            "expected a throttled loop (<=500 accept calls in 400ms), got {observed} (busy-spin?)"
-        );
-        // Ensure the loop actually ran past the immediate-retry band, so a
-        // regression that drops the sleep cannot pass vacuously with zero
-        // iterations (e.g. if cancel raced first).
-        assert!(
-            observed > ACCEPT_BACKOFF_IMMEDIATE as u64,
-            "expected the loop to iterate past the immediate-retry band, got {observed}"
         );
         Ok(())
     }


### PR DESCRIPTION
Switches the `tng exec` hook-log collector from a per-child SOCK_STREAM listener to a single SOCK_DGRAM socket, and adds integration-test coverage.

Stacks on `log-error-routing` (merge that first — this branch's three commits sit directly on its tip).

## `log: switch hook centralization UDS from stream to datagram`

- The collector binds one abstract-namespace datagram socket and runs a single recv loop — no accept loop, no per-connection tasks. It holds one fd regardless of how many hook children log concurrently, so `tng exec` no longer raises `RLIMIT_NOFILE`.
- Wire format simplified to `[route:1][payload]`: the 4-byte length prefix is dropped (a stream-protocol artifact; a datagram is self-delimiting). The incremental `FrameDecoder` becomes a one-shot `decode_frame`; a malformed datagram is dropped without desyncing the next.
- The cdylib sink is a connected, non-blocking datagram socket with an atomic `send` — lossy (drops on WouldBlock/EMSGSIZE), never blocks the host.
- A 256 KiB recv buffer (above the kernel's ~210 KiB datagram ceiling) plus an `n == buf.len()` guard so no record is silently truncated.

## `test(log): hook centralization under recursion, fork, and great-grandchild`

- Recursion / no-deadlock: a shell target spawns a subprocess making 30 real hooked connects, proving the connect→trace→send path is recursion-free.
- Fork / multi-producer: five concurrent fork+exec'd subprocesses each re-init the cdylib and reach the single collector.
- Great-grandchild: two levels of fork+exec; the great-grandchild re-inits and reaches the collector.

## `test(log): egress multi-process centralization + rolling under tng exec`

- Egress multi-process: the SERVER `tng exec` target spawns three echo servers (grandchildren) on different captured ports; each `bind()` is intercepted and reaches the collector.
- Rolling: `--log-rolling` with a tiny `--log-max-size` rotates `info.log.tng` into numbered backups; asserts rotation, the backup cap, and log-content sanity across active + backups.

All new tests assert both correct work and log-content sanity (no panic, disjoint ERROR routing, no per-process files).

## Verification

`cargo fmt`, `make clippy`, `cargo build`, unit tests (types 19 / cdylib 10 / collector 5), and the nine log integration tests across four files all pass.
