### PR TITLE
deps: bump trustee pin to latest main, adopt regorus-regovm backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,19 @@ Several kinds of text in this repo are read by future developers and users long 
 
 These rules apply wherever text is meant to be read later. Ephemeral output (a one-off reply in this session, a `println!` debug line) does not need to follow them.
 
+### Comment & Documentation Discipline
+
+The "Comments explain *why*, not *what*" rule above, made concrete. These apply to code comments, TOML/Cargo comment blocks, and reference docs alike. Most of them are corollaries of one test: *would deleting this comment let a future maintainer make a real mistake?* If yes, keep it, dense, free of version pins and upstream internals. If no, move it to the commit message.
+
+1. **Comment the abnormal, not the normal.** Default, obvious, or cross-platform-consistent behavior stays silent; enabling a feature on every target needs no rationale. Only the surprise needs a comment: a feature that is *mandatory* on one target, a flag whose removal breaks a build, a value that looks wrong but is deliberate. A comment exists for exactly one reason: deleting it would let someone make a real mistake (an unexplained build break, a correct config "fixed" into a bug, a re-introduced regression). "Explains a non-obvious constraint" passes; "restates what the code does" or "tells a historical story" fails.
+2. **Write why/constraint/gotcha, not what/mechanism.** The code shows what it does and the mechanism can be re-derived from source. A comment earns its place with the non-obvious: *why* a value is what it is, the *constraint* it satisfies, the *gotcha* it avoids, ideally naming the exact error a wrong choice produces. Don't restate the mechanism of another crate.
+3. **No version-pinned assertions in comments.** "As of dep vX, feature Y pulls Z" rots on the next bump and is the first thing forgotten when editing. What a dep pulls today is answerable from cargo and the lockfile in real time; don't snapshot it in prose. Version-fragile facts belong in the commit message, which is dated and immutable.
+4. **Don't explain another repo's internals.** `#[cfg(...)]` gates, internal function names, and `compile_error!` syntax of an upstream crate cannot be verified from this repo and rot when upstream refactors. State the observable contract at most ("upstream will not compile without it"), not the internal mechanism.
+5. **Make each block self-contained; don't dedupe via cross-reference.** "See the block above for the full rationale" couples two sites that must be edited together and forces the reader to jump. A short reason is restated where needed; a long reason probably shouldn't be a comment at all (see rule 6).
+6. **Constraints live in comments; rationale and history live in the commit message.** Separate the durable (a constraint the next editor must respect and that must stay true) from the transient (why we chose this in this commit). Commit messages are immutable, dated, and searchable, the right home for "why we decided X"; comments are for the live constraint.
+7. **Write dense, not long.** Three lines stating three constraints beat nine lines stating one plus mechanism and history. Every line should carry a fact the maintainer would otherwise lack; cut any line that is re-derivable or rotting.
+8. **Inheriting a bad style is not a reason to extend it.** When you arrive and existing comments are already verbose and stale, "carry over the accurate parts" does not mean "perpetuate the verbose pattern." If the pattern is the problem, fix the pattern (trim), don't append in kind.
+
 ## Documentation Structure & Craft
 
 These lessons come from repeated remote-attestation doc reviews; apply them to any `docs/*.md` / `*_zh.md` reference doc, especially reader-facing config references.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=2703b7d924c1c2de357cf234be773d852464f57e#2703b7d924c1c2de357cf234be773d852464f57e"
