### PR TITLE
Bump patch version to 2.9.2

### DIFF
--- a/APPLICATION/tng/buildspec.yml
+++ b/APPLICATION/tng/buildspec.yml
@@ -30,7 +30,7 @@ images:
       path: Dockerfile
       scene:
         args: []
-        tags: [[2.9.1, latest]]
+        tags: [[2.9.2, latest]]
         registry: [*ACR_PROD]
       # 测试配置
       test_config: [*WORKSPACE, *PROJECT, *TEST_SUITE, *TEST_CONF, *TEST_CASE, *CLOUD_SERVER_TAG[0], '']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "rats-cert"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "as-any",
@@ -7752,7 +7752,7 @@ dependencies = [
 
 [[package]]
 name = "tng"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "again",
  "anyhow",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "tng-hook-cdylib"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "atty",
  "ctor",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "tng-hook-types"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "cidr",
  "local-ip-address",
@@ -7893,7 +7893,7 @@ dependencies = [
 
 [[package]]
 name = "tng-testsuite"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "again",
  "anyhow",
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "tng-wasm"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = ["Kun Lai <laikun@linux.alibaba.com>"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/inclavare-containers/tng"
-version = "2.9.1"
+version = "2.9.2"
 
 [workspace.dependencies]
 again = "0.1.2"

--- a/tng-python/pyproject.toml
+++ b/tng-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tng-sdk"
-version = "2.9.1"
+version = "2.9.2"
 description = "TNG (Trusted Network Gateway) Python SDK — encrypted HTTP requests with remote attestation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/trusted-network-gateway.spec
+++ b/trusted-network-gateway.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: trusted-network-gateway
-Version: 2.9.1
+Version: 2.9.2
 Release: 1%{?dist}
 Summary: Trusted Network Gateway
 Group: Applications/System
@@ -85,6 +85,17 @@ install -p -m 755 %{_builddir}/%{name}-%{version}/src/target/release/libtng_hook
 
 
 %changelog
+* Tue Sep 08 2026 Kun Lai <laikun@linux.alibaba.com> - 2.9.2-1
+- test(log): egress multi-process centralization + rolling under tng exec
+- test(log): hook centralization under recursion, fork, and great-grandchild
+- log: switch hook centralization UDS from stream to datagram
+- log: centralize hook log rolling into tng exec via abstract-namespace UDS
+- docs(claude): codify documentation writing rules from the ra doc work
+- feat(log): route ERROR+ events to a separate error log file
+- docs(ra): extract remote attestation config into a standalone guide
+- ci(wasm): stop tag-triggered GitHub Pages deployments
+- test(testsuite): fix flaky nip_io_hosts cleanup race with vfork spawns
+
 * Fri Sep 04 2026 Kun Lai <laikun@linux.alibaba.com> - 2.9.1-1
 - test(log): add integration test for JSON, rolling, and flush-on-exit
 - feat(log): add size-based rolling with per-pid hook files and exit flush


### PR DESCRIPTION
Regenerate version info via make bump-version-patch across Cargo.toml, Cargo.lock, APPLICATION/tng/buildspec.yml, tng-python/pyproject.toml, and the RPM spec (Version + auto-collected %changelog since v2.9.1).