+source = "git+https://github.com/openanolis/trustee/?rev=4998682d7ec00e1d3b3a0a638fce11fa0301233a#4998682d7ec00e1d3b3a0a638fce11fa0301233a"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "eventlog"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=2703b7d924c1c2de357cf234be773d852464f57e#2703b7d924c1c2de357cf234be773d852464f57e"
+source = "git+https://github.com/openanolis/trustee/?rev=4998682d7ec00e1d3b3a0a638fce11fa0301233a#4998682d7ec00e1d3b3a0a638fce11fa0301233a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5629,7 +5629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5649,7 +5649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5681,7 +5681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -5694,7 +5694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6179,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "reference-value-provider-service"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=2703b7d924c1c2de357cf234be773d852464f57e#2703b7d924c1c2de357cf234be773d852464f57e"
+source = "git+https://github.com/openanolis/trustee/?rev=4998682d7ec00e1d3b3a0a638fce11fa0301233a#4998682d7ec00e1d3b3a0a638fce11fa0301233a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8811,7 +8811,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/trustee/?rev=2703b7d924c1c2de357cf234be773d852464f57e#2703b7d924c1c2de357cf234be773d852464f57e"
+source = "git+https://github.com/openanolis/trustee/?rev=4998682d7ec00e1d3b3a0a638fce11fa0301233a#4998682d7ec00e1d3b3a0a638fce11fa0301233a"
 dependencies = [
  "anyhow",
  "asn1-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ as-any = "0.3.2"
 async-http-proxy = {version = "1.2.5", features = ["runtime-tokio"]}
 async-stream = "0.3.6"
 async-trait = "0.1.88"
-attestation-service = {git = "https://github.com/openanolis/trustee/", rev = "2703b7d924c1c2de357cf234be773d852464f57e", default-features = false}
+attestation-service = {git = "https://github.com/openanolis/trustee/", rev = "4998682d7ec00e1d3b3a0a638fce11fa0301233a", default-features = false}
 atty = "0.2.14"
 auto_enums = {version = "0.8", features = ["std", "tokio1"]}
 axum = {version = "0.8.4", default-features = false}
@@ -96,7 +96,7 @@ rand = "0.9.1"
 rand_chacha = "0.9.0"
 rayon = "1.10.0"
 rcgen = "0.13.2"
-reference-value-provider-service = {git = "https://github.com/openanolis/trustee/", rev = "2703b7d924c1c2de357cf234be773d852464f57e", default-features = false}
+reference-value-provider-service = {git = "https://github.com/openanolis/trustee/", rev = "4998682d7ec00e1d3b3a0a638fce11fa0301233a", default-features = false}
 regex = "1.11.1"
 regorus = {version = "0.11.0", default-features = false}
 reqwest = {version = "=0.12.9", default-features = false, features = ["json", "http2", "rustls-tls-webpki-roots-no-provider", "brotli", "gzip", "zstd"]}# select 0.12.9 version since we have to align to the hyper-util=0.1.7 version used by hyper-util-wasm

--- a/rats-cert/Cargo.toml
+++ b/rats-cert/Cargo.toml
@@ -52,18 +52,17 @@ x509-cert = {workspace = true, optional = true}
 zeroize = {workspace = true}
 
 [target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
-# Native builds enable the attestation-service `fs` feature so the builtin
-# converter supports `file://` provenance sources (and on-disk RV storage /
-# signer key/cert paths). `policy-rvps` is also required: the upstream
-# default policy (`ear_broker::DEFAULT_POLICY`, which the builtin converter
-# loads) calls the rego builtin `query_reference_value(...)`, which is only
-# registered under attestation-service's `policy-rvps` feature. Without it,
-# policy appraisal fails with "could not find function query_reference_value".
-# wasm enables `policy-rvps` too (see the wasm target block below); `fs` is
-# native-only (the wasm verify path uses in-memory RV storage, not the fs).
-# This is a target-specific re-declaration: cargo merges it with the
+# `fs` is native-only: the builtin converter supports `file://` provenance
+# sources and on-disk RV storage / signer key/cert paths; wasm uses in-memory
+# RV storage, so `fs` stays off there.
+# `policy-rvps` is required: the default policy (`ear_broker::DEFAULT_POLICY`)
+# calls the rego builtin `query_reference_value`, registered only under that
+# feature; without it appraisal fails with "could not find function
+# query_reference_value".
+# `regorus-regovm` is enabled on both targets for cross-platform consistency.
+# Target-specific re-declaration: cargo merges this with the base
 # `[dependencies]` entry for non-wasm only.
-attestation-service = {workspace = true, default-features = false, features = ["fs", "policy-rvps"], optional = true}
+attestation-service = {workspace = true, default-features = false, features = ["fs", "policy-rvps", "regorus-regovm"], optional = true}
 rustls-webpki = {workspace = true, optional = true, features = ["alloc", "aws-lc-rs"]}
 tempfile = {workspace = true, optional = true}
 time = {workspace = true, features = ["std", "parsing"]}
@@ -71,21 +70,14 @@ tokio = {workspace = true, default-features = true, features = ["fs"]}
 tonic = {workspace = true, default-features = false, features = ["codegen", "channel"], optional = true}
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
-# Enable attestation-service's `policy-rvps` on wasm too. The builtin
-# converter loads the upstream default policy (`ear_broker::DEFAULT_POLICY`),
-# whose rego calls `query_reference_value(...)`; that builtin is only
-# registered under `policy-rvps`. As of trustee a7cae246, `policy-rvps` is
-# wasm-compatible: it now pulls only `tokio/time` (the old `tokio/rt` — the
-# multi-thread runtime / `spawn_blocking`, unavailable on
-# wasm32-unknown-unknown — was dropped), and the rego engine (regorus,
-# pure-Rust) runs on wasm. The getrandom 0.4 that regorus 0.11 -> rand 0.10
-# transitively needs is given the `wasm_js` feature by attestation-service's
-# own renamed `getrandom_04` wasm dep (so the Makefile `getrandom_backend`
-# cfg for the 0.3 line and the `js` feature for the 0.2 line are not enough
-# on their own). `fs` stays off on wasm (in-memory RV storage only). This is
-# a target-specific re-declaration: cargo merges it with the base
-# `[dependencies]` entry for wasm only.
-attestation-service = {workspace = true, default-features = false, features = ["policy-rvps"], optional = true}
+# `policy-rvps` is required (the default policy calls `query_reference_value`,
+# registered only under it); `regorus-regovm` is mandatory on wasm: upstream
+# will not compile without it. `fs` is off (in-memory RV storage only).
+# getrandom's `wasm_js` feature is wired by attestation-service's own
+# `getrandom_04` dep, so the Makefile `getrandom_backend` cfg alone does not
+# cover the regorus path. Target-specific re-declaration: cargo merges this
+# with the base `[dependencies]` entry for wasm only.
+attestation-service = {workspace = true, default-features = false, features = ["policy-rvps", "regorus-regovm"], optional = true}
 # Web Crypto API deps for the builtin-as challenger keygen path. On wasm the
 # rustcrypto `rsa` prime generation (used by `JwtChallenger::new`) is pure
 # software and slow; instead we ask the host (hardware-accelerated) WebCrypto

--- a/rats-cert/src/tee/coco/converter/builtin/mod.rs
+++ b/rats-cert/src/tee/coco/converter/builtin/mod.rs
@@ -316,7 +316,7 @@ impl BuiltinCocoConverter {
                         // `crypto-rustcrypto`, `verify_dsse_signature`
                         // (DSSEPAE + ECDSA P-256) is injected too — see
                         // `builtin_as_host_await_functions`.
-                        .with_extra_host_await_functions(builtin_as_host_await_functions()),
+                        .with_extra_extension_functions(builtin_as_host_await_functions()),
                     ),
                 ),
             )
@@ -1145,18 +1145,18 @@ tdx_eventlog_present if {{ count(input.tdx.uefi_event_logs) > 0 }}
 /// `crypto.sha256(json.marshal(manifest)) == payload_hash` comparison works).
 ///
 /// Registered under the dotted name `crypto.sha256` (regorus's function-rule
-/// syntax accepts dotted keys) via `OPAInMemory::with_extra_host_await_functions`
+/// syntax accepts dotted keys) via `OPAInMemory::with_extra_extension_functions`
 /// so the existing, already-written rego policy is unchanged and stays
 /// forward-compatible with a future regorus that ships the builtin natively.
 /// Only the sha256 primitive is injected; manifest reconstruction
 /// (`json.marshal`) and the comparison stay in rego.
 ///
-/// The `RegoVmHostAwaitFunction` type alias already cfg-gates the `Send` bound
+/// The `ExtensionFunction` type alias already cfg-gates the `Send` bound
 /// (dropped on `wasm32-unknown-unknown`, where the RVPS resolver is `?Send`),
 /// so this closure's `Box::pin(async move { ... })` future matches both the
 /// native and wasm variants without an explicit cfg here. Mirrors the trustee
 /// fork's `evaluate_with_injected_crypto_sha256_dotted_host_await` test.
-fn crypto_sha256_host_await() -> attestation_service::policy_engine::opa::RegoVmHostAwaitFunction {
+fn crypto_sha256_host_await() -> attestation_service::policy_engine::opa::ExtensionFunction {
     use attestation_service::policy_engine::PolicyError;
 
     std::sync::Arc::new(|argument: regorus::Value| {
@@ -1200,7 +1200,7 @@ fn dsse_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
 /// Host-await function that verifies a DSSE publisher signature over a
 /// reconstructed ReleaseManifest. regorus 0.11 ships no ECDSA builtin, so the
 /// DSSEPAE + sha256 + ECDSA P-256 `VerifyASN1` primitive is injected here via
-/// `OPAInMemory::with_extra_host_await_functions`, alongside `crypto.sha256`.
+/// `OPAInMemory::with_extra_extension_functions`, alongside `crypto.sha256`.
 ///
 /// Takes a packed 3-element array `[payload_str, signature_b64, publisher_key_pem]`
 /// (single-arg, since the host-await wrapper is single-arg). Computes
@@ -1219,8 +1219,8 @@ fn dsse_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
 /// module pulls in); the rego policy that calls this is itself only generated
 /// under `crypto-rustcrypto`.
 #[cfg(feature = "crypto-rustcrypto")]
-fn verify_dsse_signature_host_await(
-) -> attestation_service::policy_engine::opa::RegoVmHostAwaitFunction {
+fn verify_dsse_signature_host_await() -> attestation_service::policy_engine::opa::ExtensionFunction
+{
     use attestation_service::policy_engine::PolicyError;
     use p256::ecdsa::signature::Verifier;
 
@@ -1276,7 +1276,7 @@ fn verify_dsse_signature_host_await(
 /// sync.
 fn builtin_as_host_await_functions() -> Vec<(
     String,
-    attestation_service::policy_engine::opa::RegoVmHostAwaitFunction,
+    attestation_service::policy_engine::opa::ExtensionFunction,
 )> {
     let mut fns = vec![("crypto.sha256".to_string(), crypto_sha256_host_await())];
     #[cfg(feature = "crypto-rustcrypto")]
@@ -2004,7 +2004,7 @@ default file_system := 2"#,
         // sha256 during the behavior test below. Under `crypto-rustcrypto`,
         // `verify_dsse_signature` is injected too — see
         // `builtin_as_host_await_functions`.
-        .with_extra_host_await_functions(builtin_as_host_await_functions());
+        .with_extra_extension_functions(builtin_as_host_await_functions());
         // The four rules our templates define. The real AS also queries four more
         // AR4SI claims (instance-identity, runtime-opaque, ...); those are simply
         // skipped when a policy leaves them undefined, so they need not be queried.


### PR DESCRIPTION
## What

Bump the `attestation-service` / `reference-value-provider-service` git pin from `2703b7d` to `4998682` (latest trustee `main`) and adapt the code to the upstream RegoVM refactor.

## Why

The pinned rev `2703b7d` had drifted from trustee `main`. The 14 commits between them land the RegoVM policy backend this branch exists to adopt:
- `policy-rvps` drops `tokio/rt` (now `["tokio/time"]` only), so it is fully wasm-compatible.
- A new opt-in `regorus-regovm` feature gates the suspendable `__builtin_host_await` VM path; the sync interpreter becomes the native default.
- On `wasm32-unknown-unknown`, trustee now `compile_error!`s unless `regorus-regovm` is enabled.
- `dcap-qvl` rev bump (perfmon bit fix in the pure-Rust TDX verifier path).

## Changes

- `Cargo.toml`: pin rev `2703b7d` -> `4998682` for both crates.
- `rats-cert/Cargo.toml`: enable `regorus-regovm` on both native and wasm. Mandatory on wasm (the upstream `compile_error!`); on native it preserves the regovm host-await backend the `crypto.sha256` / `verify_dsse_signature` closures were written against, and needs no tokio multi-thread runtime. Stale `a7cae246` comment ref refreshed to the new pin.
- `rats-cert/src/tee/coco/converter/builtin/mod.rs`: rename the upstream API, `RegoVmHostAwaitFunction` -> `ExtensionFunction` and `with_extra_host_await_functions` -> `with_extra_extension_functions`. The closures already cfg-gate the `Send` bound via the type alias, so no closure bodies changed.

No user-facing config fields, endpoints, or wire formats change (internal feature gate plus dep pin bump), so no `version_compatibility` row is added.

## Verification

- Linux: `cargo fmt`, `make clippy`, `cargo build` all clean.
- Windows: `make windows-cross-build` (`x86_64-pc-windows-gnu`) passes.
- wasm: `make wasm-build-debug` (`wasm32-unknown-unknown`) passes; the `regorus-regovm` feature satisfies the upstream `compile_error!`.
- Runtime: the regovm policy path passes the self-contained rekor (DSSE signature verification via the injected `verify_dsse_signature` host function), rego, and policy-load unit tests in `rats-cert`.
- macOS: `make mac-cross-build` fails to link `dcap-qvl` (`unable to find framework 'CoreFoundation'`). This is a pre-existing local zig-sysroot gap (no Apple frameworks shipped with cargo-zigbuild on this host), not a regression: the same build fails identically at the old pin `2703b7d`. `dcap-qvl`'s manifest (crate-type + deps) is byte-identical between the two revs; only `src/quote.rs` changed.